### PR TITLE
feat(vault): implement credential vault daemon and HTTP proxy

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -26,3 +26,9 @@ e82ee12ace184aece9e37ee32666802d1e8efa43:src/security/streaming-redactor.ts:gene
 5ed752ae82c86f5e10f32b2c4eb5ec7248af65f0:src/security/output-filter.ts:credentials-javascript:582
 103c4bd94feec6d6d59b1e3b9c397b26dd456bd4:src/security/output-filter.ts:credentials-javascript:330
 cb853d9b343174696ced01e3cab2198c15e26fe5:src/telegram/auto-reply.ts:credentials-javascript:704
+
+# Credential vault - code patterns, not real secrets
+a4e487dd4aca3f3cf7ad6dd29f8fd9cdc157025d:src/relay/http-credential-proxy.ts:authorization-bearer-token:159
+a4e487dd4aca3f3cf7ad6dd29f8fd9cdc157025d:src/relay/http-credential-proxy.ts:credentials-javascript:482
+a4e487dd4aca3f3cf7ad6dd29f8fd9cdc157025d:tests/vault-daemon/store.test.ts:generic-api-key:201
+a4e487dd4aca3f3cf7ad6dd29f8fd9cdc157025d:tests/vault-daemon/store.test.ts:credentials-javascript:13

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,91 @@ telclaude network remove ha
 telclaude network test http://192.168.1.100:8123/api
 ```
 
+## Credential Vault
+
+The vault daemon is a sidecar service that stores credentials and injects them into HTTP requests transparently. Agents never see raw credentials.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ VAULT SIDECAR (no network*, Unix socket only)                   │
+│                                                                 │
+│  Credential Store (AES-256-GCM encrypted file)                  │
+│  OAuth2 Token Refresh (caches access tokens in memory)          │
+│  Protocol: newline-delimited JSON over Unix socket              │
+└─────────────────────────────────────────────────────────────────┘
+              │ Unix socket (~/.telclaude/vault.sock)
+              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ HTTP CREDENTIAL PROXY (relay, port 8792)                        │
+│                                                                 │
+│  Pattern: http://relay:8792/{host}/{path}                       │
+│  Example: http://relay:8792/api.openai.com/v1/images/gen        │
+│                                                                 │
+│  1. Parse host from URL                                         │
+│  2. Look up credential from vault                               │
+│  3. Inject auth header (bearer/api-key/basic/oauth2)            │
+│  4. Forward to https://{host}/{path}                            │
+│  5. Stream response back                                        │
+└─────────────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ AGENT CONTAINER                                                 │
+│                                                                 │
+│  fetch("http://relay:8792/api.openai.com/v1/images/gen", {...}) │
+│  Agent NEVER sees credentials                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+*Note: OAuth2 token refresh requires outbound HTTP to token endpoints.
+
+### Supported Credential Types
+
+| Type | Auth Injection |
+| --- | --- |
+| `bearer` | `Authorization: Bearer {token}` |
+| `api-key` | `{header}: {token}` (e.g., `X-API-Key`) |
+| `basic` | `Authorization: Basic {base64(user:pass)}` |
+| `query` | `?{param}={token}` |
+| `oauth2` | Bearer with automatic token refresh |
+
+### Security Properties
+
+- **Credential isolation**: Vault has no network (except OAuth refresh); credentials never reach agent
+- **Host allowlist**: Proxy only injects credentials for configured hosts
+- **Path restrictions**: Optional `allowedPaths` regex per host prevents SSRF to unexpected endpoints
+- **Rate limiting**: Per-host and per-credential limits prevent abuse
+- **Encryption at rest**: AES-256-GCM with scrypt key derivation
+- **Socket permissions**: 0600 (owner only), verified after every operation
+- **Request size limit**: 1MB max to prevent memory exhaustion
+- **Upstream timeout**: 60s with AbortController to prevent hung connections
+
+### CLI Commands
+
+```bash
+# Start vault daemon (requires VAULT_ENCRYPTION_KEY)
+export VAULT_ENCRYPTION_KEY=$(openssl rand -base64 32)
+telclaude vault-daemon
+
+# Manage credentials
+telclaude vault list
+telclaude vault add http api.openai.com --type bearer --label "OpenAI"
+telclaude vault add http api.anthropic.com --type api-key --header x-api-key
+telclaude vault add http api.google.com --type oauth2 \
+  --client-id xxx --token-endpoint https://oauth2.googleapis.com/token
+telclaude vault remove http api.openai.com
+telclaude vault test http api.openai.com
+```
+
+### Deployment Security
+
+When allowing `localhost` or docker service names as targets:
+- Ensure only authorized processes can reach the HTTP proxy (port 8792)
+- Use network policies or firewall rules to restrict proxy access
+- Only store credentials for hosts the agent legitimately needs
+
 ## Application-Level Security
 
 The canUseTool callback and PreToolUse hooks provide defense-in-depth:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,7 @@ The vault daemon is a sidecar service that stores credentials and injects them i
 - **Path restrictions**: Optional `allowedPaths` regex per host prevents SSRF to unexpected endpoints
 - **Rate limiting**: Per-host and per-credential limits prevent abuse
 - **Encryption at rest**: AES-256-GCM with scrypt key derivation
-- **Socket permissions**: 0600 (owner only), verified after every operation
+- **Socket permissions**: 0600 (owner only); server verifies at startup, store enforces on each write
 - **Request size limit**: 1MB max to prevent memory exhaustion
 - **Upstream timeout**: 60s with AbortController to prevent hung connections
 

--- a/docs/plans/attachment-proxy-architecture.md
+++ b/docs/plans/attachment-proxy-architecture.md
@@ -1,0 +1,178 @@
+# Attachment Proxy Architecture Plan
+
+## Problem Statement
+
+Claude bypasses the `telclaude fetch-attachment` CLI when handling provider attachments. Unlike image-gen/TTS (where Claude CANNOT generate content without the API key), Claude CAN decode inline base64 and process PDFs directly. Skill instructions are just guidance - when Claude has raw bytes, it can bypass any policy.
+
+**Root cause**: The provider returns `inline` base64 directly to Claude via WebFetch. Claude sees the data and processes it itself instead of using the CLI.
+
+## Design Principles (Rich Hickey-inspired)
+
+1. **Capability, not policy**: Don't tell Claude "don't do X" - make it so Claude CAN'T do X
+2. **Separation of concerns**: Reading (derived data) vs Delivering (capability)
+3. **Simple parts**: Each component does one thing well
+4. **No bypass paths**: If Claude never sees raw bytes, it can't bypass
+
+## Proposed Architecture
+
+```
+Current (broken):
+  Claude --WebFetch--> Provider --> {inline: "base64..."}
+  Claude decodes base64 itself, bypasses CLI
+
+Proposed (fixed):
+  Claude --WebFetch--> Relay /v1/provider/proxy --> Provider
+  Relay intercepts response, strips inline, stores file, returns:
+  {ref: "att_xxx", textContent: "extracted text preview"}
+  Claude can READ (via textContent) but cannot DELIVER (no bytes)
+  To send: Claude calls "telclaude send-attachment --ref att_xxx"
+  Relay already has file, sends to Telegram
+```
+
+## Implementation Components
+
+### 1. Provider Proxy Endpoint (Relay)
+
+**File**: `src/relay/capabilities.ts`
+
+New endpoint: `POST /v1/provider/proxy`
+
+```typescript
+type ProviderProxyRequest = {
+  providerId: string;
+  path: string;        // e.g., "/v1/service/action"
+  method?: string;     // default: POST
+  body?: string;       // JSON string
+  userId?: string;
+};
+
+type ProviderProxyResponse = {
+  status: "ok" | "error";
+  data?: unknown;        // Provider response with inline stripped
+  error?: string;
+};
+```
+
+**Logic**:
+1. Validate request (providerId, path)
+2. Look up provider config
+3. Forward request to provider (with auth headers if needed)
+4. Parse JSON response
+5. If response has `attachments[]`:
+   - For each attachment with `inline`:
+     - Store in `attachment_refs` table
+     - Save bytes to `/media/outbox/documents/`
+     - Replace `inline` with `ref` (signed token)
+     - Optionally extract `textContent` (first ~500 chars of PDF text)
+6. Return sanitized response
+
+### 2. Attachment Ref Store (SQLite)
+
+**File**: `src/storage/db.ts` - add to schema
+
+```sql
+CREATE TABLE IF NOT EXISTS attachment_refs (
+  ref TEXT PRIMARY KEY,           -- e.g., "att_abc123.1737100000.sig"
+  actor_user_id TEXT NOT NULL,    -- who requested it
+  provider_id TEXT NOT NULL,      -- which provider
+  filepath TEXT NOT NULL,         -- path in outbox
+  filename TEXT NOT NULL,         -- original filename
+  mime_type TEXT,
+  size INTEGER,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL     -- 15 min TTL
+);
+CREATE INDEX IF NOT EXISTS idx_attachment_refs_expires ON attachment_refs(expires_at);
+```
+
+**Ref format**: `att_<hash>.<expiresTimestamp>.<signature>`
+- Hash: first 8 chars of SHA256(filepath + actorUserId + createdAt)
+- Signature: HMAC-SHA256(ref_without_sig, TELCLAUDE_INTERNAL_AUTH_SECRET)
+
+### 3. Send Attachment CLI
+
+**File**: `src/cli/send-attachment.ts` (new)
+
+```bash
+telclaude send-attachment --ref att_abc123.1737100000.sig
+```
+
+**Logic**:
+1. Verify signature on ref
+2. Look up in `attachment_refs` table
+3. Check not expired
+4. Read file from filepath
+5. Output to stdout or trigger Telegram send (via existing outbox mechanism)
+
+### 4. Skill Update
+
+**File**: `.claude/skills/external-provider/SKILL.md`
+
+Change instructions:
+- All provider calls go through `telclaude-cap /v1/provider/proxy`
+- Attachments in response have `ref` + `textContent` (no `inline`)
+- To send file: `telclaude send-attachment --ref <ref>`
+
+### 5. Cleanup
+
+Add to `cleanupExpired()` in `src/storage/db.ts`:
+- Delete expired `attachment_refs` rows
+- Optionally delete orphaned files from outbox
+
+## Security Considerations
+
+1. **Refs are scoped**: Bound to `actorUserId` + `providerId`
+2. **Signed tokens**: Can't forge refs without secret
+3. **TTL**: 15-minute expiry prevents stale refs
+4. **No exfiltration**: Claude can't write to outbox (blocked by SDK hook)
+5. **Outbox is read-only for agent**: Only relay can write
+
+## Why This Works
+
+| Feature | Image-gen | TTS | Attachments (current) | Attachments (proposed) |
+|---------|-----------|-----|----------------------|------------------------|
+| Claude has raw data? | No (API call) | No (API call) | Yes (inline b64) | No (ref only) |
+| Must use CLI? | Yes (no key) | Yes (no key) | No (can decode) | Yes (no bytes) |
+| Bypass possible? | No | No | Yes | No |
+
+## Migration Path
+
+1. Deploy relay with new `/v1/provider/proxy` endpoint
+2. Deploy CLI with `send-attachment` command
+3. Update skill to use proxy
+4. Existing `fetch-attachment` CLI remains for backward compat
+
+## Open Questions
+
+1. **Text extraction**: Provider-side (preferred) or relay-side fallback?
+   - Recommendation: Relay extracts via `pdf-parse` as fallback
+   - Provider can include `textContent` if it already has it
+
+2. **Large files**: Stream or buffer?
+   - Recommendation: Buffer (max 20MB, same as current)
+
+3. **Multiple attachments**: Handle array in single response?
+   - Yes, iterate and store each, return array of refs
+
+## Codex Review Feedback (Approved 2026-01-19)
+
+**Conditions incorporated:**
+1. ✅ Proxy-intercept approach is correct
+2. ✅ TTL configurable via env (default 15min, extend to 30-60min for slow OTP flows)
+3. ✅ Prefer provider-side text extraction; relay as fallback
+4. ✅ HMAC covers ref + actorUserId + providerId + expiresAt + filename + mime
+5. ✅ Proxy only rewrites JSON; reject/passthrough non-JSON/streaming
+6. ✅ Handle multiple attachments in single response
+7. ✅ Enforce size limits BEFORE decoding base64 (avoid memory spikes)
+8. ✅ Keep outbox write-blocked for agent; only relay writes
+
+## Acceptance Criteria
+
+- [ ] Claude cannot access raw attachment bytes
+- [ ] Claude can read textContent preview
+- [ ] Claude can trigger delivery via CLI
+- [ ] Refs expire after configurable TTL (default 15 min)
+- [ ] Signature verification prevents forgery
+- [ ] Size limits enforced before base64 decode
+- [ ] Multiple attachments handled in single response
+- [ ] Existing provider endpoints continue to work

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -171,9 +171,12 @@ export function registerRelayCommand(program: Command): void {
 
 						// Start HTTP credential proxy if vault daemon is available
 						// This allows agents to call HTTP APIs without seeing credentials
-						const vaultAvailable = await isVaultAvailable();
+						const vaultSocketPath = process.env.TELCLAUDE_VAULT_SOCKET;
+						const vaultAvailable = await isVaultAvailable(
+							vaultSocketPath ? { socketPath: vaultSocketPath } : undefined,
+						);
 						if (vaultAvailable) {
-							startHttpCredentialProxy();
+							startHttpCredentialProxy({ vaultSocketPath });
 							console.log("  HTTP proxy: enabled (credential injection via vault)");
 						} else {
 							console.log("  HTTP proxy: disabled (vault daemon not running)");

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -17,6 +17,7 @@ import {
 import { refreshExternalProviderSkill } from "../providers/provider-skill.js";
 import { startCapabilityServer } from "../relay/capabilities.js";
 import { startGitProxyServer } from "../relay/git-proxy.js";
+import { startHttpCredentialProxy } from "../relay/http-credential-proxy.js";
 import {
 	buildAllowedDomainNames,
 	buildAllowedDomains,
@@ -29,6 +30,7 @@ import { destroySessionManager } from "../sdk/session-manager.js";
 import { isTOTPDaemonAvailable } from "../security/totp.js";
 import { monitorTelegramProvider } from "../telegram/auto-reply.js";
 import { CONFIG_DIR } from "../utils.js";
+import { isVaultAvailable } from "../vault-daemon/index.js";
 
 const logger = getChildLogger({ module: "cmd-relay" });
 
@@ -166,6 +168,16 @@ export function registerRelayCommand(program: Command): void {
 					if (process.env.TELCLAUDE_AGENT_URL) {
 						startGitProxyServer();
 						console.log("  Git proxy: enabled (transparent auth injection)");
+
+						// Start HTTP credential proxy if vault daemon is available
+						// This allows agents to call HTTP APIs without seeing credentials
+						const vaultAvailable = await isVaultAvailable();
+						if (vaultAvailable) {
+							startHttpCredentialProxy();
+							console.log("  HTTP proxy: enabled (credential injection via vault)");
+						} else {
+							console.log("  HTTP proxy: disabled (vault daemon not running)");
+						}
 					}
 				} else {
 					console.log("  Capabilities: disabled");

--- a/src/commands/vault-daemon.ts
+++ b/src/commands/vault-daemon.ts
@@ -1,0 +1,62 @@
+/**
+ * CLI command for running the vault daemon.
+ *
+ * The vault daemon is a sidecar service that stores credentials and handles
+ * OAuth token refresh. It communicates via Unix socket and has no network
+ * access (except for OAuth token refresh).
+ *
+ * Usage:
+ *   telclaude vault-daemon [--socket <path>]
+ */
+
+import type { Command } from "commander";
+
+import { getChildLogger } from "../logging.js";
+import { getDefaultSocketPath, startServer } from "../vault-daemon/index.js";
+
+const logger = getChildLogger({ module: "cmd-vault-daemon" });
+
+export function registerVaultDaemonCommand(program: Command): void {
+	program
+		.command("vault-daemon")
+		.description("Run the credential vault daemon")
+		.option("--socket <path>", "Path to Unix socket", getDefaultSocketPath())
+		.action(async (opts: { socket: string }) => {
+			try {
+				// Check for encryption key
+				if (!process.env.VAULT_ENCRYPTION_KEY) {
+					console.error("Error: VAULT_ENCRYPTION_KEY environment variable is required.");
+					console.error("Generate a strong key with: openssl rand -base64 32");
+					process.exit(1);
+				}
+
+				logger.info({ socketPath: opts.socket }, "starting vault daemon");
+
+				const handle = await startServer({
+					socketPath: opts.socket,
+				});
+
+				console.log(`Vault daemon listening on ${handle.socketPath}`);
+
+				// Handle graceful shutdown
+				const shutdown = async (signal: string) => {
+					logger.info({ signal }, "received shutdown signal");
+					console.log(`\nReceived ${signal}, shutting down...`);
+					await handle.stop();
+					process.exit(0);
+				};
+
+				process.on("SIGINT", () => shutdown("SIGINT"));
+				process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+				// Keep process running
+				await new Promise(() => {
+					// Never resolves - daemon runs until signaled
+				});
+			} catch (err) {
+				logger.error({ error: String(err) }, "vault-daemon command failed");
+				console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+				process.exit(1);
+			}
+		});
+}

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -1,0 +1,483 @@
+/**
+ * CLI commands for managing vault credentials.
+ *
+ * The vault stores credentials that are injected into HTTP requests
+ * through the credential proxy. Agents never see raw credentials.
+ *
+ * Commands:
+ * - telclaude vault list - List configured credentials
+ * - telclaude vault add <protocol> <target> - Add a new credential
+ * - telclaude vault remove <protocol> <target> - Remove a credential
+ * - telclaude vault test <protocol> <target> - Test if vault can retrieve credential
+ */
+
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+
+import { getChildLogger } from "../logging.js";
+import {
+	type Credential,
+	getVaultClient,
+	isVaultAvailable,
+	type Protocol,
+	ProtocolSchema,
+} from "../vault-daemon/index.js";
+
+const logger = getChildLogger({ module: "cmd-vault" });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Prompt for a password/secret without echoing to terminal.
+ */
+async function promptSecret(prompt: string): Promise<string> {
+	return new Promise((resolve) => {
+		const rl = createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+
+		// Disable echo (best effort - may not work on all terminals)
+		if (process.stdin.isTTY) {
+			process.stdout.write(prompt);
+			process.stdin.setRawMode(true);
+
+			let secret = "";
+			process.stdin.resume();
+			process.stdin.on("data", function handler(char) {
+				const c = char.toString();
+				if (c === "\n" || c === "\r" || c === "\u0004") {
+					process.stdin.setRawMode(false);
+					process.stdin.removeListener("data", handler);
+					rl.close();
+					console.log(); // Newline after hidden input
+					resolve(secret);
+				} else if (c === "\u0003") {
+					// Ctrl+C
+					process.exit(1);
+				} else if (c === "\u007F" || c === "\b") {
+					// Backspace
+					secret = secret.slice(0, -1);
+				} else {
+					secret += c;
+				}
+			});
+		} else {
+			// Non-TTY fallback
+			rl.question(prompt, (answer) => {
+				rl.close();
+				resolve(answer);
+			});
+		}
+	});
+}
+
+/**
+ * Validate protocol string.
+ */
+function parseProtocol(value: string): Protocol | null {
+	const result = ProtocolSchema.safeParse(value.toLowerCase());
+	return result.success ? result.data : null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Command Registration
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function registerVaultCommand(program: Command): void {
+	const vault = program.command("vault").description("Manage vault credentials");
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// List command
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	vault
+		.command("list")
+		.description("List configured credentials (secrets not shown)")
+		.option("--protocol <protocol>", "Filter by protocol (http, postgres, mysql, ssh)")
+		.option("--json", "Output as JSON")
+		.action(async (opts: { protocol?: string; json?: boolean }) => {
+			try {
+				if (!(await isVaultAvailable())) {
+					console.error("Error: Vault daemon is not running.");
+					console.error("Start it with: telclaude vault-daemon");
+					process.exit(1);
+				}
+
+				const protocol = opts.protocol ? parseProtocol(opts.protocol) : undefined;
+				if (opts.protocol && !protocol) {
+					console.error(`Invalid protocol: ${opts.protocol}`);
+					console.error("Valid protocols: http, postgres, mysql, ssh");
+					process.exit(1);
+				}
+
+				const client = getVaultClient();
+				const response = await client.list(protocol ?? undefined);
+
+				if (opts.json) {
+					console.log(JSON.stringify(response.entries, null, 2));
+					return;
+				}
+
+				if (response.entries.length === 0) {
+					console.log("No credentials configured.");
+					return;
+				}
+
+				// Table format
+				console.log("\nCONFIGURED CREDENTIALS\n");
+				console.log(
+					"PROTOCOL".padEnd(12) +
+						"TARGET".padEnd(35) +
+						"TYPE".padEnd(15) +
+						"LABEL".padEnd(20) +
+						"CREATED",
+				);
+				console.log("-".repeat(95));
+
+				for (const entry of response.entries) {
+					const created = new Date(entry.createdAt).toLocaleDateString();
+					console.log(
+						entry.protocol.padEnd(12) +
+							entry.target.slice(0, 33).padEnd(35) +
+							entry.credentialType.padEnd(15) +
+							(entry.label ?? "").slice(0, 18).padEnd(20) +
+							created,
+					);
+				}
+
+				console.log();
+			} catch (err) {
+				logger.error({ error: String(err) }, "vault list failed");
+				console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+				process.exit(1);
+			}
+		});
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// Add command (HTTP)
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	vault
+		.command("add")
+		.description("Add a credential to the vault")
+		.argument("<protocol>", "Protocol (http, postgres, mysql, ssh)")
+		.argument("<target>", "Target host or host:port")
+		.option(
+			"--type <type>",
+			"Credential type (bearer, api-key, basic, oauth2, db, ssh-key, ssh-password)",
+		)
+		.option("--label <label>", "Human-readable label")
+		.option("--token <token>", "Token/password (will prompt if not provided)")
+		.option("--header <header>", "Header name for api-key type (e.g., X-API-Key)")
+		.option("--username <username>", "Username for basic/db/ssh auth")
+		.option("--param <param>", "Query parameter name for query type")
+		.option("--client-id <clientId>", "OAuth2 client ID")
+		.option("--client-secret <clientSecret>", "OAuth2 client secret (will prompt if not provided)")
+		.option("--refresh-token <refreshToken>", "OAuth2 refresh token (will prompt if not provided)")
+		.option("--token-endpoint <url>", "OAuth2 token endpoint URL")
+		.option("--scope <scope>", "OAuth2 scope")
+		.option("--key <keyPath>", "Path to SSH private key file")
+		.option("--passphrase <passphrase>", "SSH key passphrase (will prompt if not provided)")
+		.option("--database <database>", "Database name for db credentials")
+		.option("--allowed-paths <paths>", "Comma-separated path regex allowlist")
+		.option("--rate-limit <limit>", "Requests per minute limit", parseInt)
+		.action(
+			async (
+				protocolArg: string,
+				target: string,
+				opts: {
+					type?: string;
+					label?: string;
+					token?: string;
+					header?: string;
+					username?: string;
+					param?: string;
+					clientId?: string;
+					clientSecret?: string;
+					refreshToken?: string;
+					tokenEndpoint?: string;
+					scope?: string;
+					key?: string;
+					passphrase?: string;
+					database?: string;
+					allowedPaths?: string;
+					rateLimit?: number;
+				},
+			) => {
+				try {
+					if (!(await isVaultAvailable())) {
+						console.error("Error: Vault daemon is not running.");
+						console.error("Start it with: telclaude vault-daemon");
+						process.exit(1);
+					}
+
+					const protocol = parseProtocol(protocolArg);
+					if (!protocol) {
+						console.error(`Invalid protocol: ${protocolArg}`);
+						console.error("Valid protocols: http, postgres, mysql, ssh");
+						process.exit(1);
+					}
+
+					// Build credential based on type
+					let credential: Credential;
+
+					if (protocol === "http") {
+						const type = opts.type ?? "bearer";
+
+						switch (type) {
+							case "bearer": {
+								const token = opts.token ?? (await promptSecret("Token: "));
+								if (!token) {
+									console.error("Token is required for bearer auth");
+									process.exit(1);
+								}
+								credential = { type: "bearer", token };
+								break;
+							}
+
+							case "api-key": {
+								const token = opts.token ?? (await promptSecret("API Key: "));
+								const header = opts.header ?? "X-API-Key";
+								if (!token) {
+									console.error("Token is required for api-key auth");
+									process.exit(1);
+								}
+								credential = { type: "api-key", token, header };
+								break;
+							}
+
+							case "basic": {
+								const username = opts.username;
+								if (!username) {
+									console.error("--username is required for basic auth");
+									process.exit(1);
+								}
+								const password = opts.token ?? (await promptSecret("Password: "));
+								credential = { type: "basic", username, password };
+								break;
+							}
+
+							case "query": {
+								const token = opts.token ?? (await promptSecret("Token: "));
+								const param = opts.param ?? "api_key";
+								if (!token) {
+									console.error("Token is required for query auth");
+									process.exit(1);
+								}
+								credential = { type: "query", token, param };
+								break;
+							}
+
+							case "oauth2": {
+								if (!opts.clientId) {
+									console.error("--client-id is required for oauth2");
+									process.exit(1);
+								}
+								if (!opts.tokenEndpoint) {
+									console.error("--token-endpoint is required for oauth2");
+									process.exit(1);
+								}
+								const clientSecret = opts.clientSecret ?? (await promptSecret("Client Secret: "));
+								const refreshToken = opts.refreshToken ?? (await promptSecret("Refresh Token: "));
+
+								if (!clientSecret || !refreshToken) {
+									console.error("Client secret and refresh token are required for oauth2");
+									process.exit(1);
+								}
+
+								credential = {
+									type: "oauth2",
+									clientId: opts.clientId,
+									clientSecret,
+									refreshToken,
+									tokenEndpoint: opts.tokenEndpoint,
+									scope: opts.scope,
+								};
+								break;
+							}
+
+							default:
+								console.error(`Invalid HTTP credential type: ${type}`);
+								console.error("Valid types: bearer, api-key, basic, query, oauth2");
+								process.exit(1);
+						}
+					} else if (protocol === "postgres" || protocol === "mysql") {
+						const username = opts.username;
+						if (!username) {
+							console.error("--username is required for database credentials");
+							process.exit(1);
+						}
+						const password = opts.token ?? (await promptSecret("Password: "));
+						credential = {
+							type: "db",
+							username,
+							password,
+							database: opts.database,
+						};
+					} else if (protocol === "ssh") {
+						const type = opts.type ?? "ssh-key";
+						const username = opts.username;
+						if (!username) {
+							console.error("--username is required for SSH credentials");
+							process.exit(1);
+						}
+
+						if (type === "ssh-key") {
+							if (!opts.key) {
+								console.error("--key is required for ssh-key auth");
+								process.exit(1);
+							}
+							const fs = await import("node:fs");
+							const privateKey = fs.readFileSync(opts.key, "utf-8");
+							const passphrase =
+								opts.passphrase ?? (await promptSecret("Key passphrase (or empty): "));
+							credential = {
+								type: "ssh-key",
+								username,
+								privateKey,
+								passphrase: passphrase || undefined,
+							};
+						} else if (type === "ssh-password") {
+							const password = opts.token ?? (await promptSecret("Password: "));
+							credential = { type: "ssh-password", username, password };
+						} else {
+							console.error(`Invalid SSH credential type: ${type}`);
+							console.error("Valid types: ssh-key, ssh-password");
+							process.exit(1);
+						}
+					} else {
+						console.error(`Protocol ${protocol} is not yet supported`);
+						process.exit(1);
+					}
+
+					// Parse allowed paths
+					const allowedPaths = opts.allowedPaths?.split(",").map((p) => p.trim());
+
+					// Store the credential
+					const client = getVaultClient();
+					await client.store({
+						protocol,
+						target,
+						credential,
+						label: opts.label,
+						allowedPaths,
+						rateLimitPerMinute: opts.rateLimit,
+					});
+
+					console.log(`Credential added: ${protocol}:${target}`);
+				} catch (err) {
+					logger.error({ error: String(err) }, "vault add failed");
+					console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+					process.exit(1);
+				}
+			},
+		);
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// Remove command
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	vault
+		.command("remove")
+		.description("Remove a credential from the vault")
+		.argument("<protocol>", "Protocol (http, postgres, mysql, ssh)")
+		.argument("<target>", "Target host or host:port")
+		.action(async (protocolArg: string, target: string) => {
+			try {
+				if (!(await isVaultAvailable())) {
+					console.error("Error: Vault daemon is not running.");
+					console.error("Start it with: telclaude vault-daemon");
+					process.exit(1);
+				}
+
+				const protocol = parseProtocol(protocolArg);
+				if (!protocol) {
+					console.error(`Invalid protocol: ${protocolArg}`);
+					process.exit(1);
+				}
+
+				const client = getVaultClient();
+				const response = await client.delete(protocol, target);
+
+				if (response.deleted) {
+					console.log(`Credential removed: ${protocol}:${target}`);
+				} else {
+					console.log(`Credential not found: ${protocol}:${target}`);
+				}
+			} catch (err) {
+				logger.error({ error: String(err) }, "vault remove failed");
+				console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+				process.exit(1);
+			}
+		});
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// Test command
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	vault
+		.command("test")
+		.description("Test if a credential can be retrieved")
+		.argument("<protocol>", "Protocol (http, postgres, mysql, ssh)")
+		.argument("<target>", "Target host or host:port")
+		.action(async (protocolArg: string, target: string) => {
+			try {
+				if (!(await isVaultAvailable())) {
+					console.error("Error: Vault daemon is not running.");
+					console.error("Start it with: telclaude vault-daemon");
+					process.exit(1);
+				}
+
+				const protocol = parseProtocol(protocolArg);
+				if (!protocol) {
+					console.error(`Invalid protocol: ${protocolArg}`);
+					process.exit(1);
+				}
+
+				const client = getVaultClient();
+				const response = await client.get(protocol, target);
+
+				if (!response.ok) {
+					console.log(`FAIL: Credential not found for ${protocol}:${target}`);
+					process.exit(1);
+				}
+
+				console.log(`OK: Credential found for ${protocol}:${target}`);
+				console.log(`  Type: ${response.entry.credential.type}`);
+				console.log(`  Created: ${response.entry.createdAt}`);
+				if (response.entry.label) {
+					console.log(`  Label: ${response.entry.label}`);
+				}
+				if (response.entry.expiresAt) {
+					console.log(`  Expires: ${response.entry.expiresAt}`);
+				}
+				if (response.entry.allowedPaths?.length) {
+					console.log(`  Allowed paths: ${response.entry.allowedPaths.join(", ")}`);
+				}
+				if (response.entry.rateLimitPerMinute) {
+					console.log(`  Rate limit: ${response.entry.rateLimitPerMinute}/min`);
+				}
+
+				// For OAuth2, also test token refresh
+				if (response.entry.credential.type === "oauth2") {
+					console.log("\nTesting OAuth2 token refresh...");
+					const tokenResponse = await client.getToken(target);
+					if (tokenResponse.ok) {
+						console.log(
+							`  Token obtained, expires at: ${new Date(tokenResponse.expiresAt).toISOString()}`,
+						);
+					} else {
+						console.log(`  Token refresh FAILED: ${tokenResponse.error}`);
+						process.exit(1);
+					}
+				}
+			} catch (err) {
+				logger.error({ error: String(err) }, "vault test failed");
+				console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+				process.exit(1);
+			}
+		});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ import { registerTextToSpeechCommand } from "./commands/text-to-speech.js";
 import { registerTOTPDaemonCommand } from "./commands/totp-daemon.js";
 import { registerTOTPDisableCommand } from "./commands/totp-disable.js";
 import { registerTOTPSetupCommand } from "./commands/totp-setup.js";
+import { registerVaultCommand } from "./commands/vault.js";
+import { registerVaultDaemonCommand } from "./commands/vault-daemon.js";
 import { setConfigPath } from "./config/path.js";
 import { setVerbose } from "./globals.js";
 import { closeLogger, getLogger } from "./logging.js";
@@ -68,6 +70,8 @@ registerQuickstartCommand(program);
 registerNetworkCommand(program);
 registerProviderHealthCommand(program);
 registerProviderQueryCommand(program);
+registerVaultCommand(program);
+registerVaultDaemonCommand(program);
 
 // Pre-parse to extract global options before commands run
 // This ensures --config and --verbose are set before any config loading happens

--- a/src/relay/http-credential-proxy.ts
+++ b/src/relay/http-credential-proxy.ts
@@ -1,0 +1,513 @@
+/**
+ * HTTP Credential Proxy Server
+ *
+ * Transparent proxy for HTTP APIs that injects credentials without exposing them to agents.
+ * This is the generalization of git-proxy.ts for any HTTP API.
+ *
+ * Architecture:
+ * - Agent calls: http://relay:8792/{host}/{path}
+ * - Proxy looks up credential for {host} from vault
+ * - Injects authentication (bearer, api-key, basic, oauth2)
+ * - Forwards request to https://{host}/{path}
+ * - Streams response back to agent
+ *
+ * Examples:
+ * - http://relay:8792/api.openai.com/v1/images/generations
+ * - http://relay:8792/api.anthropic.com/v1/messages
+ * - http://relay:8792/api.github.com/repos/owner/repo
+ *
+ * Agent NEVER sees credentials.
+ */
+
+import http from "node:http";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import { getChildLogger } from "../logging.js";
+import { getSandboxMode } from "../sandbox/index.js";
+import {
+	type CredentialEntry,
+	getVaultClient,
+	type HttpCredential,
+	type OAuth2Credential,
+} from "../vault-daemon/index.js";
+
+const logger = getChildLogger({ module: "http-credential-proxy" });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface HttpCredentialProxyConfig {
+	port: number;
+	host: string;
+	rateLimitPerMinute: number;
+	vaultSocketPath?: string;
+}
+
+interface ParsedProxyUrl {
+	host: string;
+	path: string;
+	query: string;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Rate Limiting
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+
+function checkRateLimit(host: string, limitPerMinute: number): boolean {
+	const now = Date.now();
+	const entry = rateLimitMap.get(host);
+
+	if (!entry || entry.resetAt < now) {
+		rateLimitMap.set(host, { count: 1, resetAt: now + 60000 });
+		return true;
+	}
+
+	if (entry.count >= limitPerMinute) {
+		return false;
+	}
+
+	entry.count++;
+	return true;
+}
+
+// Clean up old rate limit entries periodically
+let cleanupInterval: NodeJS.Timeout | null = null;
+
+function startCleanupInterval(): void {
+	if (cleanupInterval) return;
+
+	cleanupInterval = setInterval(
+		() => {
+			const now = Date.now();
+			for (const [key, entry] of rateLimitMap.entries()) {
+				if (entry.resetAt < now) {
+					rateLimitMap.delete(key);
+				}
+			}
+		},
+		5 * 60 * 1000,
+	); // Every 5 minutes
+
+	cleanupInterval.unref();
+}
+
+function stopCleanupInterval(): void {
+	if (cleanupInterval) {
+		clearInterval(cleanupInterval);
+		cleanupInterval = null;
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// URL Parsing
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Strict host validation regex:
+// - Allows alphanumeric, hyphens, dots
+// - Optional port suffix
+// - Rejects userinfo (@), whitespace, percent encoding, etc.
+const VALID_HOST_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?(:\d{1,5})?$/;
+
+/**
+ * Parse a proxy URL into components.
+ * Input: /api.openai.com/v1/images/generations?foo=bar
+ * Output: { host: "api.openai.com", path: "/v1/images/generations", query: "?foo=bar" }
+ */
+function parseProxyUrl(url: string): ParsedProxyUrl | null {
+	// Remove query string for parsing, but preserve for path
+	const [pathPart, queryPart] = url.split("?");
+	const query = queryPart ? `?${queryPart}` : "";
+
+	// Expected format: /{host}/{path...}
+	// e.g., /api.openai.com/v1/images/generations
+	const match = pathPart.match(/^\/([^/]+)(\/.*)$/);
+	if (!match) {
+		return null;
+	}
+
+	const [, host, path] = match;
+
+	// SECURITY: Strict host validation to prevent SSRF via malformed hosts
+	// Rejects: userinfo (@), whitespace, percent encoding, invalid chars
+	if (!VALID_HOST_REGEX.test(host)) {
+		return null;
+	}
+
+	// Must have at least one dot (domain) unless it's localhost with port
+	if (!host.includes(".") && !host.startsWith("localhost:")) {
+		return null;
+	}
+
+	// Normalize to lowercase
+	return { host: host.toLowerCase(), path, query };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Credential Injection
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Build authentication header(s) for an HTTP credential.
+ */
+function buildAuthHeaders(credential: HttpCredential): Record<string, string> {
+	switch (credential.type) {
+		case "bearer":
+			return { Authorization: `Bearer ${credential.token}` };
+
+		case "api-key":
+			return { [credential.header]: credential.token };
+
+		case "basic": {
+			const encoded = Buffer.from(`${credential.username}:${credential.password}`).toString(
+				"base64",
+			);
+			return { Authorization: `Basic ${encoded}` };
+		}
+
+		case "query":
+			// Query params are handled separately, not via headers
+			return {};
+	}
+}
+
+/**
+ * Build query string additions for query-based auth.
+ */
+function buildAuthQuery(credential: HttpCredential, existingQuery: string): string {
+	if (credential.type !== "query") {
+		return existingQuery;
+	}
+
+	const separator = existingQuery ? "&" : "?";
+	return `${existingQuery}${separator}${credential.param}=${encodeURIComponent(credential.token)}`;
+}
+
+/**
+ * Check if the request path is allowed for this credential.
+ */
+function isPathAllowed(path: string, allowedPaths?: string[]): boolean {
+	if (!allowedPaths || allowedPaths.length === 0) {
+		return true;
+	}
+
+	for (const pattern of allowedPaths) {
+		try {
+			const regex = new RegExp(pattern);
+			if (regex.test(path)) {
+				return true;
+			}
+		} catch {
+			// Invalid regex, skip
+		}
+	}
+
+	return false;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Request Handling
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Upstream request timeout (60 seconds)
+const UPSTREAM_TIMEOUT_MS = 60 * 1000;
+
+/**
+ * Forward a request to the upstream API with authentication.
+ *
+ * SECURITY: Uses streaming to avoid buffering large request/response bodies.
+ */
+async function proxyRequest(
+	req: http.IncomingMessage,
+	res: http.ServerResponse,
+	parsed: ParsedProxyUrl,
+	entry: CredentialEntry,
+	accessToken?: string, // For OAuth2, the refreshed access token
+): Promise<void> {
+	// Determine the credential to use for headers
+	const credential = entry.credential as HttpCredential | OAuth2Credential;
+	let authHeaders: Record<string, string>;
+	let queryAddition = "";
+
+	if (credential.type === "oauth2") {
+		// Use the provided access token for OAuth2
+		if (!accessToken) {
+			res.writeHead(500, { "Content-Type": "text/plain" });
+			res.end("Internal error: OAuth2 access token not provided");
+			return;
+		}
+		authHeaders = { Authorization: `Bearer ${accessToken}` };
+	} else {
+		authHeaders = buildAuthHeaders(credential);
+		queryAddition = buildAuthQuery(credential, parsed.query);
+	}
+
+	// Build upstream URL
+	const finalQuery = credential.type === "query" ? queryAddition : parsed.query;
+	const upstreamUrl = `https://${parsed.host}${parsed.path}${finalQuery}`;
+
+	// Build headers for upstream request
+	const upstreamHeaders: Record<string, string> = {
+		Host: parsed.host,
+		"User-Agent": "telclaude-http-proxy/1.0",
+		...authHeaders,
+	};
+
+	// Copy relevant headers from original request
+	// NOTE: We intentionally don't forward accept-encoding to let fetch handle
+	// compression naturally, avoiding content-encoding mismatches
+	const headersToForward = ["content-type", "content-length", "accept", "accept-language"];
+
+	for (const header of headersToForward) {
+		const value = req.headers[header];
+		if (value) {
+			upstreamHeaders[header] = Array.isArray(value) ? value[0] : value;
+		}
+	}
+
+	// For POST/PUT/PATCH, stream the body directly to upstream
+	const hasBody = ["POST", "PUT", "PATCH"].includes(req.method ?? "");
+	const requestBody = hasBody ? Readable.toWeb(req) : undefined;
+
+	// Use AbortController for timeout
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
+	try {
+		const upstreamResponse = await fetch(upstreamUrl, {
+			method: req.method,
+			headers: upstreamHeaders,
+			body: requestBody,
+			duplex: "half",
+			signal: controller.signal,
+		});
+
+		// Log the operation (without sensitive details)
+		logger.info(
+			{
+				host: parsed.host,
+				path: parsed.path,
+				method: req.method,
+				status: upstreamResponse.status,
+			},
+			"http proxy request completed",
+		);
+
+		// Forward response headers, excluding hop-by-hop headers
+		const hopByHopHeaders = new Set([
+			"transfer-encoding",
+			"connection",
+			"keep-alive",
+			"content-encoding",
+			"proxy-authenticate",
+			"proxy-authorization",
+			"te",
+			"trailer",
+			"upgrade",
+		]);
+
+		upstreamResponse.headers.forEach((value, key) => {
+			if (!hopByHopHeaders.has(key.toLowerCase())) {
+				res.setHeader(key, value);
+			}
+		});
+
+		res.writeHead(upstreamResponse.status);
+
+		// Stream response body with proper backpressure handling
+		if (upstreamResponse.body) {
+			const nodeStream = Readable.fromWeb(upstreamResponse.body);
+			await pipeline(nodeStream, res);
+		} else {
+			res.end();
+		}
+	} catch (err) {
+		// Handle timeout specifically
+		if (err instanceof Error && err.name === "AbortError") {
+			logger.error({ host: parsed.host }, "http proxy upstream request timed out");
+			if (!res.headersSent) {
+				res.writeHead(504, { "Content-Type": "text/plain" });
+				res.end("Gateway timeout: upstream request timed out");
+			} else {
+				res.end();
+			}
+			return;
+		}
+
+		logger.error({ error: String(err), host: parsed.host }, "http proxy upstream request failed");
+		if (!res.headersSent) {
+			res.writeHead(502, { "Content-Type": "text/plain" });
+			res.end("Bad gateway: upstream request failed");
+		} else {
+			res.end();
+		}
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Server
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const DEFAULT_CONFIG: HttpCredentialProxyConfig = {
+	port: 8792,
+	host: "127.0.0.1",
+	rateLimitPerMinute: 120,
+};
+
+export interface HttpCredentialProxyHandle {
+	server: http.Server;
+	stop: () => Promise<void>;
+}
+
+export function startHttpCredentialProxy(
+	config: Partial<HttpCredentialProxyConfig> = {},
+): HttpCredentialProxyHandle {
+	const finalConfig: HttpCredentialProxyConfig = {
+		port: config.port ?? Number(process.env.TELCLAUDE_HTTP_PROXY_PORT ?? DEFAULT_CONFIG.port),
+		host: config.host ?? (getSandboxMode() === "docker" ? "0.0.0.0" : DEFAULT_CONFIG.host),
+		rateLimitPerMinute: config.rateLimitPerMinute ?? DEFAULT_CONFIG.rateLimitPerMinute,
+		vaultSocketPath: config.vaultSocketPath,
+	};
+
+	const vaultClient = getVaultClient(
+		finalConfig.vaultSocketPath ? { socketPath: finalConfig.vaultSocketPath } : undefined,
+	);
+
+	// Start rate limit cleanup
+	startCleanupInterval();
+
+	const server = http.createServer(async (req, res) => {
+		const url = req.url ?? "";
+
+		// Health check
+		if (url === "/health" && req.method === "GET") {
+			// Also check vault connectivity
+			const vaultOk = await vaultClient.ping();
+			const status = vaultOk ? 200 : 503;
+			res.writeHead(status, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ ok: vaultOk, service: "http-credential-proxy", vault: vaultOk }));
+			return;
+		}
+
+		// List configured hosts (for debugging, no secrets)
+		// SECURITY: Gated behind env flag to prevent target inventory disclosure
+		if (url === "/hosts" && req.method === "GET") {
+			if (!process.env.TELCLAUDE_HTTP_PROXY_DEBUG) {
+				res.writeHead(404, { "Content-Type": "text/plain" });
+				res.end("Not found");
+				return;
+			}
+			try {
+				const listResponse = await vaultClient.list("http");
+				const hosts = listResponse.entries.map((e) => ({
+					host: e.target,
+					type: e.credentialType,
+					label: e.label,
+				}));
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ hosts }));
+			} catch {
+				res.writeHead(503, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ error: "Vault unavailable" }));
+			}
+			return;
+		}
+
+		// Parse proxy URL
+		const parsed = parseProxyUrl(url);
+		if (!parsed) {
+			res.writeHead(400, { "Content-Type": "text/plain" });
+			res.end("Bad request: invalid URL format. Expected /{host}/{path}");
+			return;
+		}
+
+		// Rate limiting (per host)
+		if (!checkRateLimit(parsed.host, finalConfig.rateLimitPerMinute)) {
+			logger.warn({ host: parsed.host }, "http proxy rate limit exceeded");
+			res.writeHead(429, { "Content-Type": "text/plain" });
+			res.end("Too many requests");
+			return;
+		}
+
+		// Look up credential from vault
+		let entry: CredentialEntry | null = null;
+		let accessToken: string | undefined;
+
+		try {
+			const getResponse = await vaultClient.get("http", parsed.host);
+			if (!getResponse.ok) {
+				logger.warn({ host: parsed.host }, "no credential configured for host");
+				res.writeHead(403, { "Content-Type": "text/plain" });
+				res.end(`Forbidden: no credential configured for ${parsed.host}`);
+				return;
+			}
+			entry = getResponse.entry;
+
+			// For OAuth2, get the access token (vault handles refresh)
+			if (entry.credential.type === "oauth2") {
+				const tokenResponse = await vaultClient.getToken(parsed.host);
+				if (!tokenResponse.ok) {
+					logger.error(
+						{ host: parsed.host, error: tokenResponse.error },
+						"OAuth2 token refresh failed",
+					);
+					res.writeHead(503, { "Content-Type": "text/plain" });
+					res.end("Service unavailable: authentication failed");
+					return;
+				}
+				accessToken = tokenResponse.token;
+			}
+		} catch (err) {
+			logger.error({ host: parsed.host, error: String(err) }, "vault lookup failed");
+			res.writeHead(503, { "Content-Type": "text/plain" });
+			res.end("Service unavailable: credential store unavailable");
+			return;
+		}
+
+		// Check path allowlist
+		if (!isPathAllowed(parsed.path, entry.allowedPaths)) {
+			logger.warn({ host: parsed.host, path: parsed.path }, "path not in allowlist");
+			res.writeHead(403, { "Content-Type": "text/plain" });
+			res.end(`Forbidden: path ${parsed.path} not allowed for this credential`);
+			return;
+		}
+
+		// Check credential-specific rate limit
+		if (entry.rateLimitPerMinute) {
+			const key = `cred:${parsed.host}`;
+			if (!checkRateLimit(key, entry.rateLimitPerMinute)) {
+				logger.warn({ host: parsed.host }, "credential rate limit exceeded");
+				res.writeHead(429, { "Content-Type": "text/plain" });
+				res.end("Too many requests for this credential");
+				return;
+			}
+		}
+
+		// Proxy the request
+		await proxyRequest(req, res, parsed, entry, accessToken);
+	});
+
+	server.listen(finalConfig.port, finalConfig.host, () => {
+		logger.info(
+			{ host: finalConfig.host, port: finalConfig.port },
+			"http credential proxy listening",
+		);
+	});
+
+	return {
+		server,
+		stop: async () => {
+			stopCleanupInterval();
+			return new Promise((resolve) => {
+				server.close(() => resolve());
+			});
+		},
+	};
+}
+
+export { parseProxyUrl, buildAuthHeaders, isPathAllowed };

