### PR TITLE
feat: add external provider (sidecar) support

### DIFF
--- a/.claude/skills/external-provider.md
+++ b/.claude/skills/external-provider.md
@@ -12,9 +12,11 @@ Check the provider configuration to see which services are available. Common exa
 ## How to Use
 
 1. **Fetch data via WebFetch** to the provider's REST API (POST for service endpoints):
+   - Determine the base URL from `telclaude.json` (`providers[].baseUrl`)
+   - If multiple providers exist, choose the one mapped to the service
    ```
    WebFetch({
-     url: "http://127.0.0.1:3001/v1/{service}/{endpoint}",
+     url: "<provider.baseUrl>/v1/{service}/{endpoint}",
      method: "POST",
      body: "{\"subjectUserId\":\"<target-user-id>\",\"params\":{...}}"
    })
@@ -70,7 +72,8 @@ Check the provider configuration to see which services are available. Common exa
 
 ## Endpoints Reference
 
-Common provider endpoints (actual availability depends on configuration):
+Common provider endpoints (actual availability depends on configuration). For the
+authoritative list, see the Provider Schemas section below.
 
 | Endpoint | Description |
 |----------|-------------|
@@ -80,3 +83,8 @@ Common provider endpoints (actual availability depends on configuration):
 | `/v1/{service}/balance` | Current balance |
 | `/v1/health` | Provider health status |
 | `/v1/challenge/respond` | OTP submission (relay-only) |
+
+## Provider Schemas (auto-generated)
+<!-- PROVIDER_SCHEMA_START -->
+Schemas will be injected here at runtime.
+<!-- PROVIDER_SCHEMA_END -->

--- a/.claude/skills/external-provider.md
+++ b/.claude/skills/external-provider.md
@@ -1,0 +1,82 @@
+# External Service Provider
+
+Use this skill when the user asks about data from configured external providers (citizen services, banking, health, etc.).
+
+## Available Services
+
+Check the provider configuration to see which services are available. Common examples:
+- Health services (appointments, records)
+- Banking services (balance, transactions)
+- Government services (documents, status)
+
+## How to Use
+
+1. **Fetch data via WebFetch** to the provider's REST API (POST for service endpoints):
+   ```
+   WebFetch({
+     url: "http://127.0.0.1:3001/v1/{service}/{endpoint}",
+     method: "POST",
+     body: "{\"subjectUserId\":\"<target-user-id>\",\"params\":{...}}"
+   })
+   ```
+   - If the user is requesting their own data, omit `subjectUserId`.
+   - Use `/v1/health` with GET only when checking provider status.
+
+2. **Parse the JSON response**. Expected shape:
+   ```json
+   {
+     "status": "ok" | "auth_required" | "challenge_pending" | "parse_error" | "error",
+     "data": { ... },
+     "confidence": 0.0-1.0,
+     "lastUpdated": "ISO timestamp",
+     "error": "message if status is error",
+     "challenge": {
+       "id": "challenge-id",
+       "type": "sms_otp" | "app_otp" | "push",
+       "hint": "sent to ***1234",
+       "service": "service-name"
+     }
+   }
+   ```
+
+3. **Handle status codes**:
+   - `ok`: Present the data with confidence level and last-updated time
+   - `auth_required`: Inform user that service needs authentication setup
+   - `challenge_pending`: Tell user to complete OTP via `/otp <service> <code>`
+   - `parse_error`: Service data couldn't be parsed; may need maintenance
+   - `error`: Show error message to user
+
+## Important Rules
+
+1. **Never ask for credentials** - The provider handles authentication separately
+2. **Never guess URLs** - Only call endpoints documented by the provider
+3. **Show confidence levels** - If confidence < 1.0, mention data may be incomplete
+4. **Show freshness** - Always tell user when data was last updated
+5. **Handle challenges gracefully** - If OTP needed, explain the `/otp <service> <code>` command
+
+## Example Responses
+
+### Successful data fetch:
+"Your next appointment is on January 15th at 2:30 PM with Dr. Cohen (Cardiology). This information was last updated 5 minutes ago."
+
+### Challenge pending:
+"To access your bank balance, please complete verification. Check your phone for an SMS code, then reply with `/otp poalim <code>`."
+
+### Auth required:
+"This service needs to be set up first. Please ask the operator to configure authentication for the banking service."
+
+### Parse error:
+"I couldn't retrieve your appointments - the service may need maintenance. Try again later or contact the operator."
+
+## Endpoints Reference
+
+Common provider endpoints (actual availability depends on configuration):
+
+| Endpoint | Description |
+|----------|-------------|
+| `/v1/{service}/summary` | Overview/dashboard data |
+| `/v1/{service}/appointments` | Upcoming appointments |
+| `/v1/{service}/transactions` | Recent transactions |
+| `/v1/{service}/balance` | Current balance |
+| `/v1/health` | Provider health status |
+| `/v1/challenge/respond` | OTP submission (relay-only) |

--- a/.claude/skills/external-provider/SKILL.md
+++ b/.claude/skills/external-provider/SKILL.md
@@ -68,7 +68,7 @@ Check the provider configuration to see which services are available. Common exa
 "Your next appointment is on January 15th at 2:30 PM with Dr. Cohen (Cardiology). This information was last updated 5 minutes ago."
 
 ### Challenge pending:
-"To access your bank balance, please complete verification. Check your phone for an SMS code, then reply with `/otp poalim <code>`."
+"To access your bank balance, please complete verification. Check your phone for an SMS code, then reply with `/otp bank <code>`."
 
 ### Auth required:
 "This service needs to be set up first. Please ask the operator to configure authentication for the banking service."

--- a/.claude/skills/external-provider/SKILL.md
+++ b/.claude/skills/external-provider/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: external-provider
 description: Access configured sidecar providers (health, banking, government) via WebFetch.
-allowed-tools: [WebFetch]
+allowed-tools: WebFetch
 ---
 
 # External Provider

--- a/.claude/skills/external-provider/SKILL.md
+++ b/.claude/skills/external-provider/SKILL.md
@@ -1,4 +1,10 @@
-# External Service Provider
+---
+name: external-provider
+description: Access configured sidecar providers (health, banking, government) via WebFetch.
+allowed-tools: [WebFetch]
+---
+
+# External Provider
 
 Use this skill when the user asks about data from configured external providers (citizen services, banking, health, etc.).
 
@@ -85,6 +91,5 @@ authoritative list, see the Provider Schemas section below.
 | `/v1/challenge/respond` | OTP submission (relay-only) |
 
 ## Provider Schemas (auto-generated)
-<!-- PROVIDER_SCHEMA_START -->
-Schemas will be injected here at runtime.
-<!-- PROVIDER_SCHEMA_END -->
+
+See `references/provider-schema.md` for the latest schema fetched from `/v1/schema`.

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docker/telclaude.json
 secrets/
 *.pem
 .agent-mail/
+docker/docker-compose.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ docker/telclaude.json
 # Secrets (GitHub App keys, etc.)
 secrets/
 *.pem
+.agent-mail/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,7 +171,7 @@ ENV HOME=/home/node
 # Healthcheck - verify node process is running
 # Uses simple process check without procps (saves ~10MB)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD ["node", "-e", "process.exit(0)"]
+    CMD ["telclaude", "provider-health", "--json"]
 
 # Default working directory for Claude operations
 WORKDIR /workspace

--- a/docker/docker-compose.override.yml.example
+++ b/docker/docker-compose.override.yml.example
@@ -1,0 +1,51 @@
+# NFS Volume Override Example
+#
+# Copy this file to docker-compose.override.yml (gitignored) and customize.
+# This enables NFS-backed storage for production deployments.
+#
+# Prerequisites:
+#   1. NFS share exported and accessible (e.g., from QNAP NAS)
+#   2. Directories exist on NFS share:
+#      - /pi4docker/telclaude-data
+#      - /pi4docker/telclaude-claude
+#      - /pi4docker/telclaude-totp-data
+#      - /pi4docker/telclaude-media-outbox
+#   3. Proper permissions (containers run as UID 1000)
+#
+# Usage:
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#   # Edit NAS_IP below
+#   docker compose up -d
+
+volumes:
+  telclaude-data:
+    name: telclaude-data
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=${NAS_IP:-10.0.0.35},rw,nolock,soft
+      device: ":/pi4docker/telclaude-data"
+
+  telclaude-claude:
+    name: telclaude-claude
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=${NAS_IP:-10.0.0.35},rw,nolock,soft
+      device: ":/pi4docker/telclaude-claude"
+
+  totp-data:
+    name: telclaude-totp-data
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=${NAS_IP:-10.0.0.35},rw,nolock,soft
+      device: ":/pi4docker/telclaude-totp-data"
+
+  media-outbox:
+    name: telclaude-media-outbox
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=${NAS_IP:-10.0.0.35},rw,nolock,soft
+      device: ":/pi4docker/telclaude-media-outbox"

--- a/docker/docker-compose.override.yml.example
+++ b/docker/docker-compose.override.yml.example
@@ -5,16 +5,21 @@
 #
 # Prerequisites:
 #   1. NFS share exported and accessible (e.g., from QNAP NAS)
-#   2. Directories exist on NFS share:
-#      - /pi4docker/telclaude-data
-#      - /pi4docker/telclaude-claude
-#      - /pi4docker/telclaude-totp-data
-#      - /pi4docker/telclaude-media-outbox
+#   2. Directories exist on NFS share (under NFS_BASE_PATH):
+#      - telclaude-data
+#      - telclaude-totp-data
+#      - telclaude-media-outbox
 #   3. Proper permissions (containers run as UID 1000)
+#
+# NOTE: telclaude-claude is intentionally NOT included here.
+# It stays on local storage because NFS with UID squashing can cause
+# permission issues with .claude config files. The volume is small
+# (config only) so local storage performance is fine.
 #
 # Usage:
 #   cp docker-compose.override.yml.example docker-compose.override.yml
-#   # Edit NAS_IP below
+#   export NAS_IP=192.168.1.100        # Your NAS IP
+#   export NFS_BASE_PATH=/your/export  # NFS export path
 #   docker compose up -d
 
 volumes:
@@ -23,29 +28,21 @@ volumes:
     driver: local
     driver_opts:
       type: nfs
-      o: addr=${NAS_IP:-10.0.0.35},rw,nolock,soft
-      device: ":/pi4docker/telclaude-data"
-
-  telclaude-claude:
-    name: telclaude-claude
-    driver: local
-    driver_opts:
-      type: nfs
-      o: addr=${NAS_IP:-10.0.0.35},rw,nolock,soft
-      device: ":/pi4docker/telclaude-claude"
+      o: addr=${NAS_IP:?Set NAS_IP environment variable},rw,nolock,soft
+      device: ":${NFS_BASE_PATH:-/docker}/telclaude-data"
 
   totp-data:
     name: telclaude-totp-data
     driver: local
     driver_opts:
       type: nfs
-      o: addr=${NAS_IP:-10.0.0.35},rw,nolock,soft
-      device: ":/pi4docker/telclaude-totp-data"
+      o: addr=${NAS_IP:?Set NAS_IP environment variable},rw,nolock,soft
+      device: ":${NFS_BASE_PATH:-/docker}/telclaude-totp-data"
 
   media-outbox:
     name: telclaude-media-outbox
     driver: local
     driver_opts:
       type: nfs
-      o: addr=${NAS_IP:-10.0.0.35},rw,nolock,soft
-      device: ":/pi4docker/telclaude-media-outbox"
+      o: addr=${NAS_IP:?Set NAS_IP environment variable},rw,nolock,soft
+      device: ":${NFS_BASE_PATH:-/docker}/telclaude-media-outbox"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -141,7 +141,7 @@ services:
     restart: unless-stopped
 
     healthcheck:
-      test: ["CMD", "node", "-e", "process.exit(0)"]
+      test: ["CMD", "telclaude", "provider-health", "--json"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -175,6 +175,7 @@ services:
       - TELCLAUDE_AGENT_PORT=8788
       - TELCLAUDE_AGENT_WORKDIR=/workspace
       - TELCLAUDE_LOG_LEVEL=${TELCLAUDE_LOG_LEVEL:-info}
+      - TELCLAUDE_CONFIG=/data/telclaude.json
 
       # Relay capability broker
       - TELCLAUDE_CAPABILITIES_URL=http://telclaude:8790
@@ -208,6 +209,9 @@ services:
 
       # Claude Code configuration (credentials, settings)
       - telclaude-claude:/home/node/.claude:rw
+
+      # Configuration file (for provider allowlist + health checks)
+      - ./telclaude.json:/data/telclaude.json:ro
 
       # Shared media volumes (inbox/outbox split)
       - media-inbox:/media/inbox:ro

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -53,7 +53,8 @@ if [ "$(id -u)" = "0" ]; then
         echo "[entrypoint] Installing bundled skills"
         mkdir -p /home/node/.claude/skills
         cp -a /app/.claude/skills/. /home/node/.claude/skills/
-        chown -R "${TELCLAUDE_UID}:${TELCLAUDE_GID}" /home/node/.claude
+        # chown may fail on NFS with UID squashing - that's OK, files are still accessible
+        chown -R "${TELCLAUDE_UID}:${TELCLAUDE_GID}" /home/node/.claude 2>/dev/null || true
     fi
 
     # Install bundled CLAUDE.md (agent playbook) if present
@@ -71,7 +72,7 @@ if [ "$(id -u)" = "0" ]; then
             echo "[entrypoint] Symlinking skills to workspace"
             mkdir -p /workspace/.claude
             ln -s /home/node/.claude/skills /workspace/.claude/skills
-            chown -h "${TELCLAUDE_UID}:${TELCLAUDE_GID}" /workspace/.claude /workspace/.claude/skills
+            chown -h "${TELCLAUDE_UID}:${TELCLAUDE_GID}" /workspace/.claude /workspace/.claude/skills 2>/dev/null || true
         fi
     else
         echo "[entrypoint] Skipping workspace skills symlink (workspace not writable)"
@@ -86,7 +87,7 @@ if [ "$(id -u)" = "0" ]; then
     # Must be done before dropping privileges since tmpfs dirs created as root
     mkdir -p /home/node/.telclaude/logs
     touch /home/node/.telclaude/logs/telclaude.log
-    chown -R "${TELCLAUDE_UID}:${TELCLAUDE_GID}" /home/node/.telclaude
+    chown -R "${TELCLAUDE_UID}:${TELCLAUDE_GID}" /home/node/.telclaude 2>/dev/null || true
 
     for dir in /data /home/node /home/node/.claude /media/inbox /media/outbox; do
         if [ -d "$dir" ]; then

--- a/docker/telclaude.json.example
+++ b/docker/telclaude.json.example
@@ -1,0 +1,78 @@
+{
+  // Telclaude Configuration Example
+  // Copy to telclaude.json and customize before running docker compose up
+  //
+  // JSON5 format - comments allowed, trailing commas OK
+
+  "telegram": {
+    // REQUIRED: Your Telegram chat ID(s) - bot ignores unlisted chats
+    // Get your ID from @userinfobot on Telegram
+    "allowedChats": [123456789]
+  },
+
+  "security": {
+    "permissions": {
+      // Default tier for new/unlinked users: READ_ONLY, WRITE_LOCAL, or FULL_ACCESS
+      "defaultTier": "READ_ONLY"
+    },
+    "network": {
+      // Private endpoints allow WebFetch to local network services
+      // Required for external providers (sidecars)
+      "privateEndpoints": [
+        // Example: Local sidecar on port 3001
+        // {
+        //   "label": "citizen-services",
+        //   "host": "127.0.0.1",
+        //   "ports": [3001],
+        //   "description": "Local citizen services sidecar"
+        // },
+        //
+        // Example: Home Assistant on LAN
+        // {
+        //   "label": "home-assistant",
+        //   "host": "192.168.1.100",
+        //   "ports": [8123],
+        //   "description": "Home automation"
+        // },
+        //
+        // Example: Docker service by hostname
+        // {
+        //   "label": "my-sidecar",
+        //   "host": "my-sidecar-container",
+        //   "ports": [8080]
+        // }
+      ]
+    }
+  },
+
+  // External providers (sidecar services)
+  // These are private REST APIs that telclaude can call via WebFetch
+  "providers": [
+    // Example: Citizen services sidecar
+    // {
+    //   "id": "citizen-services",
+    //   "baseUrl": "http://127.0.0.1:3001",
+    //   "services": ["health-api", "bank-api", "gov-api"],
+    //   "description": "Local citizen services sidecar"
+    // }
+    //
+    // To use providers:
+    // 1. Uncomment and configure a provider above
+    // 2. Add matching privateEndpoint in security.network.privateEndpoints
+    // 3. Start your sidecar service
+    // 4. The agent can now call /v1/{service}/{action} endpoints
+    //
+    // OTP flow: When provider returns challenge_pending, user sends /otp <service> <code>
+  ],
+
+  "inbound": {
+    "reply": {
+      "enabled": true
+    }
+  },
+
+  "logging": {
+    // debug, info, warn, error
+    "level": "info"
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,34 @@ Claude Agent SDK (allowedTools per tier)
 - Internal relay ↔ agent RPC is allowed via hostname allowlist in the firewall script.
 - **Allowlist scope**: Domain allowlists are enforced, but HTTP method restrictions are not enforced at runtime.
 
+## External Providers (Sidecars)
+
+Telclaude can call private sidecar services over `WebFetch` via `privateEndpoints`.
+This keeps telclaude OSS generic while allowing country- or org-specific integrations.
+
+**Config example:**
+```json
+{
+  "providers": [
+    {
+      "id": "citizen-services",
+      "baseUrl": "http://127.0.0.1:3001",
+      "services": ["clalit", "poalim", "massad"],
+      "description": "Local citizen services sidecar"
+    }
+  ],
+  "security": {
+    "network": {
+      "privateEndpoints": [
+        { "label": "citizen-services", "host": "127.0.0.1", "ports": [3001] }
+      ]
+    }
+  }
+}
+```
+
+**OTP routing** (relay-only): `/otp <service> <code>` sends OTP directly to the provider's `/v1/challenge/respond` endpoint (never to the LLM).
+
 ### Private Network Allowlist
 
 For local services (Home Assistant, Plex, NAS, etc.), you can configure explicit private network endpoints:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,15 @@ This keeps telclaude OSS generic while allowing country- or org-specific integra
 **OTP routing** (relay-only): `/otp <service> <code>` sends OTP directly to the provider's `/v1/challenge/respond` endpoint (never to the LLM).
 Control commands (including `/otp`) are rate-limited to 5 attempts per minute per user to reduce brute-force risk.
 
+## Skills & Plugins
+
+- Skills are stored as folders containing `SKILL.md` under `.claude/skills` (project) or `~/.claude/skills` (user).
+- Telclaude ships built-in skills in `.claude/skills`; the Docker entrypoint copies them to `/home/node/.claude/skills`
+  and symlinks `/workspace/.claude/skills` for the SDK.
+- To add new skills, place a skill folder in `.claude/skills` or mount it into `/home/node/.claude/skills` (volume).
+- For sharing skills across repos, use Claude Code plugins (plugin root with `skills/` and `plugin.json`) and enable them
+  via `.claude/settings.json` (`extraKnownMarketplaces` + `enabledPlugins`).
+
 ### Private Network Allowlist
 
 For local services (Home Assistant, Plex, NAS, etc.), you can configure explicit private network endpoints:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,6 +119,10 @@ Control commands (including `/otp`) are rate-limited to 5 attempts per minute pe
   `skills/`, `agents/`, `commands/`, or `hooks/` folders.
 - To install plugins, add a marketplace (`/plugin marketplace add ./path`) and install with `/plugin install name@marketplace`.
   Team workflows can pin marketplaces/plugins in `.claude/settings.json` so installs happen automatically when the repo is trusted.
+- **Private/local plugins**: while a plugin repo is private, add its repo root as a *local* marketplace path
+  (the repo must contain `.claude-plugin/marketplace.json`), then install the plugin by name. Example:
+  ` /plugin marketplace add /Users/you/MyProjects/israel-services `
+  then ` /plugin install israel-services@israel-services-marketplace `.
 
 ### Private Network Allowlist
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ This keeps telclaude OSS generic while allowing country- or org-specific integra
     {
       "id": "citizen-services",
       "baseUrl": "http://127.0.0.1:3001",
-      "services": ["clalit", "poalim", "massad"],
+      "services": ["health-api", "bank-api", "gov-api"],
       "description": "Local citizen services sidecar"
     }
   ],
@@ -121,8 +121,8 @@ Control commands (including `/otp`) are rate-limited to 5 attempts per minute pe
   Team workflows can pin marketplaces/plugins in `.claude/settings.json` so installs happen automatically when the repo is trusted.
 - **Private/local plugins**: while a plugin repo is private, add its repo root as a *local* marketplace path
   (the repo must contain `.claude-plugin/marketplace.json`), then install the plugin by name. Example:
-  ` /plugin marketplace add /Users/you/MyProjects/israel-services `
-  then ` /plugin install israel-services@israel-services-marketplace `.
+  ` /plugin marketplace add /Users/you/MyProjects/my-local-services `
+  then ` /plugin install my-local-services@my-local-services-marketplace `.
 
 ### Private Network Allowlist
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,7 @@ Claude Agent SDK (allowedTools per tier)
 - `TELCLAUDE_NETWORK_MODE=open|permissive`: enables broad egress for WebFetch only.
 - Internal relay ↔ agent RPC is allowed via hostname allowlist in the firewall script.
 - **Allowlist scope**: Domain allowlists are enforced, but HTTP method restrictions are not enforced at runtime.
+- **CGNAT/Tailscale**: The private IP matcher treats 100.64.0.0/10 (RFC 6598) as private to support Tailscale.
 
 ## External Providers (Sidecars)
 
@@ -106,6 +107,7 @@ This keeps telclaude OSS generic while allowing country- or org-specific integra
 ```
 
 **OTP routing** (relay-only): `/otp <service> <code>` sends OTP directly to the provider's `/v1/challenge/respond` endpoint (never to the LLM).
