### PR TITLE
feat(cli): add provider-query command for external provider access

### DIFF
--- a/.claude/skills/external-provider/SKILL.md
+++ b/.claude/skills/external-provider/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: external-provider
-description: Access configured sidecar providers (health, banking, government) via WebFetch.
-allowed-tools: Read, WebFetch
+description: Access configured sidecar providers (health, banking, government) via CLI commands.
+allowed-tools: Read, Bash
 ---
 
 # External Provider
@@ -17,7 +17,12 @@ Check the provider schema to see which services are available. The authoritative
 
 ## How to Use
 
-**Use WebFetch to call providers directly.** The system automatically injects authentication headers.
+**IMPORTANT: Use the `telclaude` CLI commands for all provider operations.**
+- Do NOT use WebFetch or curl to call provider endpoints directly
+- Use Bash only to run `telclaude` CLI commands (provider-query, send-attachment, etc.)
+- The CLI handles HMAC authentication through the relay
+- Direct HTTP calls will fail with "Missing internal auth headers"
+- The relay sanitizes responses (strips inline base64, stores attachments)
 
 ### 1. Read the schema file
 
@@ -25,28 +30,34 @@ Check the provider schema to see which services are available. The authoritative
 Read references/provider-schema.md
 ```
 
-This shows the provider ID, base URL, and available endpoints.
+This shows the provider ID and available services/actions.
 
-### 2. Call the provider via WebFetch
+### 2. Query the provider via CLI
 
-```
-WebFetch
-  url: http://<provider-host>:<port>/v1/<service>/<action>
-  method: POST
-  body: {"subjectUserId": "<user-id>", "params": {...}}
+```bash
+telclaude provider-query --provider <providerId> --service <service> --action <action>
 ```
 
-Example:
+With parameters:
+```bash
+telclaude provider-query --provider <providerId> --service <service> --action <action> --params '{"key": "value"}'
 ```
-WebFetch
-  url: http://israel-services:3001/v1/clalit/appointments
-  method: POST
-  body: {"params": {}}
+
+Examples:
+```bash
+# Get appointments
+telclaude provider-query --provider israel-services --service clalit --action appointments
+
+# Get bank transactions with date range
+telclaude provider-query --provider israel-services --service poalim --action scrape --params '{"startDate": "2024-01-01"}'
+
+# Get lab results
+telclaude provider-query --provider israel-services --service maccabi --action lab_results
 ```
 
 ### 3. Parse the response
 
-Provider returns:
+The command outputs JSON:
 ```json
 {
   "status": "ok" | "auth_required" | "challenge_pending" | "error",
@@ -59,12 +70,17 @@ Provider returns:
       "filename": "document.pdf",
       "mimeType": "application/pdf",
       "size": 12345,
-      "inline": "base64...",
-      "textContent": "Preview text from the document..."
+      "ref": "att_abc123.1234567890.signature",
+      "textContent": "Extracted text from the PDF for analysis..."
     }
   ]
 }
 ```