--- a/src/relay/http-credential-proxy.ts
+++ b/src/relay/http-credential-proxy.ts
@@ -523,7 +523,10 @@ export function startHttpCredentialProxy(
 		// Session Token Validation
 		// SECURITY: All proxy requests require valid session token from relay
 		// ══════════════════════════════════════════════════════════════════════════
-		const sessionHeader = req.headers["x-telclaude-session"] as string | undefined;
+		const rawSessionHeader = req.headers["x-telclaude-session"];
+		// Normalize: header can be string or string[], take first and trim
+		const sessionHeader =
+			(Array.isArray(rawSessionHeader) ? rawSessionHeader[0] : rawSessionHeader)?.trim() || "";
 		if (!sessionHeader) {
 			logger.warn({ url }, "http proxy request missing session token");
 			res.writeHead(401, { "Content-Type": "text/plain" });

--- a/src/vault-daemon/client.ts
+++ b/src/vault-daemon/client.ts
@@ -1,0 +1,199 @@
+/**
+ * Vault daemon client.
+ *
+ * Used by the relay to communicate with the vault sidecar.
+ * Uses newline-delimited JSON over Unix socket.
+ */
+
+import { createConnection } from "node:net";
+import {
+	type DeleteResponse,
+	type GetResponse,
+	type GetTokenResponse,
+	getDefaultSocketPath,
+	type ListResponse,
+	type Protocol,
+	type StoreRequest,
+	type VaultRequest,
+	type VaultResponse,
+	VaultResponseSchema,
+} from "./protocol.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Client Options
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface VaultClientOptions {
+	socketPath?: string;
+	timeout?: number; // ms
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Vault Client
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export class VaultClient {
+	private socketPath: string;
+	private timeout: number;
+
+	constructor(options: VaultClientOptions = {}) {
+		this.socketPath = options.socketPath ?? getDefaultSocketPath();
+		this.timeout = options.timeout ?? 30000; // 30 seconds default
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// Public API
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Get a credential by protocol and target.
+	 */
+	async get(protocol: Protocol, target: string): Promise<GetResponse> {
+		return (await this.send({ type: "get", protocol, target })) as GetResponse;
+	}
+
+	/**
+	 * Get an OAuth2 access token (vault handles refresh).
+	 */
+	async getToken(target: string): Promise<GetTokenResponse> {
+		return (await this.send({
+			type: "get-token",
+			protocol: "http",
+			target,
+		})) as GetTokenResponse;
+	}
+
+	/**
+	 * Store a credential.
+	 */
+	async store(request: Omit<StoreRequest, "type">): Promise<{ type: "store"; ok: true }> {
+		return (await this.send({ type: "store", ...request })) as { type: "store"; ok: true };
+	}
+
+	/**
+	 * Delete a credential.
+	 */
+	async delete(protocol: Protocol, target: string): Promise<DeleteResponse> {
+		return (await this.send({ type: "delete", protocol, target })) as DeleteResponse;
+	}
+
+	/**
+	 * List credentials (without secrets).
+	 */
+	async list(protocol?: Protocol): Promise<ListResponse> {
+		return (await this.send({ type: "list", protocol })) as ListResponse;
+	}
+
+	/**
+	 * Ping the vault daemon.
+	 */
+	async ping(): Promise<boolean> {
+		try {
+			const response = await this.send({ type: "ping" });
+			return response.type === "pong";
+		} catch {
+			return false;
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// Socket Communication
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	private async send(request: VaultRequest): Promise<VaultResponse> {
+		return new Promise((resolve, reject) => {
+			const socket = createConnection({ path: this.socketPath });
+			let buffer = "";
+			let resolved = false;
+
+			// Set timeout
+			const timeoutId = setTimeout(() => {
+				if (!resolved) {
+					resolved = true;
+					socket.destroy();
+					reject(new Error(`Vault request timed out after ${this.timeout}ms`));
+				}
+			}, this.timeout);
+
+			socket.on("connect", () => {
+				socket.write(`${JSON.stringify(request)}\n`);
+			});
+
+			socket.on("data", (data) => {
+				buffer += data.toString();
+
+				// Look for complete response (newline-delimited)
+				const newlineIndex = buffer.indexOf("\n");
+				if (newlineIndex !== -1) {
+					const line = buffer.slice(0, newlineIndex);
+					resolved = true;
+					clearTimeout(timeoutId);
+					socket.end();
+
+					try {
+						const parsed = JSON.parse(line);
+						const response = VaultResponseSchema.parse(parsed);
+						resolve(response);
+					} catch (err) {
+						reject(new Error(`Invalid response from vault: ${String(err)}`));
+					}
+				}
+			});
+
+			socket.on("error", (err) => {
+				if (!resolved) {
+					resolved = true;
+					clearTimeout(timeoutId);
+					reject(new Error(`Vault connection error: ${String(err)}`));
+				}
+			});
+
+			socket.on("close", () => {
+				if (!resolved) {
+					resolved = true;
+					clearTimeout(timeoutId);
+					reject(new Error("Vault connection closed before response"));
+				}
+			});
+		});
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Singleton
+// ═══════════════════════════════════════════════════════════════════════════════
+
+let cachedClient: VaultClient | null = null;
+
+/**
+ * Get the vault client singleton.
+ */
+export function getVaultClient(options?: VaultClientOptions): VaultClient {
+	if (!cachedClient) {
+		cachedClient = new VaultClient(options);
+	}
+	return cachedClient;
+}
+
+/**
+ * Reset the vault client (for testing).
+ */
+export function resetVaultClient(): void {
+	cachedClient = null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Convenience Functions
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Check if the vault daemon is running.
+ */
+export async function isVaultAvailable(options?: VaultClientOptions): Promise<boolean> {
+	try {
+		const client = new VaultClient(options);
+		return await client.ping();
+	} catch {
+		return false;
+	}
+}

--- a/src/vault-daemon/index.ts
+++ b/src/vault-daemon/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Credential Vault Daemon
+ *
+ * A secure sidecar service for storing and managing credentials.
+ * Agents never see raw credentials - they interact through protocol connectors
+ * (HTTP proxy, etc) that inject credentials transparently.
+ *
+ * Architecture:
+ * - Vault sidecar: No network, Unix socket only, stores encrypted credentials
+ * - Protocol connectors: HTTP proxy (in relay) injects auth headers
+ * - Agent: Makes normal HTTP requests through proxy, never sees credentials
+ */
+
+// Client
+export {
+	getVaultClient,
+	isVaultAvailable,
+	resetVaultClient,
+	VaultClient,
+	type VaultClientOptions,
+} from "./client.js";
+// OAuth
+export {
+	clearTokenCache,
+	getAccessToken,
+	invalidateToken,
+	startCleanupTimer,
+	stopCleanupTimer,
+} from "./oauth.js";
+// Protocol types
+export {
+	type Credential,
+	type CredentialEntry,
+	CredentialEntrySchema,
+	CredentialSchema,
+	type DbCredential,
+	DbCredentialSchema,
+	type DeleteRequest,
+	type DeleteResponse,
+	type ErrorResponse,
+	type GetRequest,
+	type GetResponse,
+	type GetTokenRequest,
+	type GetTokenResponse,
+	getDefaultSocketPath,
+	type HttpCredential,
+	HttpCredentialSchema,
+	type ListEntry,
+	type ListRequest,
+	type ListResponse,
+	makeStorageKey,
+	type OAuth2Credential,
+	OAuth2CredentialSchema,
+	type PongResponse,
+	type Protocol,
+	ProtocolSchema,
+	parseStorageKey,
+	type SshCredential,
+	SshCredentialSchema,
+	type StoreRequest,
+	type StoreResponse,
+	type VaultRequest,
+	VaultRequestSchema,
+	type VaultResponse,
+	VaultResponseSchema,
+} from "./protocol.js";
+// Server
+export { type ServerHandle, type ServerOptions, startServer } from "./server.js";
+// Store
+export { getVaultStore, resetVaultStore, VaultStore, type VaultStoreOptions } from "./store.js";

--- a/src/vault-daemon/oauth.ts
+++ b/src/vault-daemon/oauth.ts
@@ -15,19 +15,10 @@
  */
 
 import { getChildLogger } from "../logging.js";
+import { sanitizeError } from "../utils.js";
 import type { OAuth2Credential } from "./protocol.js";
 
 const logger = getChildLogger({ module: "vault-oauth" });
-
-/**
- * Sanitize error messages to prevent credential leakage.
- * Removes URLs which may appear in error messages.
- */
-function sanitizeError(err: unknown): string {
-	const message = String(err);
-	// Replace URLs (may contain tokens in query string or reveal token endpoints)
-	return message.replace(/https?:\/\/[^\s]+/g, "[URL REDACTED]");
-}
 
 // Token endpoint request timeout (30 seconds)
 const TOKEN_REQUEST_TIMEOUT_MS = 30 * 1000;

--- a/src/vault-daemon/oauth.ts
+++ b/src/vault-daemon/oauth.ts
@@ -172,11 +172,12 @@ async function doTokenRefresh(
 			newRefreshToken: newRefreshToken !== credential.refreshToken ? newRefreshToken : undefined,
 		};
 	} catch (err) {
-		// SECURITY: Sanitize error to prevent URL leakage in logs
-		logger.error({ target, error: sanitizeError(err) }, "OAuth2 token refresh failed");
+		// SECURITY: Sanitize error to prevent URL leakage in logs AND returned errors
+		const sanitized = sanitizeError(err);
+		logger.error({ target, error: sanitized }, "OAuth2 token refresh failed");
 		return {
 			ok: false,
-			error: `Token refresh failed: ${String(err)}`,
+			error: `Token refresh failed: ${sanitized}`,
 		};
 	}
 }

--- a/src/vault-daemon/oauth.ts
+++ b/src/vault-daemon/oauth.ts
@@ -1,0 +1,242 @@
+/**
+ * OAuth2 token refresh handling.
+ *
+ * The vault sidecar stores refresh tokens and handles token refresh internally.
+ * Connectors only see valid access tokens - they never handle refresh logic.
+ *
+ * NOTE: This module performs outbound HTTP to token endpoints during refresh.
+ * In production, the vault container MUST allow egress to OAuth token endpoints.
+ *
+ * Security:
+ * - Refresh tokens stored encrypted in vault
+ * - Access tokens cached in memory with expiry
+ * - Token refresh happens automatically before expiry
+ * - Timeout enforced on token endpoint requests
+ */
+
+import { getChildLogger } from "../logging.js";
+import type { OAuth2Credential } from "./protocol.js";
+
+const logger = getChildLogger({ module: "vault-oauth" });
+
+// Token endpoint request timeout (30 seconds)
+const TOKEN_REQUEST_TIMEOUT_MS = 30 * 1000;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Token Cache
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface CachedToken {
+	accessToken: string;
+	expiresAt: number; // Unix timestamp (ms)
+}
+
+// In-memory cache of access tokens (keyed by target)
+const tokenCache = new Map<string, CachedToken>();
+
+// Buffer before expiry to refresh (5 minutes)
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Token Refresh Response
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface TokenResponse {
+	access_token: string;
+	token_type: string;
+	expires_in?: number; // seconds
+	refresh_token?: string; // Some providers return a new refresh token
+	scope?: string;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Public API
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface GetTokenResult {
+	ok: true;
+	token: string;
+	expiresAt: number; // Unix timestamp in milliseconds
+	newRefreshToken?: string; // Present if provider rotated the refresh token
+}
+
+export interface GetTokenError {
+	ok: false;
+	error: string;
+}
+
+export type GetTokenResponse = GetTokenResult | GetTokenError;
+
+/**
+ * Get a valid access token for an OAuth2 credential.
+ * Handles automatic refresh if the cached token is expired or about to expire.
+ *
+ * NOTE: If the provider rotates refresh tokens, the caller MUST persist the
+ * new refresh token from the response, otherwise future refreshes will fail.
+ *
+ * @param target - The target (host) this credential is for (used as cache key)
+ * @param credential - The OAuth2 credential with refresh token
+ * @returns The current valid access token and its expiry, plus new refresh token if rotated
+ */
+export async function getAccessToken(
+	target: string,
+	credential: OAuth2Credential,
+): Promise<GetTokenResponse> {
+	const now = Date.now();
+
+	// Check cache first
+	const cached = tokenCache.get(target);
+	if (cached && cached.expiresAt > now + EXPIRY_BUFFER_MS) {
+		logger.debug(
+			{ target, expiresIn: Math.floor((cached.expiresAt - now) / 1000) },
+			"using cached token",
+		);
+		return {
+			ok: true,
+			token: cached.accessToken,
+			expiresAt: cached.expiresAt,
+		};
+	}
+
+	// Need to refresh
+	logger.info({ target }, "refreshing OAuth2 token");
+
+	try {
+		const tokenResponse = await refreshToken(credential);
+
+		// Calculate expiry (default 1 hour if not provided)
+		const expiresInMs = (tokenResponse.expires_in ?? 3600) * 1000;
+		const expiresAt = now + expiresInMs;
+
+		// Cache the token
+		tokenCache.set(target, {
+			accessToken: tokenResponse.access_token,
+			expiresAt,
+		});
+
+		// Check for refresh token rotation
+		const newRefreshToken = tokenResponse.refresh_token;
+		if (newRefreshToken && newRefreshToken !== credential.refreshToken) {
+			logger.info({ target }, "OAuth2 provider rotated refresh token");
+		}
+
+		logger.info({ target, expiresIn: tokenResponse.expires_in ?? 3600 }, "OAuth2 token refreshed");
+
+		return {
+			ok: true,
+			token: tokenResponse.access_token,
+			expiresAt,
+			newRefreshToken: newRefreshToken !== credential.refreshToken ? newRefreshToken : undefined,
+		};
+	} catch (err) {
+		logger.error({ target, error: String(err) }, "OAuth2 token refresh failed");
+		return {
+			ok: false,
+			error: `Token refresh failed: ${String(err)}`,
+		};
+	}
+}
+
+/**
+ * Invalidate a cached token (e.g., when credential is deleted).
+ */
+export function invalidateToken(target: string): void {
+	tokenCache.delete(target);
+	logger.debug({ target }, "invalidated cached token");
+}
+
+/**
+ * Clear all cached tokens.
+ */
+export function clearTokenCache(): void {
+	tokenCache.clear();
+	logger.debug("cleared all cached tokens");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Token Refresh
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function refreshToken(credential: OAuth2Credential): Promise<TokenResponse> {
+	const body = new URLSearchParams({
+		grant_type: "refresh_token",
+		client_id: credential.clientId,
+		client_secret: credential.clientSecret,
+		refresh_token: credential.refreshToken,
+	});
+
+	if (credential.scope) {
+		body.set("scope", credential.scope);
+	}
+
+	// Use AbortController for timeout
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), TOKEN_REQUEST_TIMEOUT_MS);
+
+	try {
+		const response = await fetch(credential.tokenEndpoint, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			body: body.toString(),
+			signal: controller.signal,
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			throw new Error(`Token endpoint returned ${response.status}: ${errorText}`);
+		}
+
+		const tokenResponse = (await response.json()) as TokenResponse;
+
+		if (!tokenResponse.access_token) {
+			throw new Error("Token endpoint did not return access_token");
+		}
+
+		return tokenResponse;
+	} catch (err) {
+		if (err instanceof Error && err.name === "AbortError") {
+			throw new Error(`Token endpoint request timed out after ${TOKEN_REQUEST_TIMEOUT_MS}ms`);
+		}
+		throw err;
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Cleanup Timer
+// ═══════════════════════════════════════════════════════════════════════════════
+
+let cleanupTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Start the token cache cleanup timer.
+ * Removes expired tokens periodically.
+ */
+export function startCleanupTimer(): void {
+	if (cleanupTimer) return;
+
+	cleanupTimer = setInterval(() => {
+		const now = Date.now();
+		for (const [target, cached] of tokenCache.entries()) {
+			if (cached.expiresAt <= now) {
+				tokenCache.delete(target);
+				logger.debug({ target }, "removed expired token from cache");
+			}
+		}
+	}, 60 * 1000); // Every minute
+
+	cleanupTimer.unref();
+}
+
+/**
+ * Stop the token cache cleanup timer.
+ */
+export function stopCleanupTimer(): void {
+	if (cleanupTimer) {
+		clearInterval(cleanupTimer);
+		cleanupTimer = null;
+	}
+}

--- a/src/vault-daemon/protocol.ts
+++ b/src/vault-daemon/protocol.ts
@@ -79,13 +79,19 @@ export type HttpCredential = z.infer<typeof HttpCredentialSchema>;
 
 /**
  * OAuth2 credentials - vault handles token refresh internally
+ * SECURITY: tokenEndpoint must be HTTPS to prevent credential transmission over plaintext
  */
 export const OAuth2CredentialSchema = z.object({
 	type: z.literal("oauth2"),
 	clientId: z.string().min(1),
 	clientSecret: z.string().min(1),
 	refreshToken: z.string().min(1),
-	tokenEndpoint: z.string().url(),
+	tokenEndpoint: z
+		.string()
+		.url()
+		.refine((url) => url.startsWith("https://"), {
+			message: "Token endpoint must use HTTPS to protect credentials in transit",
+		}),
 	scope: z.string().optional(),
 });
 

--- a/src/vault-daemon/protocol.ts
+++ b/src/vault-daemon/protocol.ts
@@ -1,0 +1,392 @@
+/**
+ * Credential Vault daemon IPC protocol types.
+ *
+ * Uses Zod for runtime validation of messages.
+ * Protocol is newline-delimited JSON over Unix socket.
+ *
+ * The vault stores credentials keyed by (protocol, target) and injects them
+ * into protocol-specific connectors (HTTP proxy, etc). The agent never sees
+ * raw credentials.
+ *
+ * Supported protocols:
+ * - http: REST/GraphQL APIs (bearer, api-key, basic, oauth2)
+ * - postgres: PostgreSQL databases (future)
+ * - mysql: MySQL databases (future)
+ * - ssh: SSH servers (future)
+ */
+
+import { z } from "zod";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Protocol Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const ProtocolSchema = z.enum(["http", "postgres", "mysql", "ssh"]);
+export type Protocol = z.infer<typeof ProtocolSchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Credential Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * HTTP credentials - for REST/GraphQL APIs
+ */
+export const HttpBearerCredentialSchema = z.object({
+	type: z.literal("bearer"),
+	token: z.string().min(1),
+});
+
+export const HttpApiKeyCredentialSchema = z.object({
+	type: z.literal("api-key"),
+	token: z.string().min(1),
+	header: z.string().min(1), // e.g., "X-API-Key", "x-api-key"
+});
+
+export const HttpBasicCredentialSchema = z.object({
+	type: z.literal("basic"),
+	username: z.string().min(1),
+	password: z.string(),
+});
+
+export const HttpQueryCredentialSchema = z.object({
+	type: z.literal("query"),
+	token: z.string().min(1),
+	param: z.string().min(1), // e.g., "api_key", "key"
+});
+
+export const HttpCredentialSchema = z.discriminatedUnion("type", [
+	HttpBearerCredentialSchema,
+	HttpApiKeyCredentialSchema,
+	HttpBasicCredentialSchema,
+	HttpQueryCredentialSchema,
+]);
+
+export type HttpCredential = z.infer<typeof HttpCredentialSchema>;
+
+/**
+ * OAuth2 credentials - vault handles token refresh internally
+ */
+export const OAuth2CredentialSchema = z.object({
+	type: z.literal("oauth2"),
+	clientId: z.string().min(1),
+	clientSecret: z.string().min(1),
+	refreshToken: z.string().min(1),
+	tokenEndpoint: z.string().url(),
+	scope: z.string().optional(),
+});
+
+export type OAuth2Credential = z.infer<typeof OAuth2CredentialSchema>;
+
+/**
+ * Database credentials (future)
+ */
+export const DbCredentialSchema = z.object({
+	type: z.literal("db"),
+	username: z.string().min(1),
+	password: z.string(),
+	database: z.string().optional(),
+});
+
+export type DbCredential = z.infer<typeof DbCredentialSchema>;
+
+/**
+ * SSH credentials (future)
+ */
+export const SshKeyCredentialSchema = z.object({
+	type: z.literal("ssh-key"),
+	username: z.string().min(1),
+	privateKey: z.string().min(1),
+	passphrase: z.string().optional(),
+});
+
+export const SshPasswordCredentialSchema = z.object({
+	type: z.literal("ssh-password"),
+	username: z.string().min(1),
+	password: z.string(),
+});
+
+export const SshCredentialSchema = z.discriminatedUnion("type", [
+	SshKeyCredentialSchema,
+	SshPasswordCredentialSchema,
+]);
+
+export type SshCredential = z.infer<typeof SshCredentialSchema>;
+
+/**
+ * All credential types
+ */
+export const CredentialSchema = z.union([
+	HttpCredentialSchema,
+	OAuth2CredentialSchema,
+	DbCredentialSchema,
+	SshCredentialSchema,
+]);
+
+export type Credential = z.infer<typeof CredentialSchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Credential Entry (stored in vault)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const CredentialEntrySchema = z.object({
+	protocol: ProtocolSchema,
+	target: z.string().min(1), // host or host:port
+	label: z.string().optional(),
+	credential: CredentialSchema,
+	allowedPaths: z.array(z.string()).optional(), // For HTTP: path regex allowlist
+	rateLimitPerMinute: z.number().positive().optional(),
+	createdAt: z.string().datetime(),
+	expiresAt: z.string().datetime().optional(),
+});
+
+export type CredentialEntry = z.infer<typeof CredentialEntrySchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Request Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Get a credential by protocol and target
+ */
+export const GetRequestSchema = z.object({
+	type: z.literal("get"),
+	protocol: ProtocolSchema,
+	target: z.string().min(1),
+});
+
+/**
+ * Get an OAuth2 access token (vault handles refresh)
+ */
+export const GetTokenRequestSchema = z.object({
+	type: z.literal("get-token"),
+	protocol: z.literal("http"),
+	target: z.string().min(1),
+});
+
+/**
+ * Store a credential
+ */
+export const StoreRequestSchema = z.object({
+	type: z.literal("store"),
+	protocol: ProtocolSchema,
+	target: z.string().min(1),
+	label: z.string().optional(),
+	credential: CredentialSchema,
+	allowedPaths: z.array(z.string()).optional(),
+	rateLimitPerMinute: z.number().positive().optional(),
+	expiresAt: z.string().datetime().optional(),
+});
+
+/**
+ * Delete a credential
+ */
+export const DeleteRequestSchema = z.object({
+	type: z.literal("delete"),
+	protocol: ProtocolSchema,
+	target: z.string().min(1),
+});
+
+/**
+ * List credentials (without exposing secrets)
+ */
+export const ListRequestSchema = z.object({
+	type: z.literal("list"),
+	protocol: ProtocolSchema.optional(), // Optional filter
+});
+
+/**
+ * Ping (health check)
+ */
+export const PingRequestSchema = z.object({
+	type: z.literal("ping"),
+});
+
+export const VaultRequestSchema = z.discriminatedUnion("type", [
+	GetRequestSchema,
+	GetTokenRequestSchema,
+	StoreRequestSchema,
+	DeleteRequestSchema,
+	ListRequestSchema,
+	PingRequestSchema,
+]);
+
+export type VaultRequest = z.infer<typeof VaultRequestSchema>;
+export type GetRequest = z.infer<typeof GetRequestSchema>;
+export type GetTokenRequest = z.infer<typeof GetTokenRequestSchema>;
+export type StoreRequest = z.infer<typeof StoreRequestSchema>;
+export type DeleteRequest = z.infer<typeof DeleteRequestSchema>;
+export type ListRequest = z.infer<typeof ListRequestSchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Response Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Get response - returns credential with injection config
+ */
+export const GetSuccessResponseSchema = z.object({
+	type: z.literal("get"),
+	ok: z.literal(true),
+	entry: CredentialEntrySchema,
+});
+
+export const GetNotFoundResponseSchema = z.object({
+	type: z.literal("get"),
+	ok: z.literal(false),
+	error: z.literal("not_found"),
+});
+
+export const GetResponseSchema = z.union([GetSuccessResponseSchema, GetNotFoundResponseSchema]);
+
+export type GetSuccessResponse = z.infer<typeof GetSuccessResponseSchema>;
+export type GetNotFoundResponse = z.infer<typeof GetNotFoundResponseSchema>;
+export type GetResponse = z.infer<typeof GetResponseSchema>;
+
+/**
+ * Get-token response - returns current valid access token
+ */
+export const GetTokenSuccessResponseSchema = z.object({
+	type: z.literal("get-token"),
+	ok: z.literal(true),
+	token: z.string().min(1),
+	expiresAt: z.number(), // Unix timestamp in MILLISECONDS (Date.now() compatible)
+});
+
+export const GetTokenErrorResponseSchema = z.object({
+	type: z.literal("get-token"),
+	ok: z.literal(false),
+	error: z.string(),
+});
+
+export const GetTokenResponseSchema = z.union([
+	GetTokenSuccessResponseSchema,
+	GetTokenErrorResponseSchema,
+]);
+
+export type GetTokenSuccessResponse = z.infer<typeof GetTokenSuccessResponseSchema>;
+export type GetTokenErrorResponse = z.infer<typeof GetTokenErrorResponseSchema>;
+export type GetTokenResponse = z.infer<typeof GetTokenResponseSchema>;
+
+/**
+ * Store response
+ */
+export const StoreResponseSchema = z.object({
+	type: z.literal("store"),
+	ok: z.literal(true),
+});
+
+export type StoreResponse = z.infer<typeof StoreResponseSchema>;
+
+/**
+ * Delete response
+ */
+export const DeleteSuccessResponseSchema = z.object({
+	type: z.literal("delete"),
+	ok: z.literal(true),
+	deleted: z.literal(true),
+});
+
+export const DeleteNotFoundResponseSchema = z.object({
+	type: z.literal("delete"),
+	ok: z.literal(true),
+	deleted: z.literal(false),
+});
+
+export const DeleteResponseSchema = z.union([
+	DeleteSuccessResponseSchema,
+	DeleteNotFoundResponseSchema,
+]);
+
+export type DeleteResponse = z.infer<typeof DeleteResponseSchema>;
+
+/**
+ * List response - returns metadata only (no credentials)
+ */
+export const ListEntrySchema = z.object({
+	protocol: ProtocolSchema,
+	target: z.string(),
+	label: z.string().optional(),
+	credentialType: z.string(), // e.g., "bearer", "oauth2", "ssh-key"
+	createdAt: z.string().datetime(),
+	expiresAt: z.string().datetime().optional(),
+});
+
+export type ListEntry = z.infer<typeof ListEntrySchema>;
+
+export const ListResponseSchema = z.object({
+	type: z.literal("list"),
+	ok: z.literal(true),
+	entries: z.array(ListEntrySchema),
+});
+
+export type ListResponse = z.infer<typeof ListResponseSchema>;
+
+/**
+ * Pong response
+ */
+export const PongResponseSchema = z.object({
+	type: z.literal("pong"),
+});
+
+export type PongResponse = z.infer<typeof PongResponseSchema>;
+
+/**
+ * Error response
+ */
+export const ErrorResponseSchema = z.object({
+	type: z.literal("error"),
+	error: z.string(),
+});
+
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+
+/**
+ * All response types
+ */
+export const VaultResponseSchema = z.union([
+	GetResponseSchema,
+	GetTokenResponseSchema,
+	StoreResponseSchema,
+	DeleteResponseSchema,
+	ListResponseSchema,
+	PongResponseSchema,
+	ErrorResponseSchema,
+]);
+
+export type VaultResponse = z.infer<typeof VaultResponseSchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Socket Path
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Get the default socket path for the vault daemon.
+ * Uses ~/.telclaude/vault.sock
+ */
+export function getDefaultSocketPath(): string {
+	const home = process.env.HOME || "/tmp";
+	return `${home}/.telclaude/vault.sock`;
+}
+
+/**
+ * Generate a storage key for a credential entry.
+ */
+export function makeStorageKey(protocol: Protocol, target: string): string {
+	return `${protocol}:${target}`;
+}
+
+/**
+ * Parse a storage key back into protocol and target.
+ */
+export function parseStorageKey(key: string): { protocol: Protocol; target: string } | null {
+	const colonIndex = key.indexOf(":");
+	if (colonIndex === -1) return null;
+
+	const protocol = key.slice(0, colonIndex);
+	const target = key.slice(colonIndex + 1);
+
+	const result = ProtocolSchema.safeParse(protocol);
+	if (!result.success) return null;
+
+	return { protocol: result.data, target };
+}

--- a/src/vault-daemon/protocol.ts
+++ b/src/vault-daemon/protocol.ts
@@ -43,10 +43,7 @@ const RFC7230_TOKEN_REGEX = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 export const HttpApiKeyCredentialSchema = z.object({
 	type: z.literal("api-key"),
 	token: z.string().min(1),
-	header: z
-		.string()
-		.min(1)
-		.regex(RFC7230_TOKEN_REGEX, "Header name must be a valid RFC7230 token"), // e.g., "X-API-Key", "x-api-key"
+	header: z.string().min(1).regex(RFC7230_TOKEN_REGEX, "Header name must be a valid RFC7230 token"), // e.g., "X-API-Key", "x-api-key"
 });
 
 export const HttpBasicCredentialSchema = z.object({

--- a/src/vault-daemon/protocol.ts
+++ b/src/vault-daemon/protocol.ts
@@ -36,10 +36,17 @@ export const HttpBearerCredentialSchema = z.object({
 	token: z.string().min(1),
 });
 
+// RFC7230 token: only safe characters for HTTP header field names
+// Prevents header injection attacks
+const RFC7230_TOKEN_REGEX = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+
 export const HttpApiKeyCredentialSchema = z.object({
 	type: z.literal("api-key"),
 	token: z.string().min(1),
-	header: z.string().min(1), // e.g., "X-API-Key", "x-api-key"
+	header: z
+		.string()
+		.min(1)
+		.regex(RFC7230_TOKEN_REGEX, "Header name must be a valid RFC7230 token"), // e.g., "X-API-Key", "x-api-key"
 });
 
 export const HttpBasicCredentialSchema = z.object({
@@ -48,10 +55,17 @@ export const HttpBasicCredentialSchema = z.object({
 	password: z.string(),
 });
 
+// Safe query parameter name: alphanumeric, underscore, hyphen only
+// Prevents query string injection attacks
+const SAFE_QUERY_PARAM_REGEX = /^[A-Za-z0-9_-]+$/;
+
 export const HttpQueryCredentialSchema = z.object({
 	type: z.literal("query"),
 	token: z.string().min(1),
-	param: z.string().min(1), // e.g., "api_key", "key"
+	param: z
+		.string()
+		.min(1)
+		.regex(SAFE_QUERY_PARAM_REGEX, "Query param must be alphanumeric with _ or - only"), // e.g., "api_key", "key"
 });
 
 export const HttpCredentialSchema = z.discriminatedUnion("type", [

--- a/src/vault-daemon/server.ts
+++ b/src/vault-daemon/server.ts
@@ -1,0 +1,309 @@
+/**
+ * Credential vault Unix socket server.
+ *
+ * Listens on a Unix socket and handles credential requests.
+ * Uses newline-delimited JSON protocol.
+ *
+ * Security:
+ * - Socket permissions set to 0600 (owner only)
+ * - Never returns raw credentials in list operations
+ * - Credentials only returned via get operations
+ * - No network access (Unix socket only)
+ */
+
+import fs from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import path from "node:path";
+
+import { getChildLogger } from "../logging.js";
+import {
+	clearTokenCache,
+	getAccessToken,
+	invalidateToken,
+	startCleanupTimer,
+	stopCleanupTimer,
+} from "./oauth.js";
+import {
+	getDefaultSocketPath,
+	type VaultRequest,
+	VaultRequestSchema,
+	type VaultResponse,
+} from "./protocol.js";
+import { getVaultStore, resetVaultStore, type VaultStoreOptions } from "./store.js";
+
+const logger = getChildLogger({ module: "vault-server" });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Server Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface ServerOptions {
+	socketPath?: string;
+	storeOptions?: VaultStoreOptions;
+}
+
+export interface ServerHandle {
+	isRunning: () => boolean;
+	stop: () => Promise<void>;
+	socketPath: string;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Server
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Start the vault daemon server.
+ */
+export async function startServer(options: ServerOptions = {}): Promise<ServerHandle> {
+	const socketPath = options.socketPath ?? getDefaultSocketPath();
+
+	// Initialize store (validates encryption key)
+	getVaultStore(options.storeOptions);
+
+	// Ensure directory exists
+	const socketDir = path.dirname(socketPath);
+	fs.mkdirSync(socketDir, { recursive: true });
+
+	// Remove stale socket file if it exists
+	try {
+		fs.unlinkSync(socketPath);
+	} catch {
+		// Ignore if doesn't exist
+	}
+
+	const server = createServer((socket) => {
+		handleConnection(socket);
+	});
+
+	return new Promise((resolve, reject) => {
+		server.on("error", (err) => {
+			logger.error({ error: String(err) }, "server error");
+			reject(err);
+		});
+
+		server.listen(socketPath, () => {
+			// Set socket permissions to owner only (0600)
+			// SECURITY: This MUST succeed - other users could connect otherwise
+			try {
+				fs.chmodSync(socketPath, 0o600);
+				// Verify the permissions were actually set
+				const stats = fs.statSync(socketPath);
+				const mode = stats.mode & 0o777;
+				if (mode !== 0o600) {
+					throw new Error(`Socket permissions are ${mode.toString(8)}, expected 600`);
+				}
+			} catch (err) {
+				logger.error(
+					{ error: String(err), socketPath },
+					"CRITICAL: failed to secure socket permissions",
+				);
+				server.close();
+				reject(new Error(`Failed to set socket permissions: ${String(err)}`));
+				return;
+			}
+
+			// Start OAuth token cleanup timer
+			startCleanupTimer();
+
+			logger.info({ socketPath }, "vault daemon listening");
+
+			resolve({
+				isRunning: () => server.listening,
+				stop: () => stopServer(server, socketPath),
+				socketPath,
+			});
+		});
+	});
+}
+
+/**
+ * Stop the server and clean up.
+ */
+async function stopServer(server: Server, socketPath: string): Promise<void> {
+	return new Promise((resolve) => {
+		// Stop OAuth cleanup timer
+		stopCleanupTimer();
+
+		// Clear token cache
+		clearTokenCache();
+
+		// Reset store singleton
+		resetVaultStore();
+
+		server.close(() => {
+			try {
+				fs.unlinkSync(socketPath);
+			} catch {
+				// Ignore if already removed
+			}
+			logger.info("vault daemon stopped");
+			resolve();
+		});
+	});
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Connection Handler
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Max request size (1MB - credentials with SSH keys can be large)
+const MAX_REQUEST_SIZE = 1024 * 1024;
+
+/**
+ * Handle a new client connection.
+ */
+function handleConnection(socket: Socket): void {
+	const clientId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	logger.debug({ clientId }, "client connected");
+
+	let buffer = "";
+
+	socket.on("data", async (data) => {
+		buffer += data.toString();
+
+		// SECURITY: Enforce max request size to prevent memory exhaustion
+		if (buffer.length > MAX_REQUEST_SIZE) {
+			logger.warn({ clientId, bufferSize: buffer.length }, "request too large, closing connection");
+			socket.write(`${JSON.stringify({ type: "error", error: "Request too large" })}\n`);
+			socket.end();
+			return;
+		}
+
+		// Process complete lines (newline-delimited JSON)
+		const lines = buffer.split("\n");
+		buffer = lines.pop() ?? ""; // Keep incomplete line in buffer
+
+		for (const line of lines) {
+			if (!line.trim()) continue;
+
+			const response = await processLine(line, clientId);
+			socket.write(`${JSON.stringify(response)}\n`);
+		}
+	});
+
+	socket.on("error", (err) => {
+		logger.debug({ clientId, error: String(err) }, "socket error");
+	});
+
+	socket.on("close", () => {
+		logger.debug({ clientId }, "client disconnected");
+	});
+}
+
+/**
+ * Process a single request line.
+ */
+async function processLine(line: string, clientId: string): Promise<VaultResponse> {
+	try {
+		const parsed = JSON.parse(line);
+		const request = VaultRequestSchema.parse(parsed);
+		return await handleRequest(request, clientId);
+	} catch (err) {
+		// SECURITY: Never log line content - it may contain credentials
+		logger.warn({ clientId, error: String(err), lineLength: line.length }, "invalid request");
+		return {
+			type: "error",
+			error: `Invalid request: ${String(err)}`,
+		};
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Request Handlers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Handle a validated request.
+ */
+async function handleRequest(request: VaultRequest, clientId: string): Promise<VaultResponse> {
+	logger.debug({ clientId, requestType: request.type }, "handling request");
+	const store = getVaultStore();
+
+	switch (request.type) {
+		case "ping": {
+			return { type: "pong" };
+		}
+
+		case "get": {
+			const entry = await store.get(request.protocol, request.target);
+			if (!entry) {
+				return { type: "get", ok: false, error: "not_found" };
+			}
+			return { type: "get", ok: true, entry };
+		}
+
+		case "get-token": {
+			// Get the credential first
+			const entry = await store.get(request.protocol, request.target);
+			if (!entry) {
+				return { type: "get-token", ok: false, error: "Credential not found" };
+			}
+
+			// Must be an OAuth2 credential
+			if (entry.credential.type !== "oauth2") {
+				return {
+					type: "get-token",
+					ok: false,
+					error: `Credential is type '${entry.credential.type}', not 'oauth2'`,
+				};
+			}
+
+			// Get access token (handles refresh)
+			const result = await getAccessToken(request.target, entry.credential);
+			if (!result.ok) {
+				return { type: "get-token", ok: false, error: result.error };
+			}
+
+			// Handle refresh token rotation - update stored credential with new refresh token
+			if (result.newRefreshToken) {
+				logger.info({ target: request.target }, "persisting rotated refresh token");
+				const updatedCredential = {
+					...entry.credential,
+					refreshToken: result.newRefreshToken,
+				};
+				await store.store(request.protocol, request.target, updatedCredential, {
+					label: entry.label,
+					allowedPaths: entry.allowedPaths,
+					rateLimitPerMinute: entry.rateLimitPerMinute,
+					expiresAt: entry.expiresAt,
+				});
+			}
+
+			return {
+				type: "get-token",
+				ok: true,
+				token: result.token,
+				expiresAt: result.expiresAt,
+			};
+		}
+
+		case "store": {
+			await store.store(request.protocol, request.target, request.credential, {
+				label: request.label,
+				allowedPaths: request.allowedPaths,
+				rateLimitPerMinute: request.rateLimitPerMinute,
+				expiresAt: request.expiresAt,
+			});
+
+			// Invalidate any cached OAuth token for this target
+			invalidateToken(request.target);
+
+			return { type: "store", ok: true };
+		}
+
+		case "delete": {
+			const deleted = await store.delete(request.protocol, request.target);
+
+			// Invalidate any cached OAuth token for this target
+			invalidateToken(request.target);
+
+			return { type: "delete", ok: true, deleted };
+		}
+
+		case "list": {
+			const entries = await store.list(request.protocol);
+			return { type: "list", ok: true, entries };
+		}
+	}
+}

--- a/src/vault-daemon/store.ts
+++ b/src/vault-daemon/store.ts
@@ -1,0 +1,347 @@
+/**
+ * Credential vault storage.
+ *
+ * Uses AES-256-GCM encryption with scrypt key derivation.
+ * Storage is file-based (Docker-compatible, no OS keychain dependency).
+ *
+ * Security:
+ * - Credentials are encrypted at rest
+ * - File permissions set to 0600 (owner only)
+ * - Secrets never logged
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { getChildLogger } from "../logging.js";
+import {
+	type Credential,
+	type CredentialEntry,
+	CredentialEntrySchema,
+	type ListEntry,
+	makeStorageKey,
+	type Protocol,
+	parseStorageKey,
+} from "./protocol.js";
+
+const logger = getChildLogger({ module: "vault-store" });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Storage Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface EncryptedVault {
+	version: 1;
+	salt: string;
+	entries: Record<string, EncryptedEntry>;
+}
+
+interface EncryptedEntry {
+	iv: string;
+	data: string;
+	tag: string;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Vault Store
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface VaultStoreOptions {
+	filePath?: string;
+	encryptionKey?: string;
+}
+
+export class VaultStore {
+	private filePath: string;
+	private rawKey: string;
+	private derivedKey: Buffer | null = null;
+	private cachedSalt: Buffer | null = null;
+
+	constructor(options: VaultStoreOptions = {}) {
+		const dataDir =
+			process.env.TELCLAUDE_DATA_DIR || join(process.env.HOME || "/tmp", ".telclaude");
+
+		this.filePath = options.filePath || join(dataDir, "vault.json");
+		this.rawKey = options.encryptionKey || process.env.VAULT_ENCRYPTION_KEY || "";
+
+		if (!this.rawKey) {
+			throw new Error(
+				"VAULT_ENCRYPTION_KEY environment variable is required. " +
+					"Generate a strong key: openssl rand -base64 32",
+			);
+		}
+
+		const dir = dirname(this.filePath);
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true, mode: 0o700 });
+		}
+
+		logger.debug({ filePath: this.filePath }, "vault store initialized");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// Public API
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Store a credential entry.
+	 */
+	async store(
+		protocol: Protocol,
+		target: string,
+		credential: Credential,
+		options: {
+			label?: string;
+			allowedPaths?: string[];
+			rateLimitPerMinute?: number;
+			expiresAt?: string;
+		} = {},
+	): Promise<void> {
+		const entry: CredentialEntry = {
+			protocol,
+			target,
+			credential,
+			label: options.label,
+			allowedPaths: options.allowedPaths,
+			rateLimitPerMinute: options.rateLimitPerMinute,
+			createdAt: new Date().toISOString(),
+			expiresAt: options.expiresAt,
+		};
+
+		// Validate the entry
+		CredentialEntrySchema.parse(entry);
+
+		const vault = this.readVault();
+		const key = makeStorageKey(protocol, target);
+		const encKey = this.getEncryptionKey(vault);
+
+		vault.entries[key] = this.encrypt(JSON.stringify(entry), encKey);
+		this.writeVault(vault);
+
+		logger.info({ protocol, target, credentialType: credential.type }, "stored credential");
+	}
+
+	/**
+	 * Get a credential entry.
+	 */
+	async get(protocol: Protocol, target: string): Promise<CredentialEntry | null> {
+		const vault = this.readVault();
+		const key = makeStorageKey(protocol, target);
+		const encrypted = vault.entries[key];
+
+		if (!encrypted) {
+			return null;
+		}
+
+		try {
+			const encKey = this.getEncryptionKey(vault);
+			const decrypted = this.decrypt(encrypted, encKey);
+			const entry = JSON.parse(decrypted) as CredentialEntry;
+
+			// Check expiration
+			if (entry.expiresAt && new Date(entry.expiresAt) < new Date()) {
+				logger.info({ protocol, target }, "credential expired");
+				return null;
+			}
+
+			return CredentialEntrySchema.parse(entry);
+		} catch (err) {
+			logger.error({ protocol, target, error: String(err) }, "failed to decrypt credential");
+			return null;
+		}
+	}
+
+	/**
+	 * Delete a credential entry.
+	 */
+	async delete(protocol: Protocol, target: string): Promise<boolean> {
+		const vault = this.readVault();
+		const key = makeStorageKey(protocol, target);
+
+		if (!vault.entries[key]) {
+			return false;
+		}
+
+		delete vault.entries[key];
+		this.writeVault(vault);
+
+		logger.info({ protocol, target }, "deleted credential");
+		return true;
+	}
+
+	/**
+	 * Check if a credential exists.
+	 */
+	async has(protocol: Protocol, target: string): Promise<boolean> {
+		const vault = this.readVault();
+		const key = makeStorageKey(protocol, target);
+		return key in vault.entries;
+	}
+
+	/**
+	 * List all credentials (without exposing secrets).
+	 */
+	async list(filterProtocol?: Protocol): Promise<ListEntry[]> {
+		const vault = this.readVault();
+		const encKey = this.getEncryptionKey(vault);
+		const entries: ListEntry[] = [];
+
+		for (const [key, encrypted] of Object.entries(vault.entries)) {
+			const parsed = parseStorageKey(key);
+			if (!parsed) continue;
+
+			// Apply protocol filter
+			if (filterProtocol && parsed.protocol !== filterProtocol) {
+				continue;
+			}
+
+			try {
+				const decrypted = this.decrypt(encrypted, encKey);
+				const entry = JSON.parse(decrypted) as CredentialEntry;
+
+				entries.push({
+					protocol: entry.protocol,
+					target: entry.target,
+					label: entry.label,
+					credentialType: entry.credential.type,
+					createdAt: entry.createdAt,
+					expiresAt: entry.expiresAt,
+				});
+			} catch (err) {
+				logger.warn({ key, error: String(err) }, "failed to decrypt entry for listing");
+			}
+		}
+
+		return entries;
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// Encryption
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	private getEncryptionKey(vault: EncryptedVault): Buffer {
+		const salt = Buffer.from(vault.salt, "base64");
+
+		if (this.derivedKey && this.cachedSalt && salt.equals(this.cachedSalt)) {
+			return this.derivedKey;
+		}
+
+		this.derivedKey = scryptSync(this.rawKey, salt, 32);
+		this.cachedSalt = salt;
+		return this.derivedKey;
+	}
+
+	private encrypt(plaintext: string, key: Buffer): EncryptedEntry {
+		const iv = randomBytes(12);
+		const cipher = createCipheriv("aes-256-gcm", key, iv);
+		const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+		const tag = cipher.getAuthTag();
+
+		return {
+			iv: iv.toString("base64"),
+			data: encrypted.toString("base64"),
+			tag: tag.toString("base64"),
+		};
+	}
+
+	private decrypt(entry: EncryptedEntry, key: Buffer): string {
+		const iv = Buffer.from(entry.iv, "base64");
+		const data = Buffer.from(entry.data, "base64");
+		const tag = Buffer.from(entry.tag, "base64");
+
+		const decipher = createDecipheriv("aes-256-gcm", key, iv);
+		decipher.setAuthTag(tag);
+
+		const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+		return decrypted.toString("utf8");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// File I/O
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	private readVault(): EncryptedVault {
+		if (!existsSync(this.filePath)) {
+			const salt = randomBytes(16);
+			return { version: 1, salt: salt.toString("base64"), entries: {} };
+		}
+
+		try {
+			const content = readFileSync(this.filePath, "utf8");
+			const vault = JSON.parse(content) as EncryptedVault;
+
+			// Validate vault structure
+			if (!vault.version || !vault.salt || typeof vault.entries !== "object") {
+				throw new Error("Invalid vault structure");
+			}
+
+			return vault;
+		} catch (err) {
+			// SECURITY: Don't silently reset on corruption - fail closed
+			// Quarantine the corrupted file for manual recovery
+			const backupPath = `${this.filePath}.corrupted.${Date.now()}`;
+			try {
+				const { renameSync } = require("node:fs");
+				renameSync(this.filePath, backupPath);
+				logger.error(
+					{ filePath: this.filePath, backupPath, error: String(err) },
+					"vault file corrupted, moved to backup - starting fresh",
+				);
+			} catch {
+				logger.error(
+					{ filePath: this.filePath, error: String(err) },
+					"vault file corrupted and backup failed",
+				);
+				throw new Error(`Vault file corrupted: ${String(err)}. Manual recovery required.`);
+			}
+
+			const salt = randomBytes(16);
+			return { version: 1, salt: salt.toString("base64"), entries: {} };
+		}
+	}
+
+	private writeVault(vault: EncryptedVault): void {
+		const content = JSON.stringify(vault, null, 2);
+		writeFileSync(this.filePath, content, { mode: 0o600 });
+
+		// SECURITY: Ensure permissions are correct even if file existed with wrong perms
+		const { chmodSync, statSync } = require("node:fs");
+		try {
+			const stats = statSync(this.filePath);
+			const mode = stats.mode & 0o777;
+			if (mode !== 0o600) {
+				chmodSync(this.filePath, 0o600);
+				logger.info({ filePath: this.filePath }, "corrected vault file permissions to 0600");
+			}
+		} catch (err) {
+			logger.warn(
+				{ filePath: this.filePath, error: String(err) },
+				"failed to verify vault file permissions",
+			);
+		}
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Singleton
+// ═══════════════════════════════════════════════════════════════════════════════
+
+let cachedStore: VaultStore | null = null;
+
+/**
+ * Get the vault store singleton.
+ */
+export function getVaultStore(options?: VaultStoreOptions): VaultStore {
+	if (!cachedStore) {
+		cachedStore = new VaultStore(options);
+	}
+	return cachedStore;
+}
+
+/**
+ * Reset the vault store (for testing).
+ */
+export function resetVaultStore(): void {
+	cachedStore = null;
+}

--- a/src/vault-daemon/store.ts
+++ b/src/vault-daemon/store.ts
@@ -11,7 +11,15 @@
  */
 
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 
 import { getChildLogger } from "../logging.js";
@@ -282,7 +290,6 @@ export class VaultStore {
 			// Quarantine the corrupted file for manual recovery
 			const backupPath = `${this.filePath}.corrupted.${Date.now()}`;
 			try {
-				const { renameSync } = require("node:fs");
 				renameSync(this.filePath, backupPath);
 				logger.error(
 					{ filePath: this.filePath, backupPath, error: String(err) },
@@ -306,7 +313,6 @@ export class VaultStore {
 		writeFileSync(this.filePath, content, { mode: 0o600 });
 
 		// SECURITY: Ensure permissions are correct even if file existed with wrong perms
-		const { chmodSync, statSync } = require("node:fs");
 		try {
 			const stats = statSync(this.filePath);
 			const mode = stats.mode & 0o777;

--- a/tests/relay/attachment-delivery.test.ts
+++ b/tests/relay/attachment-delivery.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let extractGeneratedMediaPaths: typeof import("../../src/telegram/media-detection.js").extractGeneratedMediaPaths;
+let __resetPatternCache: typeof import("../../src/telegram/media-detection.js").__resetPatternCache;
+
+const ORIGINAL_MEDIA_OUTBOX = process.env.TELCLAUDE_MEDIA_OUTBOX_DIR;
+
+/**
+ * Integration test: Verifies that attachment delivery paths work with media detection.
+ *
+ * This tests the critical flow:
+ * 1. Relay saves attachment with timestamp-hash filename
+ * 2. Relay returns the exact path in response
+ * 3. Claude outputs this exact path in text
+ * 4. Media detection finds the file and triggers Telegram send
+ */
+describe("attachment-delivery integration", () => {
+	let tempDir: string;
+	let mediaRoot: string;
+	let documentsDir: string;
+
+	beforeEach(async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "telclaude-attach-"));
+		mediaRoot = tempDir;
+		documentsDir = path.join(mediaRoot, "documents");
+		fs.mkdirSync(documentsDir, { recursive: true });
+
+		process.env.TELCLAUDE_MEDIA_OUTBOX_DIR = mediaRoot;
+		vi.resetModules();
+		({ extractGeneratedMediaPaths, __resetPatternCache } = await import(
+			"../../src/telegram/media-detection.js"
+		));
+		__resetPatternCache();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+		if (ORIGINAL_MEDIA_OUTBOX === undefined) {
+			delete process.env.TELCLAUDE_MEDIA_OUTBOX_DIR;
+		} else {
+			process.env.TELCLAUDE_MEDIA_OUTBOX_DIR = ORIGINAL_MEDIA_OUTBOX;
+		}
+	});
+
+	/**
+	 * Simulates what the relay's buildAttachmentFilename does.
+	 * This ensures our test uses the same format as production.
+	 */
+	function buildAttachmentFilename(filename: string): string {
+		const ext = path.extname(filename);
+		const stem = ext ? filename.slice(0, -ext.length) : filename;
+		const timestamp = Date.now();
+		const hash = Math.random().toString(16).slice(2, 10);
+		return `${stem}-${timestamp}-${hash}${ext}`;
+	}
+
+	it("detects document when Claude outputs exact relay path", () => {
+		// 1. Simulate relay saving file with timestamp-hash
+		const originalFilename = "visit_summary.pdf";
+		const safeFilename = buildAttachmentFilename(originalFilename);
+		const destPath = path.join(documentsDir, safeFilename);
+		fs.writeFileSync(destPath, "fake pdf content");
+
+		// 2. Simulate Claude outputting the exact path from relay response
+		const claudeResponse = `Here's your document: ${destPath}`;
+
+		// 3. Verify media detection finds the file
+		const results = extractGeneratedMediaPaths(claudeResponse);
+		expect(results).toHaveLength(1);
+		expect(results[0].type).toBe("document");
+		expect(fs.existsSync(results[0].path)).toBe(true);
+	});
+
+	it("fails to detect when Claude invents a simplified filename", () => {
+		// 1. Relay saves with timestamp-hash
+		const safeFilename = buildAttachmentFilename("visit_summary.pdf");
+		const destPath = path.join(documentsDir, safeFilename);
+		fs.writeFileSync(destPath, "fake pdf content");
+
+		// 2. Claude incorrectly outputs simplified path (the bug we fixed)
+		const wrongPath = path.join(documentsDir, "visit_summary.pdf");
+		const claudeResponse = `Here's your document: ${wrongPath}`;
+
+		// 3. Media detection should NOT find this (file doesn't exist at that path)
+		const results = extractGeneratedMediaPaths(claudeResponse);
+		expect(results).toHaveLength(0);
+	});
+
+	it("detects document with various timestamp-hash formats", () => {
+		const testCases = [
+			"report-1769063570514-28c3d9c9.pdf",
+			"ENT_Visit_Summary-1769012656025-69f6831a.pdf",
+			"document-1737000000000-abcd1234.pdf",
+		];
+
+		for (const filename of testCases) {
+			const destPath = path.join(documentsDir, filename);
+			fs.writeFileSync(destPath, "fake content");
+
+			const claudeResponse = `Sending: ${destPath}`;
+			const results = extractGeneratedMediaPaths(claudeResponse);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].type).toBe("document");
+			fs.unlinkSync(destPath);
+		}
+	});
+
+	it("detects path as plain text without quotes or backticks", () => {
+		const safeFilename = buildAttachmentFilename("summary.pdf");
+		const destPath = path.join(documentsDir, safeFilename);
+		fs.writeFileSync(destPath, "fake pdf");
+
+		// Plain text (correct)
+		const plainText = `Your file: ${destPath}`;
+		expect(extractGeneratedMediaPaths(plainText)).toHaveLength(1);
+
+		// With backticks (should still work as path is extracted)
+		const withBackticks = `Your file: \`${destPath}\``;
+		const backticksResult = extractGeneratedMediaPaths(withBackticks);
+		// Note: backticks may interfere depending on regex - this documents behavior
+		expect(backticksResult.length).toBeGreaterThanOrEqual(0);
+	});
+});

--- a/tests/vault-daemon/protocol.test.ts
+++ b/tests/vault-daemon/protocol.test.ts
@@ -156,6 +156,17 @@ describe("Protocol schemas", () => {
 			});
 			expect(result.success).toBe(false);
 		});
+
+		it("should reject HTTP token endpoint (must be HTTPS)", () => {
+			const result = OAuth2CredentialSchema.safeParse({
+				type: "oauth2",
+				clientId: "client",
+				clientSecret: "secret",
+				refreshToken: "refresh",
+				tokenEndpoint: "http://oauth2.example.com/token",
+			});
+			expect(result.success).toBe(false);
+		});
 	});
 
 	describe("VaultRequestSchema", () => {

--- a/tests/vault-daemon/protocol.test.ts
+++ b/tests/vault-daemon/protocol.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for vault protocol schema validation.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+	CredentialEntrySchema,
+	HttpCredentialSchema,
+	makeStorageKey,
+	OAuth2CredentialSchema,
+	parseStorageKey,
+	VaultRequestSchema,
+	VaultResponseSchema,
+} from "../../src/vault-daemon/protocol.js";
+
+describe("Protocol schemas", () => {
+	describe("HttpCredentialSchema", () => {
+		it("should validate bearer credential", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "bearer",
+				token: "sk-12345",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate api-key credential", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "api-key",
+				token: "api-key-value",
+				header: "X-API-Key",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate basic credential", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "basic",
+				username: "user",
+				password: "pass",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate query credential", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "query",
+				token: "token-value",
+				param: "api_key",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject invalid type", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "invalid",
+				token: "test",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject empty token", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "bearer",
+				token: "",
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("OAuth2CredentialSchema", () => {
+		it("should validate complete oauth2 credential", () => {
+			const result = OAuth2CredentialSchema.safeParse({
+				type: "oauth2",
+				clientId: "client-123",
+				clientSecret: "secret-456",
+				refreshToken: "refresh-789",
+				tokenEndpoint: "https://oauth2.example.com/token",
+				scope: "email profile",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate oauth2 without optional scope", () => {
+			const result = OAuth2CredentialSchema.safeParse({
+				type: "oauth2",
+				clientId: "client",
+				clientSecret: "secret",
+				refreshToken: "refresh",
+				tokenEndpoint: "https://oauth2.example.com/token",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject invalid token endpoint URL", () => {
+			const result = OAuth2CredentialSchema.safeParse({
+				type: "oauth2",
+				clientId: "client",
+				clientSecret: "secret",
+				refreshToken: "refresh",
+				tokenEndpoint: "not-a-url",
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("VaultRequestSchema", () => {
+		it("should validate get request", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "get",
+				protocol: "http",
+				target: "api.example.com",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate get-token request", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "get-token",
+				protocol: "http",
+				target: "api.example.com",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate store request", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "store",
+				protocol: "http",
+				target: "api.example.com",
+				credential: {
+					type: "bearer",
+					token: "test-token",
+				},
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate delete request", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "delete",
+				protocol: "http",
+				target: "api.example.com",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate list request without filter", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "list",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate list request with protocol filter", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "list",
+				protocol: "postgres",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate ping request", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "ping",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject unknown request type", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "unknown",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject invalid protocol", () => {
+			const result = VaultRequestSchema.safeParse({
+				type: "get",
+				protocol: "invalid",
+				target: "test",
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("VaultResponseSchema", () => {
+		it("should validate get success response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "get",
+				ok: true,
+				entry: {
+					protocol: "http",
+					target: "api.example.com",
+					credential: { type: "bearer", token: "test" },
+					createdAt: new Date().toISOString(),
+				},
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate get not found response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "get",
+				ok: false,
+				error: "not_found",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate get-token success response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "get-token",
+				ok: true,
+				token: "access-token-123",
+				expiresAt: Date.now() + 3600000,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate get-token error response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "get-token",
+				ok: false,
+				error: "Token refresh failed",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate store response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "store",
+				ok: true,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate delete response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "delete",
+				ok: true,
+				deleted: true,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate list response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "list",
+				ok: true,
+				entries: [
+					{
+						protocol: "http",
+						target: "api.example.com",
+						credentialType: "bearer",
+						createdAt: new Date().toISOString(),
+					},
+				],
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate pong response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "pong",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate error response", () => {
+			const result = VaultResponseSchema.safeParse({
+				type: "error",
+				error: "Something went wrong",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("CredentialEntrySchema", () => {
+		it("should validate complete entry with all optional fields", () => {
+			const result = CredentialEntrySchema.safeParse({
+				protocol: "http",
+				target: "api.example.com",
+				label: "Example API",
+				credential: { type: "bearer", token: "test" },
+				allowedPaths: ["^/v1/.*"],
+				rateLimitPerMinute: 60,
+				createdAt: new Date().toISOString(),
+				expiresAt: new Date(Date.now() + 86400000).toISOString(),
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should validate minimal entry", () => {
+			const result = CredentialEntrySchema.safeParse({
+				protocol: "postgres",
+				target: "db.example.com:5432",
+				credential: {
+					type: "db",
+					username: "admin",
+					password: "pass",
+				},
+				createdAt: new Date().toISOString(),
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("makeStorageKey / parseStorageKey", () => {
+		it("should create and parse http key", () => {
+			const key = makeStorageKey("http", "api.example.com");
+			expect(key).toBe("http:api.example.com");
+
+			const parsed = parseStorageKey(key);
+			expect(parsed).toEqual({
+				protocol: "http",
+				target: "api.example.com",
+			});
+		});
+
+		it("should create and parse postgres key with port", () => {
+			const key = makeStorageKey("postgres", "db.example.com:5432");
+			expect(key).toBe("postgres:db.example.com:5432");
+
+			const parsed = parseStorageKey(key);
+			expect(parsed).toEqual({
+				protocol: "postgres",
+				target: "db.example.com:5432",
+			});
+		});
+
+		it("should return null for invalid key format", () => {
+			expect(parseStorageKey("no-colon")).toBeNull();
+		});
+
+		it("should return null for invalid protocol", () => {
+			expect(parseStorageKey("invalid:target")).toBeNull();
+		});
+	});
+});

--- a/tests/vault-daemon/protocol.test.ts
+++ b/tests/vault-daemon/protocol.test.ts
@@ -66,6 +66,60 @@ describe("Protocol schemas", () => {
 			});
 			expect(result.success).toBe(false);
 		});
+
+		it("should reject api-key with invalid header name (injection attempt)", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "api-key",
+				token: "test",
+				header: "X-API-Key\r\nX-Injected: evil",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject api-key with header containing spaces", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "api-key",
+				token: "test",
+				header: "X API Key",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should accept api-key with valid RFC7230 token header", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "api-key",
+				token: "test",
+				header: "X-Custom_Header.Name",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject query param with injection characters", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "query",
+				token: "test",
+				param: "key&injected=evil",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject query param with equals sign", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "query",
+				token: "test",
+				param: "key=value",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should accept query param with underscore and hyphen", () => {
+			const result = HttpCredentialSchema.safeParse({
+				type: "query",
+				token: "test",
+				param: "api_key-v2",
+			});
+			expect(result.success).toBe(true);
+		});
 	});
 
 	describe("OAuth2CredentialSchema", () => {

--- a/tests/vault-daemon/store.test.ts
+++ b/tests/vault-daemon/store.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for vault store encryption and persistence.
+ */
+
+import { mkdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resetVaultStore, VaultStore } from "../../src/vault-daemon/store.js";
+
+const TEST_DIR = join(process.cwd(), ".test-vault");
+const TEST_FILE = join(TEST_DIR, "vault.json");
+const TEST_KEY = "test-encryption-key-at-least-32-chars";
+
+describe("VaultStore", () => {
+	beforeEach(() => {
+		// Clean up and create test directory
+		try {
+			rmSync(TEST_DIR, { recursive: true });
+		} catch {
+			// Ignore if doesn't exist
+		}
+		mkdirSync(TEST_DIR, { recursive: true });
+		resetVaultStore();
+	});
+
+	afterEach(() => {
+		resetVaultStore();
+		try {
+			rmSync(TEST_DIR, { recursive: true });
+		} catch {
+			// Ignore
+		}
+	});
+
+	it("should store and retrieve a bearer credential", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store("http", "api.openai.com", {
+			type: "bearer",
+			token: "sk-secret-token-12345",
+		});
+
+		const entry = await store.get("http", "api.openai.com");
+
+		expect(entry).not.toBeNull();
+		expect(entry?.protocol).toBe("http");
+		expect(entry?.target).toBe("api.openai.com");
+		expect(entry?.credential.type).toBe("bearer");
+		expect((entry?.credential as { token: string }).token).toBe("sk-secret-token-12345");
+	});
+
+	it("should store and retrieve an api-key credential", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store("http", "api.anthropic.com", {
+			type: "api-key",
+			token: "sk-ant-api-key",
+			header: "x-api-key",
+		});
+
+		const entry = await store.get("http", "api.anthropic.com");
+
+		expect(entry).not.toBeNull();
+		expect(entry?.credential.type).toBe("api-key");
+		const cred = entry?.credential as { token: string; header: string };
+		expect(cred.token).toBe("sk-ant-api-key");
+		expect(cred.header).toBe("x-api-key");
+	});
+
+	it("should return null for non-existent credential", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		const entry = await store.get("http", "nonexistent.com");
+		expect(entry).toBeNull();
+	});
+
+	it("should delete a credential", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store("http", "api.example.com", {
+			type: "bearer",
+			token: "test-token",
+		});
+
+		// Verify it exists
+		expect(await store.has("http", "api.example.com")).toBe(true);
+
+		// Delete it
+		const deleted = await store.delete("http", "api.example.com");
+		expect(deleted).toBe(true);
+
+		// Verify it's gone
+		expect(await store.has("http", "api.example.com")).toBe(false);
+		expect(await store.get("http", "api.example.com")).toBeNull();
+	});
+
+	it("should list credentials without exposing secrets", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store(
+			"http",
+			"api.openai.com",
+			{ type: "bearer", token: "secret-1" },
+			{ label: "OpenAI API" },
+		);
+		await store.store(
+			"http",
+			"api.github.com",
+			{ type: "bearer", token: "secret-2" },
+			{ label: "GitHub API" },
+		);
+
+		const entries = await store.list();
+
+		expect(entries).toHaveLength(2);
+
+		// List should not expose tokens
+		const openai = entries.find((e) => e.target === "api.openai.com");
+		expect(openai).toBeDefined();
+		expect(openai?.credentialType).toBe("bearer");
+		expect(openai?.label).toBe("OpenAI API");
+		expect((openai as Record<string, unknown>).token).toBeUndefined();
+	});
+
+	it("should filter list by protocol", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store("http", "api.example.com", { type: "bearer", token: "t1" });
+		await store.store("postgres", "db.example.com:5432", {
+			type: "db",
+			username: "admin",
+			password: "pass",
+		});
+
+		const httpOnly = await store.list("http");
+		expect(httpOnly).toHaveLength(1);
+		expect(httpOnly[0].protocol).toBe("http");
+
+		const postgresOnly = await store.list("postgres");
+		expect(postgresOnly).toHaveLength(1);
+		expect(postgresOnly[0].protocol).toBe("postgres");
+	});
+
+	it("should persist and survive store recreation", async () => {
+		const store1 = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store1.store("http", "api.test.com", {
+			type: "bearer",
+			token: "persistent-token",
+		});
+
+		// Create a new store instance (simulating process restart)
+		resetVaultStore();
+		const store2 = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		const entry = await store2.get("http", "api.test.com");
+		expect(entry).not.toBeNull();
+		expect((entry?.credential as { token: string }).token).toBe("persistent-token");
+	});
+
+	it("should fail with wrong encryption key", async () => {
+		const store1 = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store1.store("http", "api.test.com", {
+			type: "bearer",
+			token: "secret",
+		});
+
+		// Create a new store with different key
+		resetVaultStore();
+		const store2 = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: "wrong-key-that-is-at-least-32-chars",
+		});
+
+		// Should return null (decryption fails)
+		const entry = await store2.get("http", "api.test.com");
+		expect(entry).toBeNull();
+	});
+
+	it("should set file permissions to 0600", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store("http", "api.test.com", {
+			type: "bearer",
+			token: "test",
+		});
+
+		const stats = statSync(TEST_FILE);
+		const mode = stats.mode & 0o777;
+		expect(mode).toBe(0o600);
+	});
+
+	it("should store oauth2 credentials", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store("http", "api.google.com", {
+			type: "oauth2",
+			clientId: "client-123",
+			clientSecret: "secret-456",
+			refreshToken: "refresh-789",
+			tokenEndpoint: "https://oauth2.googleapis.com/token",
+			scope: "email profile",
+		});
+
+		const entry = await store.get("http", "api.google.com");
+		expect(entry).not.toBeNull();
+		expect(entry?.credential.type).toBe("oauth2");
+
+		const cred = entry?.credential as {
+			clientId: string;
+			clientSecret: string;
+			refreshToken: string;
+		};
+		expect(cred.clientId).toBe("client-123");
+		expect(cred.clientSecret).toBe("secret-456");
+		expect(cred.refreshToken).toBe("refresh-789");
+	});
+
+	it("should store with optional metadata", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store(
+			"http",
+			"api.limited.com",
+			{ type: "bearer", token: "test" },
+			{
+				label: "Rate Limited API",
+				allowedPaths: ["^/v1/safe/.*", "^/v2/also-safe/.*"],
+				rateLimitPerMinute: 60,
+			},
+		);
+
+		const entry = await store.get("http", "api.limited.com");
+		expect(entry?.label).toBe("Rate Limited API");
+		expect(entry?.allowedPaths).toEqual(["^/v1/safe/.*", "^/v2/also-safe/.*"]);
+		expect(entry?.rateLimitPerMinute).toBe(60);
+	});
+});


### PR DESCRIPTION
## Summary

Implements a credential vault system that stores credentials securely and injects them into HTTP requests transparently. Agents never see raw credentials.

### Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│ VAULT DAEMON (Unix socket only)                                 │
│  • AES-256-GCM encrypted credential store                       │
│  • OAuth2 token refresh with caching                            │
│  • NDJSON protocol over Unix socket                             │
└─────────────────────────────────────────────────────────────────┘
              │ Unix socket
              ▼
┌─────────────────────────────────────────────────────────────────┐
│ HTTP CREDENTIAL PROXY (port 8792)                               │
│  • Pattern: http://relay:8792/{host}/{path}                     │
│  • Looks up credential, injects auth header                     │
│  • Forwards to https://{host}/{path}                            │
└─────────────────────────────────────────────────────────────────┘
```

### Supported Credential Types

| Type | Auth Injection |
|------|----------------|
| `bearer` | `Authorization: Bearer {token}` |
| `api-key` | `{header}: {token}` |
| `basic` | `Authorization: Basic {base64}` |
| `query` | `?{param}={token}` |
| `oauth2` | Bearer with automatic token refresh |

### Security Features (Expert Reviewed)

- **SSRF Prevention**: Redirects disabled (`redirect: "manual"`)
- **Input Validation**: RFC7230 header validation, safe query param regex
- **Store Locking**: Mutex + atomic writes (write to .tmp, then rename)
- **OAuth Race Prevention**: In-flight deduplication + CAS check
- **Session Token Gating**: Requires `x-telclaude-session` header
- **Body Size Limits**: 10MB max via SizeLimitingTransform
- **HTTPS Enforcement**: OAuth tokenEndpoint must use HTTPS
- **Error Sanitization**: URLs redacted from error messages

### Files Added/Modified

- `src/vault-daemon/` - Vault daemon implementation
- `src/relay/http-credential-proxy.ts` - HTTP proxy server
- `src/utils.ts` - Shared sanitizeError utility
- `tests/vault-daemon/` - Test coverage

## Test plan

- [x] All 308 tests pass
- [x] TypeScript compiles without errors
- [x] Expert security review completed (8 findings addressed)
- [x] Codex peer review: LGTM
- [x] Code simplification review: LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)