+Control commands (including `/otp`) are rate-limited to 5 attempts per minute per user to reduce brute-force risk.
 
 ### Private Network Allowlist
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,12 +111,14 @@ Control commands (including `/otp`) are rate-limited to 5 attempts per minute pe
 
 ## Skills & Plugins
 
-- Skills are stored as folders containing `SKILL.md` under `.claude/skills` (project) or `~/.claude/skills` (user).
+- Skills are folders with `SKILL.md`, discoverable from `~/.claude/skills` (user), `.claude/skills` (project),
+  or bundled inside plugins. Use `allowed-tools` in SKILL.md frontmatter to scope tool access.
 - Telclaude ships built-in skills in `.claude/skills`; the Docker entrypoint copies them to `/home/node/.claude/skills`
   and symlinks `/workspace/.claude/skills` for the SDK.
-- To add new skills, place a skill folder in `.claude/skills` or mount it into `/home/node/.claude/skills` (volume).
-- For sharing skills across repos, use Claude Code plugins (plugin root with `skills/` and `plugin.json`) and enable them
-  via `.claude/settings.json` (`extraKnownMarketplaces` + `enabledPlugins`).
+- Plugins are the idiomatic distribution mechanism: plugin root contains `.claude-plugin/plugin.json` and optional
+  `skills/`, `agents/`, `commands/`, or `hooks/` folders.
+- To install plugins, add a marketplace (`/plugin marketplace add ./path`) and install with `/plugin install name@marketplace`.
+  Team workflows can pin marketplaces/plugins in `.claude/settings.json` so installs happen automatically when the repo is trusted.
 
 ### Private Network Allowlist
 