+
+**Note:** The relay proxy intercepts responses and:
+- Strips `inline` base64 content (you won't see it)
+- Stores the file in the outbox
+- Adds a `ref` token for delivery
 
 ### 4. Handle status codes
 
@@ -76,75 +92,97 @@ Provider returns:
 ## Handling Attachments
 
 Attachments include:
-- `inline`: Base64-encoded file content
-- `textContent`: Extracted text (for PDFs, documents)
+- `ref`: Token to retrieve the stored file (use with `telclaude send-attachment`)
+- `textContent`: Extracted text content (for PDFs, documents) - use this to analyze/summarize
+
+**Important:** You will NOT see `inline` base64 content. The relay proxy strips it and stores the file automatically. Use `ref` to send files to users.
 
 ### Reading document content
 
 Use `textContent` to answer questions about the document:
 ```
-"Based on the visit summary, your last appointment was on January 10th..."
+"Based on the document, [relevant information extracted from textContent]..."
 ```
 
 ### Sending files to the user
 
-When user wants the actual file, deliver it via the relay:
+There are two cases depending on file size:
 
-```
-WebFetch
-  url: http://<relay-host>:8790/v1/attachment/deliver
-  method: POST
-  body: {
-    "inline": "<base64 from attachment>",
-    "filename": "<attachment filename>",
-    "mimeType": "<attachment mimeType>"
-  }
+#### Case 1: Small files (≤256KB) - Has `ref`
+
+For small files, the proxy already stored the file. Use the `ref` field:
+
+```bash
+telclaude send-attachment --ref <attachment.ref>
 ```
 
-Example workflow:
-1. User asks for their visit summary
-2. Call provider: `WebFetch to http://israel-services:3001/v1/clalit/visitSummaries`
-3. Response includes `attachments` with `inline` and `textContent`
-4. Tell user: "I found your visit summary from January 10th. Would you like me to send it?"
-5. User says "yes"
-6. Deliver: `WebFetch to relay /v1/attachment/deliver` with the inline content
-7. Report: "I've sent your visit summary."
+#### Case 2: Large files (>256KB) - Empty `ref`
+
+For large files, `ref` will be empty. Use `fetch-attachment` to fetch from the provider:
+
+```bash
+telclaude fetch-attachment --provider <providerId> --id <attachment.id> --filename <attachment.filename> --mime <attachment.mimeType>
+```
+
+#### Output and delivery
+
+Both commands output:
+```
+Attachment ready: /media/outbox/documents/<filename>.pdf
+```
+or
+```
+Attachment saved to: /media/outbox/documents/<filename>.pdf
+```
+
+You MUST include the exact path in your response. The relay watches for this path to trigger Telegram delivery.
+
+#### Example workflow
+
+1. User asks for data or a document
+2. Call provider via `telclaude provider-query`
+3. Response includes `data` and optionally `attachments` with `ref` and `textContent`
+4. Present the data to the user
+5. If attachments exist, use `textContent` to summarize the document
+6. If user wants the file:
+   - If `ref` is present: `telclaude send-attachment --ref <ref>`
+   - If `ref` is empty: `telclaude fetch-attachment --provider <providerId> --id <id> ...`
+7. Include the exact path from output in your response
 
 ## Important Rules
 
-1. **Use WebFetch directly** - No CLI commands needed
-2. **Never ask for credentials** - The provider handles authentication separately
-3. **Show confidence levels** - If confidence < 1.0, mention data may be incomplete
-4. **Show freshness** - Always tell user when data was last updated
-5. **Handle challenges gracefully** - If OTP needed, explain the `/otp <service> <code>` command
+1. **ALWAYS use the provider** - NEVER search for local files in the workspace when the user asks for health, banking, or government data. Always use `telclaude provider-query` to fetch fresh data from the provider.
+2. **Use CLI for provider queries** - Use `telclaude provider-query`, not WebFetch or curl
+3. **Never ask for credentials** - The provider handles authentication separately
+4. **Show confidence levels** - If confidence < 1.0, mention data may be incomplete
+5. **Show freshness** - Always tell user when data was last updated
+6. **Handle challenges gracefully** - If OTP needed, explain the `/otp <service> <code>` command
+7. **Never copy files directly to outbox** - Only use `telclaude send-attachment` or `telclaude fetch-attachment` to deliver files. Copying files directly to `/media/outbox/` will NOT trigger delivery.
 
 ## Example Responses
 
 ### Successful data fetch:
-"Your next appointment is on January 15th at 2:30 PM with Dr. Cohen (Cardiology). This information was last updated 5 minutes ago."
+"Your next appointment is on [date] at [time]. This information was last updated [X] minutes ago."
 
 ### Challenge pending:
-"To access your bank balance, please complete verification. Check your phone for an SMS code, then reply with `/otp <service> <code>`."
+"To access this service, please complete verification. Check your phone for an SMS code, then reply with `/otp <service> <code>`."
 
 ### Auth required:
-"This service needs to be set up first. Please ask the operator to configure authentication for the banking service."
+"This service needs to be set up first. Please ask the operator to configure authentication."
 
 ### Attachment available:
-"I found your visit summary from January 10th. The document shows you visited Dr. Smith for a follow-up. There's a PDF available (245 KB). Would you like me to send it to you?"
+"I found a document from [date]. There's a PDF available ([size]). Would you like me to send it to you?"
 
-### Attachment sent:
-"I've sent your visit summary to you."
+### Attachment sent (use EXACT path from relay response):
+"Here's your document: /media/outbox/documents/<exact-path-from-response>.pdf"
 
-## Endpoints Reference
+## CLI Command Reference
 
-| Path | Method | Description |
-|------|--------|-------------|
-| `/v1/{service}/summary` | POST | Overview/dashboard data |
-| `/v1/{service}/appointments` | POST | Upcoming appointments |
-| `/v1/{service}/transactions` | POST | Recent transactions |
-| `/v1/{service}/balance` | POST | Current balance |
-| `/v1/health` | GET | Provider health status |
-| `/v1/schema` | GET | Service schema/manifest |
+| Command | Description |
+|---------|-------------|
+| `telclaude provider-query --provider <id> --service <svc> --action <act>` | Query provider data |
+| `telclaude send-attachment --ref <ref>` | Send stored attachment to user |
+| `telclaude fetch-attachment --provider <id> --id <att-id> ...` | Fetch and send large attachment |
 
 ## Provider Schemas (auto-generated)
 

--- a/.claude/skills/telegram-reply/SKILL.md
+++ b/.claude/skills/telegram-reply/SKILL.md
@@ -20,4 +20,10 @@ Media protocol alignment:
 - **Image in → consider image out**: When appropriate, generate image responses.
 - A human wouldn't write AND talk simultaneously. Neither should you.
 
+Sending files to the user:
+- **Provider attachments**: For files from external providers (health records, banking docs), use `telclaude send-attachment --ref <attachment.ref>`.
+- **Local workspace files**: For files that exist in /workspace, use `telclaude send-local-file --path /workspace/file.pdf`.
+- After running either command, the file will be sent to the user via Telegram automatically.
+- Report success to the user: "I've sent the file."
+
 Tool access is controlled by the permission tier (READ_ONLY, WRITE_LOCAL, FULL_ACCESS) set by the host.

--- a/src/agent/server.ts
+++ b/src/agent/server.ts
@@ -209,8 +209,14 @@ export function startAgentServer(options: AgentServerOptions = {}): http.Server 
 		});
 	});
 
