### PR TITLE
chore: add funding field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
     "url": "https://github.com/avivsinai/telclaude/issues"
   },
   "homepage": "https://github.com/avivsinai/telclaude#readme",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/avivsinai"
+  },
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
## Summary
- Add `funding` field pointing to GitHub Sponsors
- Note: `homepage`, `bugs`, and `repository` fields were already present

## Test plan
- [ ] Verify `npm fund` shows the correct funding URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)