--- a/src/commands/provider-health.ts
+++ b/src/commands/provider-health.ts
@@ -1,0 +1,308 @@
+/**
+ * CLI command for checking external provider health status.
+ *
+ * Commands:
+ * - telclaude provider-health - Check all providers
+ * - telclaude provider-health <provider-id> - Check specific provider
+ * - telclaude provider-health --json - Output as JSON
+ * - telclaude provider-health --alert-telegram - Send Telegram alert if degraded
+ *
+ * Exit codes:
+ * - 0: All providers healthy
+ * - 1: At least one provider degraded (warn-level)
+ * - 2: At least one provider unhealthy (error-level)
+ */
+
+import type { Command } from "commander";
+import { loadConfig } from "../config/config.js";
+import { getChildLogger } from "../logging.js";
+import {
+	cachedDNSLookup,
+	checkPrivateNetworkAccess,
+	isPrivateIP,
+} from "../sandbox/network-proxy.js";
+
+const logger = getChildLogger({ module: "cmd-provider-health" });
+
+// Health response from provider
+interface ConnectorHealth {
+	status: "ok" | "auth_expired" | "drift_detected" | "error";
+	lastSuccess?: string;
+	lastAttempt?: string;
+	failureCount?: number;
+	driftSignals?: string[];
+}
+
+interface HealthAlert {
+	level: "warn" | "error";
+	connector: string;
+	message: string;
+	since?: string;
+}
+
+interface ProviderHealthResponse {
+	status: "healthy" | "degraded" | "unhealthy";
+	connectors?: Record<string, ConnectorHealth>;
+	alerts?: HealthAlert[];
+	error?: string;
+}
+
+interface HealthCheckResult {
+	providerId: string;
+	baseUrl: string;
+	reachable: boolean;
+	response?: ProviderHealthResponse;
+	error?: string;
+}
+
+async function checkProviderHealth(
+	providerId: string,
+	baseUrl: string,
+): Promise<HealthCheckResult> {
+	const result: HealthCheckResult = {
+		providerId,
+		baseUrl,
+		reachable: false,
+	};
+
+	try {
+		// Parse and validate URL
+		const url = new URL("/v1/health", baseUrl);
+		const port = url.port ? Number.parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
+
+		// Verify it's in private endpoint allowlist
+		const cfg = loadConfig();
+		const endpoints = cfg.security?.network?.privateEndpoints ?? [];
+
+		const privateCheck = await checkPrivateNetworkAccess(url.hostname, port, endpoints);
+		if (!privateCheck.allowed) {
+			result.error = `Provider URL not in private endpoints allowlist: ${privateCheck.reason}`;
+			return result;
+		}
+
+		// Verify IPs are private
+		const resolved = await cachedDNSLookup(url.hostname);
+		const ips = resolved && resolved.length > 0 ? resolved : [url.hostname];
+		const nonPrivate = ips.filter((ip) => !isPrivateIP(ip));
+		if (nonPrivate.length > 0) {
+			result.error = `Provider resolves to non-private IPs: ${nonPrivate.join(", ")}`;
+			return result;
+		}
+
+		// Make health check request
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), 10000);
+
+		try {
+			const response = await fetch(url.toString(), {
+				method: "GET",
+				headers: {
+					accept: "application/json",
+				},
+				signal: controller.signal,
+			});
+
+			if (!response.ok) {
+				result.error = `HTTP ${response.status}: ${response.statusText}`;
+				return result;
+			}
+
+			const text = await response.text();
+			try {
+				result.response = JSON.parse(text) as ProviderHealthResponse;
+				result.reachable = true;
+			} catch {
+				result.error = "Invalid JSON response from health endpoint";
+			}
+		} finally {
+			clearTimeout(timeout);
+		}
+	} catch (err) {
+		if (err instanceof Error && err.name === "AbortError") {
+			result.error = "Request timeout (10s)";
+		} else {
+			result.error = String(err);
+		}
+	}
+
+	return result;
+}
+
+function formatHealthOutput(results: HealthCheckResult[], json: boolean): string {
+	if (json) {
+		return JSON.stringify(results, null, 2);
+	}
+
+	const lines: string[] = [];
+
+	for (const result of results) {
+		const statusIcon = result.reachable
+			? result.response?.status === "healthy"
+				? "✓"
+				: result.response?.status === "degraded"
+					? "⚠"
+					: "✗"
+			: "✗";
+
+		lines.push(`${statusIcon} ${result.providerId} (${result.baseUrl})`);
+
+		if (!result.reachable) {
+			lines.push(`  Error: ${result.error}`);
+			continue;
+		}
+
+		const resp = result.response;
+		if (!resp) continue;
+
+		lines.push(`  Status: ${resp.status}`);
+
+		// Show connector statuses
+		if (resp.connectors) {
+			for (const [name, connector] of Object.entries(resp.connectors)) {
+				const connIcon =
+					connector.status === "ok"
+						? "✓"
+						: connector.status === "auth_expired"
+							? "🔑"
+							: connector.status === "drift_detected"
+								? "⚠"
+								: "✗";
+				lines.push(`  ${connIcon} ${name}: ${connector.status}`);
+				if (connector.lastSuccess) {
+					lines.push(`    Last success: ${connector.lastSuccess}`);
+				}
+				if (connector.driftSignals?.length) {
+					lines.push(`    Drift signals: ${connector.driftSignals.join(", ")}`);
+				}
+			}
+		}
+
+		// Show alerts
+		if (resp.alerts?.length) {
+			lines.push("  Alerts:");
+			for (const alert of resp.alerts) {
+				const alertIcon = alert.level === "error" ? "✗" : "⚠";
+				lines.push(`    ${alertIcon} [${alert.connector}] ${alert.message}`);
+			}
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function computeExitCode(results: HealthCheckResult[]): number {
+	let hasError = false;
+	let hasWarn = false;
+
+	for (const result of results) {
+		if (!result.reachable) {
+			hasError = true;
+			continue;
+		}
+
+		const status = result.response?.status;
+		if (status === "unhealthy") {
+			hasError = true;
+		} else if (status === "degraded") {
+			hasWarn = true;
+		}
+
+		// Also check for error-level alerts
+		for (const alert of result.response?.alerts ?? []) {
+			if (alert.level === "error") {
+				hasError = true;
+			} else if (alert.level === "warn") {
+				hasWarn = true;
+			}
+		}
+	}
+
+	if (hasError) return 2;
+	if (hasWarn) return 1;
+	return 0;
+}
+
+export function registerProviderHealthCommand(program: Command): void {
+	program
+		.command("provider-health")
+		.description("Check health status of configured external providers")
+		.argument("[provider-id]", "Specific provider to check (default: all)")
+		.option("--json", "Output as JSON")
+		.option("--alert-telegram", "Send Telegram alert if any provider is degraded/unhealthy")
+		.action(
+			async (
+				providerId: string | undefined,
+				options: { json?: boolean; alertTelegram?: boolean },
+			) => {
+				const cfg = loadConfig();
+				const providers = cfg.providers ?? [];
+
+				if (providers.length === 0) {
+					if (options.json) {
+						console.log(JSON.stringify({ error: "No providers configured" }));
+					} else {
+						console.log("No providers configured.");
+						console.log("Add providers to telclaude.json under 'providers' array.");
+					}
+					process.exitCode = 0;
+					return;
+				}
+
+				// Filter to specific provider if requested
+				const toCheck = providerId ? providers.filter((p) => p.id === providerId) : providers;
+
+				if (toCheck.length === 0) {
+					if (options.json) {
+						console.log(JSON.stringify({ error: `Provider '${providerId}' not found` }));
+					} else {
+						console.log(`Provider '${providerId}' not found.`);
+						console.log(`Available providers: ${providers.map((p) => p.id).join(", ")}`);
+					}
+					process.exitCode = 1;
+					return;
+				}
+
+				// Check all providers
+				const results: HealthCheckResult[] = [];
+				for (const provider of toCheck) {
+					const result = await checkProviderHealth(provider.id, provider.baseUrl);
+					results.push(result);
+				}
+
+				// Output results
+				console.log(formatHealthOutput(results, options.json ?? false));
+
+				// Compute exit code
+				const exitCode = computeExitCode(results);
+				process.exitCode = exitCode;
+
+				// Send Telegram alert if requested and there are issues
+				if (options.alertTelegram && exitCode > 0) {
+					try {
+						// Dynamic import to avoid circular deps and keep command lightweight
+						const { sendAdminAlert } = await import("../telegram/admin-alert.js");
+						const alertLevel = exitCode === 2 ? "error" : "warn";
+						const summary = results
+							.filter((r) => !r.reachable || r.response?.status !== "healthy")
+							.map((r) => `${r.providerId}: ${r.response?.status ?? r.error}`)
+							.join("\n");
+
+						await sendAdminAlert({
+							level: alertLevel,
+							title: "Provider Health Alert",
+							message: summary,
+						});
+
+						if (!options.json) {
+							console.log("\nTelegram alert sent to admin.");
+						}
+					} catch (err) {
+						logger.warn({ error: String(err) }, "Failed to send Telegram alert");
+						if (!options.json) {
+							console.log(`\nFailed to send Telegram alert: ${err}`);
+						}
+					}
+				}
+			},
+		);
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -180,6 +180,18 @@ const NetworkConfigSchema = z.object({
 	privateEndpoints: z.array(PrivateEndpointSchema).default([]),
 });
 
+// External provider configuration (sidecar services)
+const ExternalProviderSchema = z.object({
+	// Provider identifier (e.g., "citizen-services")
+	id: z.string().min(1).max(64),
+	// Base URL for provider API (should be localhost/private network)
+	baseUrl: z.string().url(),
+	// Service identifiers handled by this provider (e.g., "poalim", "clalit")
+	services: z.array(z.string()).default([]),
+	// Optional description for admin/operator clarity
+	description: z.string().max(256).optional(),
+});
+
 // Security configuration schema
 const SecurityConfigSchema = z.object({
 	// Security profile determines which layers are active
@@ -303,6 +315,8 @@ const TelclaudeConfigSchema = z.object({
 	imageGeneration: ImageGenerationConfigSchema.default({}),
 	videoProcessing: VideoProcessingConfigSchema.default({}),
 	tts: TTSConfigSchema.default({}),
+	// External providers (sidecars) - optional
+	providers: z.array(ExternalProviderSchema).default([]),
 });
 
 export type TelclaudeConfig = z.infer<typeof TelclaudeConfigSchema>;
@@ -310,6 +324,7 @@ export type ReplyConfig = z.infer<typeof ReplyConfigSchema>;
 export type SessionConfig = z.infer<typeof SessionConfigSchema>;
 export type SecurityConfig = z.infer<typeof SecurityConfigSchema>;
 export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
+export type ExternalProviderConfig = z.infer<typeof ExternalProviderSchema>;
 export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
 export type SdkConfig = z.infer<typeof SdkConfigSchema>;
 export type OpenAIConfig = z.infer<typeof OpenAIConfigSchema>;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -186,7 +186,7 @@ const ExternalProviderSchema = z.object({
 	id: z.string().min(1).max(64),
 	// Base URL for provider API (should be localhost/private network)
 	baseUrl: z.string().url(),
-	// Service identifiers handled by this provider (e.g., "poalim", "clalit")
+	// Service identifiers handled by this provider (e.g., "health-api", "bank-api")
 	services: z.array(z.string()).default([]),
 	// Optional description for admin/operator clarity
 	description: z.string().max(256).optional(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { registerGitTestCommand } from "./commands/git-test.js";
 import { registerIntegrationTestCommand } from "./commands/integration-test.js";
 import { registerLinkCommand } from "./commands/link.js";
 import { registerNetworkCommand } from "./commands/network.js";
+import { registerProviderHealthCommand } from "./commands/provider-health.js";
 import { registerQuickstartCommand } from "./commands/quickstart.js";
 import { registerRelayCommand } from "./commands/relay.js";
 import { registerResetAuthCommand } from "./commands/reset-auth.js";
@@ -58,6 +59,7 @@ registerIntegrationTestCommand(program);
 registerDiagnoseSandboxNetworkCommand(program);
 registerQuickstartCommand(program);
 registerNetworkCommand(program);
+registerProviderHealthCommand(program);
 
 // Pre-parse to extract global options before commands run
 // This ensures --config and --verbose are set before any config loading happens

--- a/src/providers/external-provider.ts
+++ b/src/providers/external-provider.ts
@@ -114,6 +114,7 @@ export async function sendProviderOtp(request: ProviderOtpRequest): Promise<Prov
 			method: "POST",
 			headers: {
 				"content-type": "application/json",
+				"x-actor-user-id": request.actorUserId,
 				"x-request-id": request.requestId ?? "",
 			},
 			body: JSON.stringify({

--- a/src/providers/external-provider.ts
+++ b/src/providers/external-provider.ts
@@ -1,0 +1,145 @@
+import { type ExternalProviderConfig, loadConfig } from "../config/config.js";
+import { getChildLogger } from "../logging.js";
+import {
+	cachedDNSLookup,
+	checkPrivateNetworkAccess,
+	isPrivateIP,
+} from "../sandbox/network-proxy.js";
+
+const logger = getChildLogger({ module: "external-provider" });
+
+export type ProviderResolution = {
+	provider: ExternalProviderConfig | null;
+	reason?: string;
+};
+
+function parseProviderUrl(baseUrl: string): URL {
+	const url = new URL(baseUrl);
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error(`Unsupported provider URL protocol: ${url.protocol}`);
+	}
+	return url;
+}
+
+async function ensurePrivateProviderUrl(
+	provider: ExternalProviderConfig,
+): Promise<{ url: URL; port: number }> {
+	const cfg = loadConfig();
+	const url = parseProviderUrl(provider.baseUrl);
+	const port = url.port ? Number.parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
+
+	const endpoints = cfg.security?.network?.privateEndpoints ?? [];
+	if (!endpoints.length) {
+		throw new Error(
+			"No private endpoints configured. Add a provider endpoint via `telclaude network add`.",
+		);
+	}
+
+	const privateCheck = await checkPrivateNetworkAccess(url.hostname, port, endpoints);
+	if (!privateCheck.allowed || !privateCheck.matchedEndpoint) {
+		throw new Error(
+			privateCheck.reason || "Provider URL must resolve to an allowlisted private endpoint.",
+		);
+	}
+
+	const resolved = await cachedDNSLookup(url.hostname);
+	const ips = resolved && resolved.length > 0 ? resolved : [url.hostname];
+	const nonPrivate = ips.filter((ip) => !isPrivateIP(ip));
+	if (nonPrivate.length > 0) {
+		throw new Error(
+			`Provider URL must resolve to private IPs only (non-private: ${nonPrivate.join(", ")})`,
+		);
+	}
+
+	return { url, port };
+}
+
+export function resolveProviderForService(serviceId: string): ProviderResolution {
+	const cfg = loadConfig();
+	const providers = cfg.providers ?? [];
+	if (!providers.length) {
+		return { provider: null, reason: "No providers configured." };
+	}
+
+	const matches = providers.filter((p) => p.services?.includes(serviceId));
+	if (matches.length === 1) {
+		return { provider: matches[0] };
+	}
+	if (matches.length > 1) {
+		return {
+			provider: null,
+			reason: `Multiple providers match service '${serviceId}'. Configure unique service mapping.`,
+		};
+	}
+
+	if (providers.length === 1) {
+		return { provider: providers[0] };
+	}
+
+	return {
+		provider: null,
+		reason: `No provider found for service '${serviceId}'.`,
+	};
+}
+
+export type ProviderOtpRequest = {
+	service: string;
+	code: string;
+	challengeId?: string;
+	actorUserId: string;
+	requestId?: string;
+};
+
+export type ProviderOtpResponse = {
+	status: string;
+	message?: string;
+	detail?: string;
+	challengeId?: string;
+};
+
+export async function sendProviderOtp(request: ProviderOtpRequest): Promise<ProviderOtpResponse> {
+	const { provider, reason } = resolveProviderForService(request.service);
+	if (!provider) {
+		throw new Error(reason || "Provider not found.");
+	}
+
+	const { url } = await ensurePrivateProviderUrl(provider);
+	const endpoint = new URL("/v1/challenge/respond", url);
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 15000);
+
+	try {
+		const response = await fetch(endpoint.toString(), {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-request-id": request.requestId ?? "",
+			},
+			body: JSON.stringify({
+				service: request.service,
+				code: request.code,
+				challengeId: request.challengeId,
+				actorUserId: request.actorUserId,
+			}),
+			signal: controller.signal,
+		});
+
+		const text = await response.text();
+		if (!response.ok) {
+			logger.warn(
+				{ status: response.status, provider: provider.id, body: text.slice(0, 200) },
+				"provider OTP request failed",
+			);
+			throw new Error(`Provider responded with ${response.status}.`);
+		}
+
+		try {
+			return JSON.parse(text) as ProviderOtpResponse;
+		} catch {
+			return { status: "ok", message: text };
+		}
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,7 @@
+export {
+	type ProviderOtpRequest,
+	type ProviderOtpResponse,
+	type ProviderResolution,
+	resolveProviderForService,
+	sendProviderOtp,
+} from "./external-provider.js";

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,3 +5,4 @@ export {
 	resolveProviderForService,
 	sendProviderOtp,
 } from "./external-provider.js";
+export { validateProviderBaseUrl } from "./provider-validation.js";

--- a/src/providers/provider-health.ts
+++ b/src/providers/provider-health.ts
@@ -1,0 +1,150 @@
+import { getChildLogger } from "../logging.js";
+import { validateProviderBaseUrl } from "./provider-validation.js";
+
+const logger = getChildLogger({ module: "provider-health" });
+
+// Health response from provider
+export interface ConnectorHealth {
+	status: "ok" | "auth_expired" | "drift_detected" | "error";
+	lastSuccess?: string;
+	lastAttempt?: string;
+	failureCount?: number;
+	driftSignals?: string[];
+}
+
+export interface HealthAlert {
+	level: "warn" | "error";
+	connector: string;
+	message: string;
+	since?: string;
+}
+
+export interface ProviderHealthResponse {
+	status: "healthy" | "degraded" | "unhealthy";
+	connectors?: Record<string, ConnectorHealth>;
+	alerts?: HealthAlert[];
+	error?: string;
+}
+
+export interface HealthCheckResult {
+	providerId: string;
+	baseUrl: string;
+	reachable: boolean;
+	response?: ProviderHealthResponse;
+	error?: string;
+}
+
+export async function checkProviderHealth(
+	providerId: string,
+	baseUrl: string,
+): Promise<HealthCheckResult> {
+	const result: HealthCheckResult = {
+		providerId,
+		baseUrl,
+		reachable: false,
+	};
+
+	try {
+		const { url: base } = await validateProviderBaseUrl(baseUrl);
+		const url = new URL("/v1/health", base);
+
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), 10000);
+
+		try {
+			const response = await fetch(url.toString(), {
+				method: "GET",
+				headers: {
+					accept: "application/json",
+				},
+				signal: controller.signal,
+			});
+
+			if (!response.ok) {
+				result.error = `HTTP ${response.status}: ${response.statusText}`;
+				return result;
+			}
+
+			const text = await response.text();
+			try {
+				result.response = JSON.parse(text) as ProviderHealthResponse;
+				result.reachable = true;
+			} catch {
+				result.error = "Invalid JSON response from health endpoint";
+			}
+		} finally {
+			clearTimeout(timeout);
+		}
+	} catch (err) {
+		if (err instanceof Error && err.name === "AbortError") {
+			result.error = "Request timeout (10s)";
+		} else if (err instanceof Error && err.message) {
+			result.error = err.message;
+		} else {
+			result.error = String(err);
+		}
+	}
+
+	return result;
+}
+
+export function computeProviderHealthExitCode(results: HealthCheckResult[]): number {
+	let hasError = false;
+	let hasWarn = false;
+
+	for (const result of results) {
+		if (!result.reachable) {
+			hasError = true;
+			continue;
+		}
+
+		const status = result.response?.status;
+		if (status === "unhealthy") {
+			hasError = true;
+		} else if (status === "degraded") {
+			hasWarn = true;
+		}
+
+		for (const alert of result.response?.alerts ?? []) {
+			if (alert.level === "error") {
+				hasError = true;
+			} else if (alert.level === "warn") {
+				hasWarn = true;
+			}
+		}
+	}
+
+	if (hasError) return 2;
+	if (hasWarn) return 1;
+	return 0;
+}
+
+export function formatProviderHealthSummary(results: HealthCheckResult[]): string {
+	const issues = results.filter(
+		(result) => !result.reachable || result.response?.status !== "healthy",
+	);
+	if (issues.length === 0) {
+		return "All providers healthy.";
+	}
+	return issues
+		.map((result) => `${result.providerId}: ${result.response?.status ?? result.error}`)
+		.join("; ");
+}
+
+export function logProviderHealthResults(results: HealthCheckResult[]): void {
+	for (const result of results) {
+		if (!result.reachable) {
+			logger.warn(
+				{ provider: result.providerId, error: result.error },
+				"provider health check failed",
+			);
+			continue;
+		}
+		const status = result.response?.status ?? "unknown";
+		if (status === "healthy") {
+			logger.info({ provider: result.providerId }, "provider healthy");
+		} else {
+			logger.warn({ provider: result.providerId, status }, "provider not healthy");
+		}
+	}
+}

--- a/src/providers/provider-skill.ts
+++ b/src/providers/provider-skill.ts
@@ -1,0 +1,315 @@
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ExternalProviderConfig } from "../config/config.js";
+import { getChildLogger } from "../logging.js";
+import { validateProviderBaseUrl } from "./provider-validation.js";
+
+const logger = getChildLogger({ module: "provider-skill" });
+
+const SKILL_FILE = "external-provider.md";
+const SCHEMA_MARKER_START = "<!-- PROVIDER_SCHEMA_START -->";
+const SCHEMA_MARKER_END = "<!-- PROVIDER_SCHEMA_END -->";
+
+type ActionDoc = {
+	id: string;
+	description?: string;
+};
+
+type ServiceDoc = {
+	id: string;
+	name?: string;
+	description?: string;
+	actions: ActionDoc[];
+};
+
+type ProviderSchemaResult = {
+	provider: ExternalProviderConfig;
+	schema?: unknown;
+	error?: string;
+};
+
+function coerceDescription(value: unknown): string | undefined {
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	}
+	return undefined;
+}
+
+function parseActionDocString(text: string): ActionDoc {
+	const trimmed = text.trim();
+	const parts = trimmed.split(/\s[-–—]\s/);
+	const id = parts[0]?.trim() ?? trimmed;
+	const description = parts.length > 1 ? parts.slice(1).join(" - ").trim() : undefined;
+	return { id, description: description || undefined };
+}
+
+function normalizeActions(value: unknown): ActionDoc[] {
+	if (!value) return [];
+	if (Array.isArray(value)) {
+		return value
+			.map((entry) => {
+				if (typeof entry === "string") return parseActionDocString(entry);
+				if (entry && typeof entry === "object") {
+					const record = entry as Record<string, unknown>;
+					const id =
+						coerceDescription(record.id) ??
+						coerceDescription(record.name) ??
+						coerceDescription(record.action) ??
+						coerceDescription(record.key);
+					if (!id) return null;
+					return {
+						id,
+						description:
+							coerceDescription(record.description) ??
+							coerceDescription(record.summary) ??
+							coerceDescription(record.label),
+					};
+				}
+				return null;
+			})
+			.filter((entry): entry is ActionDoc => Boolean(entry));
+	}
+	if (typeof value === "object") {
+		return Object.entries(value as Record<string, unknown>).map(([key, entry]) => {
+			const record = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : null;
+			const description = record
+				? coerceDescription(record.description) ??
+					coerceDescription(record.summary) ??
+					coerceDescription(record.label)
+				: undefined;
+			return { id: key, description };
+		});
+	}
+	return [];
+}
+
+function extractServiceDocs(schema: unknown): ServiceDoc[] {
+	if (!schema || typeof schema !== "object") return [];
+	const record = schema as Record<string, unknown>;
+	const container =
+		record.services ?? record.connectors ?? record.providers ?? record.service ?? record.connector;
+	if (!container) return [];
+
+	const services: ServiceDoc[] = [];
+
+	if (Array.isArray(container)) {
+		for (const entry of container) {
+			if (!entry || typeof entry !== "object") continue;
+			const service = entry as Record<string, unknown>;
+			const id =
+				coerceDescription(service.id) ??
+				coerceDescription(service.service) ??
+				coerceDescription(service.name);
+			if (!id) continue;
+			const docs = (service.$docs ?? service.docs) as Record<string, unknown> | undefined;
+			const availableActions = docs?.available_actions ?? docs?.availableActions;
+			const actionCandidates = [
+				normalizeActions(service.actions),
+				normalizeActions(service.endpoints),
+				normalizeActions(availableActions),
+			];
+			const actions = actionCandidates.find((list) => list.length > 0) ?? [];
+			services.push({
+				id,
+				name: coerceDescription(service.name) ?? coerceDescription(service.label),
+				description:
+					coerceDescription(service.description) ?? coerceDescription(docs?.description),
+				actions,
+			});
+		}
+	} else if (typeof container === "object") {
+		for (const [id, entry] of Object.entries(container as Record<string, unknown>)) {
+			if (!entry || typeof entry !== "object") {
+				services.push({ id, actions: [] });
+				continue;
+			}
+			const service = entry as Record<string, unknown>;
+			const docs = (service.$docs ?? service.docs) as Record<string, unknown> | undefined;
+			const availableActions = docs?.available_actions ?? docs?.availableActions;
+			const actionCandidates = [
+				normalizeActions(service.actions),
+				normalizeActions(service.endpoints),
+				normalizeActions(availableActions),
+			];
+			const actions = actionCandidates.find((list) => list.length > 0) ?? [];
+			services.push({
+				id,
+				name: coerceDescription(service.name) ?? coerceDescription(service.label),
+				description:
+					coerceDescription(service.description) ?? coerceDescription(docs?.description),
+				actions,
+			});
+		}
+	}
+
+	return services;
+}
+
+async function fetchProviderSchema(
+	provider: ExternalProviderConfig,
+): Promise<ProviderSchemaResult> {
+	try {
+		const { url: base } = await validateProviderBaseUrl(provider.baseUrl);
+		const endpoint = new URL("/v1/schema", base);
+
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), 10000);
+
+		try {
+			const response = await fetch(endpoint.toString(), {
+				method: "GET",
+				headers: {
+					accept: "application/json",
+				},
+				signal: controller.signal,
+			});
+
+			if (!response.ok) {
+				return {
+					provider,
+					error: `HTTP ${response.status}: ${response.statusText}`,
+				};
+			}
+
+			const text = await response.text();
+			try {
+				return { provider, schema: JSON.parse(text) };
+			} catch {
+				return { provider, error: "Invalid JSON response from schema endpoint" };
+			}
+		} finally {
+			clearTimeout(timeout);
+		}
+	} catch (err) {
+		const message =
+			err instanceof Error && err.name === "AbortError"
+				? "Request timeout (10s)"
+				: err instanceof Error && err.message
+					? err.message
+					: String(err);
+		return { provider, error: message };
+	}
+}
+
+function formatServiceDoc(service: ServiceDoc): string[] {
+	const lines: string[] = [];
+	const description = service.description || service.name;
+	if (description) {
+		lines.push(`- ${service.id} — ${description}`);
+	} else {
+		lines.push(`- ${service.id}`);
+	}
+
+	if (service.actions.length > 0) {
+		for (const action of service.actions) {
+			const actionDesc = action.description ? ` — ${action.description}` : "";
+			lines.push(`  - /v1/${service.id}/${action.id}${actionDesc}`);
+		}
+	}
+	return lines;
+}
+
+function buildSchemaMarkdown(results: ProviderSchemaResult[]): string {
+	const lines: string[] = [];
+	lines.push(`Last updated: ${new Date().toISOString()}`);
+	lines.push("");
+
+	if (results.length === 0) {
+		lines.push("No providers configured.");
+		return lines.join("\n");
+	}
+
+	for (const result of results) {
+		lines.push(`### Provider: ${result.provider.id}`);
+		lines.push(`Base URL: ${result.provider.baseUrl}`);
+
+		if (result.error) {
+			lines.push(`Schema fetch failed: ${result.error}`);
+			lines.push("");
+			continue;
+		}
+
+		const services = extractServiceDocs(result.schema);
+		if (services.length === 0) {
+			lines.push("Schema retrieved, but no structured services/actions detected.");
+			lines.push("Refer to /v1/schema for full details.");
+			lines.push("");
+			continue;
+		}
+
+		lines.push("Services:");
+		for (const service of services) {
+			lines.push(...formatServiceDoc(service));
+		}
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}
+
+function upsertSchemaSection(content: string, section: string): string {
+	const start = content.indexOf(SCHEMA_MARKER_START);
+	const end = content.indexOf(SCHEMA_MARKER_END);
+
+	if (start !== -1 && end !== -1 && end > start) {
+		const before = content.slice(0, start + SCHEMA_MARKER_START.length);
+		const after = content.slice(end);
+		return `${before}\n${section}\n${after}`;
+	}
+
+	const suffix = content.endsWith("\n") ? "" : "\n";
+	return (
+		`${content}${suffix}\n## Provider Schemas (auto-generated)\n` +
+		`${SCHEMA_MARKER_START}\n${section}\n${SCHEMA_MARKER_END}\n`
+	);
+}
+
+async function resolveSkillPath(): Promise<string | null> {
+	const candidates = [
+		path.join(process.cwd(), ".claude", "skills", SKILL_FILE),
+		path.join("/workspace", ".claude", "skills", SKILL_FILE),
+		path.join(os.homedir(), ".claude", "skills", SKILL_FILE),
+		path.join("/app", ".claude", "skills", SKILL_FILE),
+	];
+
+	for (const candidate of candidates) {
+		try {
+			await fs.access(candidate, fsConstants.W_OK);
+			return candidate;
+		} catch {
+			// skip
+		}
+	}
+
+	return null;
+}
+
+export async function refreshExternalProviderSkill(
+	providers: ExternalProviderConfig[],
+): Promise<void> {
+	const skillPath = await resolveSkillPath();
+	if (!skillPath) {
+		logger.warn("external-provider skill not found; skipping schema injection");
+		return;
+	}
+
+	const results: ProviderSchemaResult[] = [];
+	for (const provider of providers) {
+		results.push(await fetchProviderSchema(provider));
+	}
+
+	const section = buildSchemaMarkdown(results);
+
+	try {
+		const existing = await fs.readFile(skillPath, "utf8");
+		const updated = upsertSchemaSection(existing, section);
+		if (updated !== existing) {
+			await fs.writeFile(skillPath, updated, "utf8");
+		}
+	} catch (err) {
+		logger.warn({ error: String(err), skillPath }, "failed to update external provider skill");
+	}
+}

--- a/src/providers/provider-skill.ts
+++ b/src/providers/provider-skill.ts
@@ -97,9 +97,9 @@ function normalizeActions(value: unknown): ActionDoc[] {
 		return Object.entries(value as Record<string, unknown>).map(([key, entry]) => {
 			const record = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : null;
 			const description = record
-				? coerceDescription(record.description) ??
+				? (coerceDescription(record.description) ??
 					coerceDescription(record.summary) ??
-					coerceDescription(record.label)
+					coerceDescription(record.label))
 				: undefined;
 			const params =
 				record?.params && typeof record.params === "object"
@@ -108,7 +108,9 @@ function normalizeActions(value: unknown): ActionDoc[] {
 			return {
 				id: key,
 				description,
-				method: record ? coerceDescription(record.method) ?? coerceDescription(record.httpMethod) : undefined,
+				method: record
+					? (coerceDescription(record.method) ?? coerceDescription(record.httpMethod))
+					: undefined,
 				mode: record ? coerceDescription(record.mode) : undefined,
 				requiresAuth:
 					record && typeof record.requiresAuth === "boolean" ? record.requiresAuth : undefined,
@@ -148,8 +150,7 @@ function extractServiceDocs(schema: unknown): ServiceDoc[] {
 			services.push({
 				id,
 				name: coerceDescription(service.name) ?? coerceDescription(service.label),
-				description:
-					coerceDescription(service.description) ?? coerceDescription(docs?.description),
+				description: coerceDescription(service.description) ?? coerceDescription(docs?.description),
 				actions,
 			});
 		}
@@ -171,8 +172,7 @@ function extractServiceDocs(schema: unknown): ServiceDoc[] {
 			services.push({
 				id,
 				name: coerceDescription(service.name) ?? coerceDescription(service.label),
-				description:
-					coerceDescription(service.description) ?? coerceDescription(docs?.description),
+				description: coerceDescription(service.description) ?? coerceDescription(docs?.description),
 				actions,
 			});
 		}

--- a/src/providers/provider-validation.ts
+++ b/src/providers/provider-validation.ts
@@ -1,0 +1,49 @@
+import { loadConfig } from "../config/config.js";
+import {
+	cachedDNSLookup,
+	checkPrivateNetworkAccess,
+	isPrivateIP,
+} from "../sandbox/network-proxy.js";
+
+export async function validateProviderBaseUrl(
+	baseUrl: string,
+): Promise<{ url: URL; port: number }> {
+	let url: URL;
+	try {
+		url = new URL(baseUrl);
+	} catch {
+		throw new Error(`Invalid provider URL: ${baseUrl}`);
+	}
+
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error(`Unsupported provider URL protocol: ${url.protocol}`);
+	}
+
+	const port = url.port ? Number.parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
+
+	const cfg = loadConfig();
+	const endpoints = cfg.security?.network?.privateEndpoints ?? [];
+	if (!endpoints.length) {
+		throw new Error(
+			"No private endpoints configured. Add a provider endpoint via `telclaude network add`.",
+		);
+	}
+
+	const privateCheck = await checkPrivateNetworkAccess(url.hostname, port, endpoints);
+	if (!privateCheck.allowed || !privateCheck.matchedEndpoint) {
+		throw new Error(
+			privateCheck.reason || "Provider URL must resolve to an allowlisted private endpoint.",
+		);
+	}
+
+	const resolved = await cachedDNSLookup(url.hostname);
+	const ips = resolved && resolved.length > 0 ? resolved : [url.hostname];
+	const nonPrivate = ips.filter((ip) => !isPrivateIP(ip));
+	if (nonPrivate.length > 0) {
+		throw new Error(
+			`Provider URL must resolve to private IPs only (non-private: ${nonPrivate.join(", ")})`,
+		);
+	}
+
+	return { url, port };
+}

--- a/src/sandbox/network-proxy.ts
+++ b/src/sandbox/network-proxy.ts
@@ -388,6 +388,8 @@ export function isPrivateIP(ip: string): boolean {
 		if (a === 172 && b >= 16 && b <= 31) return true;
 		// 192.168.0.0/16
 		if (a === 192 && b === 168) return true;
+		// 100.64.0.0/10 (CGNAT / Tailscale) - RFC 6598 shared address space
+		if (a === 100 && b >= 64 && b <= 127) return true;
 	} else if (ipType === 6) {
 		// Handle IPv4-mapped IPv6 (::ffff:192.168.1.1)
 		if (ip.includes(".")) {

--- a/src/telegram/admin-alert.ts
+++ b/src/telegram/admin-alert.ts
@@ -1,0 +1,103 @@
+/**
+ * Admin alert module for sending notifications to admin chats.
+ *
+ * Used by CLI commands and background tasks to notify admins of issues.
+ */
+
+import { loadConfig } from "../config/config.js";
+import { getChildLogger } from "../logging.js";
+import { getDb } from "../storage/db.js";
+
+const logger = getChildLogger({ module: "admin-alert" });
+
+export interface AdminAlert {
+	level: "info" | "warn" | "error";
+	title: string;
+	message: string;
+}
+
+/**
+ * Get all chat IDs that are linked to the "admin" identity.
+ */
+function getAdminChatIds(): number[] {
+	const db = getDb();
+	const rows = db
+		.prepare("SELECT chat_id FROM identity_links WHERE local_user_id = ?")
+		.all("admin") as Array<{ chat_id: number }>;
+	return rows.map((r) => r.chat_id);
+}
+
+/**
+ * Send an alert to all admin chats.
+ *
+ * Requires the bot to be configured and running (or at least have a valid token).
+ * If called from CLI without a running bot, creates a new bot instance temporarily.
+ */
+export async function sendAdminAlert(alert: AdminAlert): Promise<void> {
+	const cfg = loadConfig();
+	const botToken = cfg.telegram?.botToken;
+
+	if (!botToken) {
+		logger.warn("No bot token configured, cannot send admin alert");
+		throw new Error("No bot token configured");
+	}
+
+	const adminChatIds = getAdminChatIds();
+	if (adminChatIds.length === 0) {
+		logger.warn("No admin chats found, cannot send alert");
+		throw new Error("No admin chats configured");
+	}
+
+	const emoji = alert.level === "error" ? "🚨" : alert.level === "warn" ? "⚠️" : "ℹ️";
+	const text = `${emoji} *${escapeMarkdown(alert.title)}*\n\n${escapeMarkdown(alert.message)}`;
+
+	// Send to each admin chat
+	const errors: Error[] = [];
+	for (const chatId of adminChatIds) {
+		try {
+			await sendTelegramMessage(botToken, chatId, text);
+			logger.info({ chatId, title: alert.title }, "sent admin alert");
+		} catch (err) {
+			logger.warn({ chatId, error: String(err) }, "failed to send admin alert");
+			errors.push(err instanceof Error ? err : new Error(String(err)));
+		}
+	}
+
+	// If all sends failed, throw
+	if (errors.length === adminChatIds.length) {
+		throw new Error(`Failed to send alert to any admin: ${errors[0].message}`);
+	}
+}
+
+/**
+ * Send a message via Telegram Bot API directly (without grammy).
+ * Used when the bot instance isn't running.
+ */
+async function sendTelegramMessage(botToken: string, chatId: number, text: string): Promise<void> {
+	const url = `https://api.telegram.org/bot${botToken}/sendMessage`;
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+		},
+		body: JSON.stringify({
+			chat_id: chatId,
+			text,
+			parse_mode: "MarkdownV2",
+		}),
+	});
+
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(`Telegram API error: ${response.status} ${body}`);
+	}
+}
+
+/**
+ * Escape text for MarkdownV2 format.
+ */
+function escapeMarkdown(text: string): string {
+	// MarkdownV2 requires escaping these characters
+	return text.replace(/([_*[\]()~`>#+\-=|{}.!\\])/g, "\\$1");
+}

--- a/src/telegram/auto-reply.ts
+++ b/src/telegram/auto-reply.ts
@@ -263,7 +263,10 @@ type ExecutionContext = {
 async function executeAndReply(ctx: ExecutionContext): Promise<void> {
 	const { msg, config } = ctx;
 
-	const userId = String(msg.chatId);
+	// Use localUserId if chat is linked, otherwise fall back to chatId.
+	// Note: /otp requires a linked identity and will error if unlinked.
+	const identityLink = getIdentityLink(msg.chatId);
+	const userId = identityLink?.localUserId ?? String(msg.chatId);
 	const startTime = Date.now();
 
 	const replyConfig = config.inbound?.reply;


### PR DESCRIPTION
## Summary

- Add external provider (sidecar) support for private REST APIs (health, banking, government services)
- New `/otp <service> <code>` command for challenge/OTP flow
- Auto-inject `x-actor-user-id` header for provider requests
- Provider health checks integrated into Docker healthcheck
- Firewall auto-includes provider hosts from config
- CGNAT/Tailscale IP range support (100.64.0.0/10)

## Changes

- **New module**: `src/providers/` - provider resolution, OTP, health, skill schema
- **Config**: `providers[]` array and `privateEndpoints[]` for network allowlist
- **SDK client**: PreToolUse hook injects actor headers for provider requests
- **Telegram**: `/otp` command for OTP challenge flow
- **Docker**: healthcheck uses `provider-health`, firewall parses provider hosts
- **Docs**: `telclaude.json.example` template, README updated with provider setup

## Test plan

- [x] TypeScript compiles
- [x] 248 tests pass
- [x] Lint clean
- [ ] Manual test with sidecar service

🤖 Generated with [Claude Code](https://claude.com/claude-code)