+	// Override Node.js default request timeout (300000ms = 5 minutes in Node 18+)
+	// Set to MAX_TIMEOUT_MS to allow queries to run up to 10 minutes by default
+	server.requestTimeout = MAX_TIMEOUT_MS;
+	server.headersTimeout = 120000; // 2 minutes for headers
+	server.keepAliveTimeout = MAX_TIMEOUT_MS;
+
 	server.listen(port, host, () => {
-		logger.info({ host, port }, "agent server listening");
+		logger.info({ host, port, requestTimeout: server.requestTimeout }, "agent server listening");
 	});
 
 	return server;

--- a/src/commands/provider-query.ts
+++ b/src/commands/provider-query.ts
@@ -1,0 +1,124 @@
+/**
+ * CLI command for querying external providers via relay proxy.
+ *
+ * This command allows the agent to make POST requests to providers
+ * through the relay's /v1/provider/proxy endpoint. The relay handles
+ * HMAC authentication, response sanitization (strips inline base64),
+ * and attachment storage.
+ *
+ * Usage:
+ *   telclaude provider-query --provider israel-services --service clalit --action appointments
+ *   telclaude provider-query --provider israel-services --service poalim --action scrape --params '{"startDate":"2024-01-01"}'
+ */
+
+import type { Command } from "commander";
+import { getChildLogger } from "../logging.js";
+import { relayProviderProxy } from "../relay/capabilities-client.js";
+
+const logger = getChildLogger({ module: "cmd-provider-query" });
+
+export type ProviderQueryOptions = {
+	provider?: string;
+	service?: string;
+	action?: string;
+	params?: string;
+	userId?: string;
+	subjectUserId?: string;
+	idempotencyKey?: string;
+};
+
+export function registerProviderQueryCommand(program: Command): void {
+	program
+		.command("provider-query")
+		.description("Query an external provider via the relay proxy")
+		.option("--provider <id>", "Provider ID (from telclaude.json)")
+		.option("--service <id>", "Service ID (e.g., clalit, poalim)")
+		.option("--action <name>", "Action name (e.g., appointments, scrape)")
+		.option("--params <json>", "Optional JSON parameters")
+		.option("--user-id <id>", "Actor user ID for the request (optional)")
+		.option("--subject-user-id <id>", "Subject user ID for delegated requests")
+		.option("--idempotency-key <key>", "Idempotency key for write operations")
+		.action(async (opts: ProviderQueryOptions) => {
+			try {
+				const useRelay = Boolean(process.env.TELCLAUDE_CAPABILITIES_URL);
+				if (!useRelay) {
+					console.error("Error: TELCLAUDE_CAPABILITIES_URL is not configured.");
+					console.error("This command requires the relay capabilities server.");
+					process.exit(1);
+				}
+
+				const providerId = opts.provider?.trim();
+				const service = opts.service?.trim();
+				const action = opts.action?.trim();
+
+				if (!providerId) {
+					console.error("Error: --provider is required.");
+					console.error(
+						"Usage: telclaude provider-query --provider <id> --service <id> --action <name>",
+					);
+					process.exit(1);
+				}
+
+				if (!service || !action) {
+					console.error("Error: --service and --action are required.");
+					console.error(
+						"Usage: telclaude provider-query --provider <id> --service <id> --action <name>",
+					);
+					process.exit(1);
+				}
+
+				// Parse params if provided
+				let params: Record<string, unknown> = {};
+				if (opts.params) {
+					try {
+						params = JSON.parse(opts.params) as Record<string, unknown>;
+					} catch (parseErr) {
+						console.error(`Error: Invalid JSON in --params: ${String(parseErr)}`);
+						process.exit(1);
+					}
+				}
+
+				// Build the provider request body
+				const requestBody: Record<string, unknown> = {
+					params,
+				};
+
+				// Add optional fields if provided
+				const subjectUserId = opts.subjectUserId?.trim();
+				const idempotencyKey = opts.idempotencyKey?.trim();
+				if (subjectUserId) {
+					requestBody.subjectUserId = subjectUserId;
+				}
+				if (idempotencyKey) {
+					requestBody.idempotencyKey = idempotencyKey;
+				}
+
+				const userId = opts.userId ?? process.env.TELCLAUDE_REQUEST_USER_ID;
+
+				logger.info(
+					{ providerId, service, action, hasParams: Object.keys(params).length > 0 },
+					"querying provider",
+				);
+
+				const result = await relayProviderProxy({
+					providerId,
+					path: `/v1/${service}/${action}`,
+					method: "POST",
+					body: JSON.stringify(requestBody),
+					userId,
+				});
+
+				if (result.status !== "ok" && result.error) {
+					console.error(`Error: ${result.error}`);
+					process.exit(1);
+				}
+
+				// Output the full response as JSON for the agent to parse
+				console.log(JSON.stringify(result.data ?? result, null, 2));
+			} catch (err) {
+				logger.error({ error: String(err) }, "provider-query command failed");
+				console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+				process.exit(1);
+			}
+		});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { registerIntegrationTestCommand } from "./commands/integration-test.js";
 import { registerLinkCommand } from "./commands/link.js";
 import { registerNetworkCommand } from "./commands/network.js";
 import { registerProviderHealthCommand } from "./commands/provider-health.js";
+import { registerProviderQueryCommand } from "./commands/provider-query.js";
 import { registerQuickstartCommand } from "./commands/quickstart.js";
 import { registerRelayCommand } from "./commands/relay.js";
 import { registerResetAuthCommand } from "./commands/reset-auth.js";
@@ -66,6 +67,7 @@ registerDiagnoseSandboxNetworkCommand(program);
 registerQuickstartCommand(program);
 registerNetworkCommand(program);
 registerProviderHealthCommand(program);
+registerProviderQueryCommand(program);
 
 // Pre-parse to extract global options before commands run
 // This ensures --config and --verbose are set before any config loading happens

--- a/src/security/totp-session.ts
+++ b/src/security/totp-session.ts
@@ -5,7 +5,7 @@
  * Sessions are scoped per-user (localUserId), not per-chat.
  *
  * After a user verifies TOTP once, the session is remembered for
- * a configurable duration (default: 24 hours). During this time,
+ * a configurable duration (default: 1 week). During this time,
  * subsequent messages don't require TOTP re-verification.
  *
  * NOTE: TOTP is used as an identity verification gate, not for approvals.
@@ -18,8 +18,8 @@ import { getIdentityLink } from "./linking.js";
 
 const logger = getChildLogger({ module: "totp-session" });
 
-// Default TTL: 24 hours (in milliseconds)
-const DEFAULT_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+// Default TTL: 1 week (in milliseconds)
+const DEFAULT_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * A TOTP verification session.


### PR DESCRIPTION
## Summary

- Add `telclaude provider-query` CLI command for querying external providers through the relay
- Update external-provider skill to use CLI instead of WebFetch (which only supports GET)
- Add explicit rules to prevent agents from bypassing providers with local files
- Update telegram-reply skill with attachment sending instructions
- Extend TOTP session TTL to 1 week for better UX
- Fix agent server timeouts for long-running provider queries

## Background

WebFetch only supports GET requests, but providers require POST. This caused the agent to either fail or try workarounds (like finding local cached files). The new `provider-query` CLI command properly routes POST requests through the relay's `/v1/provider/proxy` endpoint with HMAC authentication.

## Test plan

- [x] Type check passes
- [x] Deployed to raspi4 and tested with real provider queries
- [x] Verified attachment delivery works via `send-attachment`
- [x] Codex review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)