### PR TITLE
feat: enable attachment fetch for READ_ONLY tier via WebFetch

### DIFF
--- a/src/security/permissions.ts
+++ b/src/security/permissions.ts
@@ -384,6 +384,11 @@ const SENSITIVE_PATH_PATTERNS: RegExp[] = [
 	// === Security-critical skills ===
 	// SECURITY: Prevents self-modification of the security-gate skill prompt.
 	/(?:^|[/\\])\.claude[/\\]skills[/\\]security-gate(?:[/\\]|$)/i,
+	// === Telclaude source code (defense in depth) ===
+	// SECURITY: Agent has no reason to write to telclaude's own source.
+	// Primary protection is Docker read-only filesystem; this is belt-and-suspenders.
+	/(?:^|[/\\])app[/\\]src(?:[/\\]|$)/i, // /app/src/ in Docker
+	/telclaude[/\\]src(?:[/\\]|$)/i, // telclaude/src/ anywhere
 
 	// === Environment files (secrets!) ===
 	// Match .env anywhere in path (but not .environment or similar)


### PR DESCRIPTION
## Summary
- Extend PreToolUse hook to allow WebFetch to relay /v1/attachment/fetch
- Inject internal auth headers automatically (no agent-visible secrets)
- Add defense-in-depth: block writes to telclaude source directories
- Update external-provider skill to use WebFetch instead of Bash CLI

## Why
READ_ONLY users couldn't receive PDF attachments because  requires Bash. This enables attachment delivery via WebFetch, which READ_ONLY allows.

## Testing
- ✅ Lint pass
- ✅ Build pass  
- ✅ 248 tests pass

🤖 Generated with Claude Code