### PR TITLE
feat: OpenClaw security backport sprint — 6 hardening features

### DIFF
--- a/docs/plans/2026-02-17-openclaw-security-backport.md
+++ b/docs/plans/2026-02-17-openclaw-security-backport.md
@@ -1,0 +1,239 @@
+# OpenClaw Security Backport Plan
+
+**Date**: 2026-02-17
+**Status**: v2 (incorporates Codex review)
+**Scope**: Security-focused features from OpenClaw worth backporting to telclaude
+**Prior art**: PR #34 (`1306a85`) already backported external-content wrapping, homoglyphs, skill scanner, bash chain analysis, skill write protection
+
+## Context
+
+Two independent agents (Claude + Codex) evaluated OpenClaw's codebase for backport candidates. This plan covers the security-focused items both agents agreed on, with effort estimates adjusted after reading telclaude's existing code.
+
+### Key Finding: SSRF Gap Is Narrower Than Estimated
+
+Both agents initially ranked "SSRF DNS pinning" as the #1 security gap. After reading telclaude's `src/sandbox/network-proxy.ts` and `src/sandbox/config.ts`, the gap is narrower:
+
+**Telclaude already has:**
+- DNS resolution with `{all: true}` via `cachedDNSLookup()` — validates ALL resolved IPs
+- DNS cache (60s TTL) to prevent rebinding attacks
+- IP canonicalization via ip-num to block hex/octal obfuscation
+- Non-overridable metadata blocks (169.254.x.x can never be allowlisted)
+- Private endpoint allowlist with CIDR + port enforcement
+- IPv4-mapped IPv6 detection (`::ffff:192.168.1.1`)
+- Self-test suite and doctor integration
+
+**What OpenClaw adds that we lack:**
+1. **DNS-pinned fetch dispatcher** — undici `Agent` with pinned `lookup`, ensuring the actual TCP connection uses the validated IPs (not a re-resolved set)
+2. **Redirect hop re-validation** — `fetchWithSsrFGuard()` sets `redirect: "manual"`, re-resolves and re-validates DNS at each hop
+3. **Integrated guarded fetch** — single `fetchWithSsrFGuard()` primitive that all outbound HTTP should use
+
+---
+
+## Task 1: DNS-Pinned Fetch Guard
+
+**Priority**: High
+**Effort**: Small-Medium (mostly integration, core primitives exist)
+**OpenClaw source**: `src/infra/net/ssrf.ts` (pinned dispatcher), `src/infra/net/fetch-guard.ts` (redirect guard)
+
+### What
+
+Create a `fetchWithGuard()` function that:
+1. Resolves hostname via existing `cachedDNSLookup()`
+2. Validates all resolved IPs via existing `isBlockedIP()` / `isNonOverridableBlock()`
+3. Creates an undici `Agent` with a pinned DNS `lookup` callback (so the TCP connection uses exactly the validated IPs)
+4. Follows redirects manually (`redirect: "manual"`), re-validating each hop's hostname
+5. Caps redirect count (default 3), detects loops
+6. Returns response + cleanup function for the dispatcher
+
+### Where in telclaude
+
+- New: `src/sandbox/fetch-guard.ts` — the guarded fetch primitive
+- Modify: `src/sandbox/network-proxy.ts` — export `createPinnedLookup()` helper (OpenClaw's pattern)
+- Modify: `src/sandbox/index.ts` — re-export fetch guard
+
+### Consumers (adopt incrementally, highest risk first)
+
+1. `src/services/summarize.ts` — fetches arbitrary user-provided URLs (highest SSRF risk)
+2. `src/commands/summarize.ts` — CLI path calls `summarizeUrl` directly
+3. `src/relay/http-credential-proxy.ts` — proxies authenticated requests to upstream hosts
+4. `src/relay/provider-proxy.ts` — already has `validateProviderBaseUrl()` with private-IP checks, so lower incremental value
+5. `src/relay/anthropic-proxy.ts` — fixed host (`api.anthropic.com`), lowest priority
+
+### Acceptance criteria
+
+- [ ] `fetchWithGuard()` resolves all IPs, blocks private/metadata, pins DNS to connection
+- [ ] Redirect hops are individually validated (hostname resolves to new IPs, all checked)
+- [ ] Redirect loop detection and max-redirect cap
+- [ ] Timeout support via AbortSignal
+- [ ] Tests: private IP redirect bypass, DNS rebinding simulation, loop detection, normal happy path
+- [ ] Existing `cachedDNSLookup` + `isBlockedIP` reused (no duplication)
+
+---
+
+## Task 2: Sandbox Posture Audit (Static)
+
+**Priority**: High
+**Effort**: Small
+**OpenClaw source**: `src/agents/sandbox/validate-sandbox-security.ts`
+
+### What
+
+> **Codex review note**: Telclaude has no runtime Docker container-creation path to hook. `src/sandbox/mode.ts` only detects docker/native mode. Re-scoped from "runtime validator" to static `doctor --security` checks against compose/env/sandbox posture.
+
+Static audit checks for `doctor --security` that flag:
+- `docker-compose.yml`: host network mode, privileged flag, unconfined seccomp/AppArmor
+- Bind mount analysis: resolve symlinks in compose volume mounts, check for escape to host root, Docker socket mount
+- Environment posture: sensitive env vars exposed to agent containers, permissive network mode without justification
+
+### Where in telclaude
+
+- New: `src/sandbox/validate-config.ts` — static validation functions (reads compose file + env)
+- Modify: `src/commands/doctor.ts` — integrate as a `--security` check
+- Input: `docker/docker-compose.yml` and `docker/.env` (parsed, not executed)
+
+### Acceptance criteria
+
+- [ ] Parses docker-compose.yml and flags dangerous settings (host network, privileged, seccomp)
+- [ ] Resolves symlinks in bind mount paths, detects escape to host root or sensitive dirs
+- [ ] Flags Docker socket bind mount (`/var/run/docker.sock`)
+- [ ] Returns structured findings (severity + description) for doctor output
+- [ ] Tests: known-bad compose configs produce findings, clean config passes
+
+---
+
+## Task 3: Inbound Message Sanitization
+
+**Priority**: Medium
+**Effort**: Small
+**Dependencies**: Homoglyph library already backported in PR #34
+
+### What
+
+Apply `foldHomoglyphs()` and zero-width character stripping to inbound Telegram messages before they reach the security pipeline. Currently we have the library but don't use it on input.
+
+> **Codex review note**: `src/telegram/auto-reply.ts` uses `msg.body` for command parsing (`/approve`, `/link`, `/otp`). Global mutation would break command semantics. Use dual-field: raw body for command parsing + audit, normalized body for observer/classification/prompting.
+
+### Where in telclaude
+
+- Modify: `src/telegram/inbound.ts` — add `normalizedBody` field early in pipeline
+- Modify: observer/classification code — use `normalizedBody` instead of raw `body`
+- Do NOT modify: `src/telegram/auto-reply.ts` command parsing (keeps raw `body`)
+- Reuse: `src/security/homoglyphs.ts` — already has `foldHomoglyphs()`, `containsHomoglyphs()`
+
+### Acceptance criteria
+
+- [ ] Inbound messages carry both `body` (raw) and `normalizedBody` (sanitized)
+- [ ] Observer/classification uses `normalizedBody`; command parsing uses raw `body`
+- [ ] Zero-width chars stripped (U+200B, U+200C, U+200D, U+FEFF, etc.)
+- [ ] Fullwidth ASCII folded to ASCII equivalents
+- [ ] Original message preserved in audit log
+- [ ] Detection logged (not blocked — just normalized)
+- [ ] Tests: message with homoglyphs is folded, command messages still parse correctly
+
+---
+
+## Task 4: Deep Security Audit Collectors
+
+**Priority**: Medium
+**Effort**: Medium
+**OpenClaw source**: `src/security/audit.ts`, `src/security/audit-extra.*.ts`
+
+### What
+
+Structured, severity-based audit collectors for `doctor --security`:
+- Config audit: dangerous sandbox settings, exposed ports, permissive network mode
+- Filesystem audit: permission checks on config/auth/session files
+- Plugin/skill trust: skill signature verification, untrusted skill detection
+- Hook hardening: check for disableAllHooks bypass vectors
+- Exposure matrix: which tiers have access to which capabilities
+
+### Where in telclaude
+
+- New: `src/commands/audit-collectors.ts` — structured collectors returning `{severity, category, message, fix?}`
+- Modify: `src/commands/doctor.ts` — integrate collectors into `--security` output
+
+### Acceptance criteria
+
+- [ ] Collectors return structured findings with severity levels (critical/warning/info)
+- [ ] Config, filesystem, skill trust, hook hardening checks implemented
+- [ ] Doctor output groups by severity, actionable descriptions
+- [ ] Tests: known-vulnerable config produces critical findings, clean config passes
+
+---
+
+## Task 5: Security Auto-Remediation
+
+**Priority**: Low (depends on Task 4)
+**Effort**: Medium
+**OpenClaw source**: `src/security/fix.ts`
+
+### What
+
+`doctor --security --fix` that automatically applies safe remediations:
+- Tighten file permissions on config/auth files
+- Set conservative config defaults for flagged settings
+- Report what was changed
+
+### Where in telclaude
+
+- Modify: `src/commands/doctor.ts` — add `--fix` flag
+- New: `src/commands/audit-fixers.ts` — remediation functions per finding type
+
+### Acceptance criteria
+
+- [ ] No-op by default — only applies fixes when `--fix` is explicitly passed
+- [ ] Only applies "safe" fixes (permission tightening, conservative defaults)
+- [ ] Reports each fix applied with before/after state
+- [ ] Config writes use atomic write + backup (write to `.tmp`, rename, keep `.bak`)
+- [ ] Tests: verify fixes are applied correctly, verify no data loss, verify backup created
+
+---
+
+## Task 6: Stream Output Size Guard
+
+**Priority**: Medium
+**Effort**: Medium (scoped down from Large)
+**OpenClaw source**: `src/agents/session-tool-result-guard.ts`, `src/agents/pi-embedded-runner/tool-result-truncation.ts`
+
+> **Codex review note**: Telclaude's `session-manager.ts` doesn't own transcript storage — SDK handles persistence. Transcript repair (patching stored transcripts) is not viable from our wrapper layer. Re-scoped to what's SDK-feasible: output/tool-result size guards in stream handling, and context overflow recovery.
+
+### What
+
+Guards in the stream handling layer:
+- Cap oversized tool-result content in streaming responses before they exhaust context
+- Detect context overflow errors and trigger graceful recovery (session reset with summary)
+- Log truncation events for debugging
+
+### Where in telclaude
+
+- New: `src/sdk/output-guard.ts` — tool-result size cap + truncation logic
+- Modify: `src/sdk/client.ts` — integrate guard in stream processing hooks
+- Modify: `src/sdk/session-manager.ts` — overflow detection → recovery path
+
+### Acceptance criteria
+
+- [ ] Oversized tool results truncated with configurable size cap
+- [ ] Context overflow detected and triggers graceful recovery (not crash)
+- [ ] Truncation events logged with original size for debugging
+- [ ] Tests: size cap enforcement, overflow recovery path
+
+---
+
+## Implementation Order
+
+Updated per Codex review — summarize path first for Task 1, dual-field for Task 3:
+
+```
+Task 1 (fetch guard — summarize path first) ─┐── Sprint 1 (security hardening)
+Task 3 (inbound sanitize — dual-field)  ─────┘
+
+Task 2 (sandbox posture audit — static)  ────┐── Sprint 2 (observability)
+Task 4 (deep audit collectors)  ─────────────┤
+Task 5 (auto-fix, depends on Task 4)  ───────┘
+
+Task 6 (stream output size guard)  ──────────── Sprint 3 (robustness)
+```
+
+## Non-Security Features
+
+A separate evaluation is tracking non-security features (Telegram UX, auth rotation, cron, inline buttons, etc.) in a parallel analysis.

--- a/src/commands/audit-collectors.ts
+++ b/src/commands/audit-collectors.ts
@@ -1,0 +1,680 @@
+/**
+ * Deep security audit collectors for `doctor --security`.
+ *
+ * Each collector returns structured findings with severity levels,
+ * category, and optional remediation. Inspired by OpenClaw's
+ * audit-extra pattern, adapted to telclaude's architecture.
+ *
+ * Categories:
+ *   config   — dangerous settings, permissive modes, missing security
+ *   fs       — file permission issues on config/auth/data files
+ *   skills   — untrusted or malicious skill patterns
+ *   hooks    — disableAllHooks bypass vectors, settings isolation
+ *   exposure — tier-to-capability mapping, over-permissive configs
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { TelclaudeConfig } from "../config/config.js";
+import { getSandboxMode } from "../sandbox/index.js";
+import { auditSandboxPosture } from "../sandbox/validate-config.js";
+import { TIER_TOOLS } from "../security/permissions.js";
+import { scanAllSkills } from "../security/skill-scanner.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export type AuditSeverity = "critical" | "warning" | "info";
+
+export type AuditFinding = {
+	/** Severity level: critical requires immediate action, warning is best-effort, info is informational. */
+	severity: AuditSeverity;
+	/** Category grouping (config, fs, skills, hooks, exposure). */
+	category: string;
+	/** Human-readable description of the finding. */
+	message: string;
+	/** Optional remediation instruction. */
+	fix?: string;
+};
+
+export type AuditReport = {
+	findings: AuditFinding[];
+	summary: Record<AuditSeverity, number>;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function countBySeverity(findings: AuditFinding[]): Record<AuditSeverity, number> {
+	let critical = 0;
+	let warning = 0;
+	let info = 0;
+	for (const f of findings) {
+		if (f.severity === "critical") critical++;
+		else if (f.severity === "warning") warning++;
+		else info++;
+	}
+	return { critical, warning, info };
+}
+
+function checkFilePermissions(filePath: string, label: string, category: string): AuditFinding[] {
+	const findings: AuditFinding[] = [];
+	if (!fs.existsSync(filePath)) return findings;
+
+	try {
+		const stat = fs.lstatSync(filePath);
+
+		// Symlink check
+		if (stat.isSymbolicLink()) {
+			findings.push({
+				severity: "warning",
+				category,
+				message: `${label} is a symlink — ensure you trust the target`,
+				fix: `Verify symlink target: readlink ${filePath}`,
+			});
+			return findings;
+		}
+
+		const mode = stat.mode & 0o777;
+		const worldWritable = (mode & 0o002) !== 0;
+		const worldReadable = (mode & 0o004) !== 0;
+		const groupWritable = (mode & 0o020) !== 0;
+		const groupReadable = (mode & 0o040) !== 0;
+
+		if (worldWritable || groupWritable) {
+			findings.push({
+				severity: "critical",
+				category,
+				message: `${label} is writable by others (mode ${mode.toString(8)})`,
+				fix: `chmod ${stat.isDirectory() ? "700" : "600"} ${filePath}`,
+			});
+		} else if (worldReadable) {
+			findings.push({
+				severity: "critical",
+				category,
+				message: `${label} is world-readable (mode ${mode.toString(8)})`,
+				fix: `chmod ${stat.isDirectory() ? "700" : "600"} ${filePath}`,
+			});
+		} else if (groupReadable) {
+			findings.push({
+				severity: "warning",
+				category,
+				message: `${label} is group-readable (mode ${mode.toString(8)})`,
+				fix: `chmod ${stat.isDirectory() ? "700" : "600"} ${filePath}`,
+			});
+		}
+	} catch {
+		// Cannot stat — skip
+	}
+
+	return findings;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Config collectors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function collectConfigFindings(
+	cfg: TelclaudeConfig,
+	env: NodeJS.ProcessEnv = process.env,
+): AuditFinding[] {
+	const findings: AuditFinding[] = [];
+
+	// 1. Test profile in production
+	if (cfg.security.profile === "test") {
+		const isTestEnvEnabled = env.TELCLAUDE_ENABLE_TEST_PROFILE === "1";
+		findings.push({
+			severity: isTestEnvEnabled ? "warning" : "critical",
+			category: "config",
+			message: "Security profile is 'test' — ALL security layers disabled",
+			fix: "Set security.profile to 'simple' or 'strict' for production use",
+		});
+	}
+
+	// 2. Permissive network mode
+	const networkMode = env.TELCLAUDE_NETWORK_MODE;
+	if (networkMode === "open") {
+		findings.push({
+			severity: "critical",
+			category: "config",
+			message: "TELCLAUDE_NETWORK_MODE=open — wildcard egress enabled, only metadata blocked",
+			fix: "Remove TELCLAUDE_NETWORK_MODE or set to 'permissive' for tighter control",
+		});
+	} else if (networkMode === "permissive") {
+		findings.push({
+			severity: "warning",
+			category: "config",
+			message: "TELCLAUDE_NETWORK_MODE=permissive — broader WebFetch egress allowed",
+			fix: "Remove TELCLAUDE_NETWORK_MODE for strict allowlist enforcement",
+		});
+	}
+
+	// 3. Observer disabled in strict profile
+	if (cfg.security.profile === "strict" && cfg.security.observer?.enabled === false) {
+		findings.push({
+			severity: "warning",
+			category: "config",
+			message: "Observer is disabled in strict profile — LLM classification will not run",
+			fix: "Remove security.observer.enabled or set to true",
+		});
+	}
+
+	// 4. Default tier too permissive
+	const defaultTier = cfg.security.permissions?.defaultTier ?? "READ_ONLY";
+	if (defaultTier === "FULL_ACCESS") {
+		findings.push({
+			severity: "critical",
+			category: "config",
+			message: "Default permission tier is FULL_ACCESS — all users get unrestricted access",
+			fix: "Set security.permissions.defaultTier to READ_ONLY or WRITE_LOCAL",
+		});
+	} else if (defaultTier === "WRITE_LOCAL") {
+		findings.push({
+			severity: "warning",
+			category: "config",
+			message: "Default permission tier is WRITE_LOCAL — new users can write files by default",
+			fix: "Consider setting security.permissions.defaultTier to READ_ONLY",
+		});
+	}
+
+	// 5. Rate limits disabled or very high
+	if (!cfg.security.rateLimits?.perUser) {
+		findings.push({
+			severity: "info",
+			category: "config",
+			message: "Per-user rate limits not configured — using defaults",
+		});
+	} else {
+		const perMin = cfg.security.rateLimits.perUser.perMinute;
+		if (perMin !== undefined && perMin > 30) {
+			findings.push({
+				severity: "warning",
+				category: "config",
+				message: `Per-user rate limit is high (${perMin}/min) — consider lowering for cost control`,
+			});
+		}
+	}
+
+	// 6. Audit logging disabled
+	if (cfg.security.audit?.enabled === false) {
+		findings.push({
+			severity: "warning",
+			category: "config",
+			message: "Audit logging is disabled — no forensic trail for security events",
+			fix: "Set security.audit.enabled to true",
+		});
+	}
+
+	// 7. Exposed sensitive env vars (when running as relay — not in agent containers)
+	const sensitiveEnvVars = [
+		"TELEGRAM_BOT_TOKEN",
+		"ANTHROPIC_API_KEY",
+		"OPENAI_API_KEY",
+		"GITHUB_TOKEN",
+		"GH_TOKEN",
+	];
+	const exposedVars = sensitiveEnvVars.filter((v) => env[v]);
+	if (exposedVars.length > 0) {
+		findings.push({
+			severity: "info",
+			category: "config",
+			message: `Sensitive env vars present: ${exposedVars.join(", ")}`,
+		});
+	}
+
+	// 8. Video processing enabled (FFmpeg security risk)
+	if (cfg.videoProcessing?.enabled === true) {
+		findings.push({
+			severity: "warning",
+			category: "config",
+			message: "Video processing is enabled — FFmpeg runs unsandboxed with parsing vulnerabilities",
+			fix: "Disable videoProcessing unless you trust all users in allowedChats",
+		});
+	}
+
+	// 9. TOTP session TTL very long
+	const totpTtl = cfg.security.totp?.sessionTtlMinutes;
+	if (totpTtl !== undefined && totpTtl > 480) {
+		findings.push({
+			severity: "warning",
+			category: "config",
+			message: `TOTP session TTL is ${totpTtl} minutes (${(totpTtl / 60).toFixed(1)}h) — consider shortening`,
+			fix: "Set security.totp.sessionTtlMinutes to 240 or less",
+		});
+	}
+
+	return findings;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Filesystem collectors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function collectFilesystemFindings(cwd: string): AuditFinding[] {
+	const findings: AuditFinding[] = [];
+	const homeDir = os.homedir();
+
+	// Config files
+	const configPaths = [
+		{ label: "telclaude.json (policy config)", path: path.join(cwd, "docker", "telclaude.json") },
+		{
+			label: "telclaude-private.json (private config)",
+			path: path.join(cwd, "docker", "telclaude-private.json"),
+		},
+		{ label: "docker/.env (secrets)", path: path.join(cwd, "docker", ".env") },
+	];
+
+	for (const { label, path: filePath } of configPaths) {
+		findings.push(...checkFilePermissions(filePath, label, "fs"));
+	}
+
+	// Sensitive system paths
+	const sensitivePaths = [
+		{ label: "SSH directory", path: path.join(homeDir, ".ssh") },
+		{ label: "AWS credentials", path: path.join(homeDir, ".aws", "credentials") },
+		{ label: "telclaude database", path: path.join(homeDir, ".telclaude", "telclaude.db") },
+		{ label: "telclaude data dir", path: path.join(homeDir, ".telclaude") },
+	];
+
+	for (const { label, path: filePath } of sensitivePaths) {
+		findings.push(...checkFilePermissions(filePath, label, "fs"));
+	}
+
+	// Audit log directory permissions
+	const auditLogDir = path.join(homeDir, ".telclaude", "logs");
+	findings.push(...checkFilePermissions(auditLogDir, "Audit log directory", "fs"));
+
+	// Check for .env in project root (common mistake)
+	const rootEnv = path.join(cwd, ".env");
+	if (fs.existsSync(rootEnv)) {
+		findings.push({
+			severity: "warning",
+			category: "fs",
+			message: ".env file exists in project root — secrets may be committed to git",
+			fix: "Ensure .env is in .gitignore and move secrets to docker/.env",
+		});
+	}
+
+	return findings;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Skill trust collectors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function collectSkillTrustFindings(cwd: string): AuditFinding[] {
+	const findings: AuditFinding[] = [];
+
+	const skillRoots = [
+		path.join(cwd, ".claude", "skills"),
+		path.join(cwd, ".claude", "skills-draft"),
+	];
+
+	// Also check CLAUDE_CONFIG_DIR skills (Docker profiles)
+	const configDir = process.env.CLAUDE_CONFIG_DIR;
+	if (configDir) {
+		skillRoots.push(path.join(configDir, "skills"));
+	}
+
+	let totalSkills = 0;
+	let blockedSkills = 0;
+	let warningSkills = 0;
+
+	for (const root of skillRoots) {
+		if (!fs.existsSync(root)) continue;
+
+		const results = scanAllSkills(root);
+		for (const result of results) {
+			totalSkills++;
+			if (result.blocked) {
+				blockedSkills++;
+				findings.push({
+					severity: "critical",
+					category: "skills",
+					message: `Skill "${result.skillName}" contains dangerous patterns (${result.counts.critical} critical, ${result.counts.high} high)`,
+					fix: `Review and remove: ${result.skillPath}`,
+				});
+			} else if (result.counts.medium > 0 || result.counts.info > 0) {
+				warningSkills++;
+				findings.push({
+					severity: "warning",
+					category: "skills",
+					message: `Skill "${result.skillName}" has ${result.counts.medium} medium, ${result.counts.info} info findings`,
+					fix: `Review: ${result.skillPath}`,
+				});
+			}
+		}
+	}
+
+	// Skills-draft directory exists — draft skills are unvetted
+	const draftDir = path.join(cwd, ".claude", "skills-draft");
+	if (fs.existsSync(draftDir)) {
+		try {
+			const entries = fs.readdirSync(draftDir, { withFileTypes: true });
+			const draftCount = entries.filter((e) => e.isDirectory()).length;
+			if (draftCount > 0) {
+				findings.push({
+					severity: "warning",
+					category: "skills",
+					message: `${draftCount} skill(s) in skills-draft/ — unvetted skills should not be promoted without review`,
+					fix: "Run telclaude doctor --skills to scan draft skills",
+				});
+			}
+		} catch {
+			// ignore
+		}
+	}
+
+	if (totalSkills > 0 && blockedSkills === 0 && warningSkills === 0) {
+		findings.push({
+			severity: "info",
+			category: "skills",
+			message: `${totalSkills} skill(s) scanned — all clean`,
+		});
+	}
+
+	return findings;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hook hardening collectors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function collectHookHardeningFindings(cwd: string): AuditFinding[] {
+	const findings: AuditFinding[] = [];
+
+	// 1. Check .claude/settings.json for settingSources restriction
+	const claudeDir = path.join(cwd, ".claude");
+	const settingsFile = path.join(claudeDir, "settings.json");
+
+	if (fs.existsSync(settingsFile)) {
+		try {
+			const settings = JSON.parse(fs.readFileSync(settingsFile, "utf-8"));
+
+			// settingSources should restrict to "project" to prevent user-level overrides
+			const sources = settings.settingSources;
+			if (!sources) {
+				findings.push({
+					severity: "critical",
+					category: "hooks",
+					message: "settingSources not configured — user-level settings can override project hooks",
+					fix: 'Add "settingSources": ["project"] to .claude/settings.json',
+				});
+			} else if (Array.isArray(sources) && !sources.includes("project")) {
+				findings.push({
+					severity: "critical",
+					category: "hooks",
+					message: `settingSources does not include "project" — project hooks may not load`,
+					fix: 'Add "project" to settingSources array in .claude/settings.json',
+				});
+			} else if (Array.isArray(sources) && sources.includes("project")) {
+				// Check for "user" in sources which could allow disableAllHooks bypass
+				if (sources.includes("user")) {
+					findings.push({
+						severity: "warning",
+						category: "hooks",
+						message: 'settingSources includes "user" — user-level settings can override hooks',
+						fix: 'Remove "user" from settingSources to prevent disableAllHooks bypass',
+					});
+				}
+			}
+
+			// 2. Check if disableAllHooks is explicitly set (should never be true)
+			if (settings.disableAllHooks === true) {
+				findings.push({
+					severity: "critical",
+					category: "hooks",
+					message: "disableAllHooks is TRUE — all PreToolUse security hooks are disabled",
+					fix: "Remove disableAllHooks from .claude/settings.json immediately",
+				});
+			}
+		} catch {
+			findings.push({
+				severity: "warning",
+				category: "hooks",
+				message: "Failed to parse .claude/settings.json",
+				fix: "Verify the file contains valid JSON",
+			});
+		}
+	} else {
+		findings.push({
+			severity: "warning",
+			category: "hooks",
+			message: ".claude/settings.json not found — SDK settings isolation not configured",
+			fix: 'Create .claude/settings.json with {"settingSources": ["project"]}',
+		});
+	}
+
+	// 3. Check settings.local.json (user override file)
+	const localSettingsFile = path.join(claudeDir, "settings.local.json");
+	if (fs.existsSync(localSettingsFile)) {
+		try {
+			const localSettings = JSON.parse(fs.readFileSync(localSettingsFile, "utf-8"));
+			if (localSettings.disableAllHooks === true) {
+				findings.push({
+					severity: "critical",
+					category: "hooks",
+					message: "disableAllHooks is TRUE in settings.local.json — security hooks bypassed",
+					fix: "Remove disableAllHooks from .claude/settings.local.json immediately",
+				});
+			}
+		} catch {
+			// Parse error is non-critical for local settings
+		}
+	}
+
+	// 4. Verify settings files have restricted permissions
+	findings.push(...checkFilePermissions(settingsFile, ".claude/settings.json", "hooks"));
+	findings.push(...checkFilePermissions(localSettingsFile, ".claude/settings.local.json", "hooks"));
+
+	return findings;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Exposure matrix collectors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function collectExposureMatrixFindings(cfg: TelclaudeConfig): AuditFinding[] {
+	const findings: AuditFinding[] = [];
+	const sandboxMode = getSandboxMode();
+
+	// Build exposure summary
+	const tierNames = Object.keys(TIER_TOOLS) as Array<keyof typeof TIER_TOOLS>;
+	const matrixLines: string[] = [];
+
+	for (const tier of tierNames) {
+		const tools = TIER_TOOLS[tier];
+		const toolList = tools.length === 0 ? "ALL TOOLS" : tools.join(", ");
+		matrixLines.push(`  ${tier}: ${toolList}`);
+	}
+
+	findings.push({
+		severity: "info",
+		category: "exposure",
+		message: `Tier-to-tool exposure matrix (${sandboxMode} mode):\n${matrixLines.join("\n")}`,
+	});
+
+	// Check for users with FULL_ACCESS
+	const users = cfg.security.permissions?.users ?? {};
+	const fullAccessUsers = Object.entries(users).filter(([, perm]) => perm.tier === "FULL_ACCESS");
+
+	if (fullAccessUsers.length > 0) {
+		findings.push({
+			severity: "info",
+			category: "exposure",
+			message: `${fullAccessUsers.length} user(s) with FULL_ACCESS: ${fullAccessUsers.map(([id]) => id).join(", ")}`,
+		});
+	}
+
+	// Social tier with Bash access
+	const socialUsers = Object.entries(users).filter(([, perm]) => perm.tier === "SOCIAL");
+	if (socialUsers.length > 0) {
+		findings.push({
+			severity: "info",
+			category: "exposure",
+			message: `${socialUsers.length} user(s) with SOCIAL tier (Bash trust-gated)`,
+		});
+	}
+
+	// No users configured at all
+	if (Object.keys(users).length === 0 && !cfg.security.permissions) {
+		findings.push({
+			severity: "warning",
+			category: "exposure",
+			message: "No user permissions configured — all users get the default tier",
+			fix: "Configure security.permissions.users for named users",
+		});
+	}
+
+	// Check for social services with elevated access
+	const enabledSocialServices = cfg.socialServices.filter((s) => s.enabled);
+	if (enabledSocialServices.length > 0) {
+		const withSkills = enabledSocialServices.filter((s) => s.enableSkills);
+		if (withSkills.length > 0) {
+			findings.push({
+				severity: "warning",
+				category: "exposure",
+				message: `${withSkills.length} social service(s) have enableSkills=true: ${withSkills.map((s) => s.id).join(", ")}`,
+				fix: "Ensure skills are appropriate for autonomous social posting",
+			});
+		}
+	}
+
+	return findings;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Docker compose collectors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function collectDockerComposeFindings(cwd: string): AuditFinding[] {
+	const composePath = path.join(cwd, "docker", "docker-compose.yml");
+	if (!fs.existsSync(composePath)) {
+		// Keep historical collector behavior for callers/tests:
+		// missing compose is treated as "no docker findings".
+		return [];
+	}
+
+	const mappedFindings = auditSandboxPosture({ cwd }).map((finding) => {
+		let message = `[${finding.category}] ${finding.message}`;
+
+		if (finding.category === "compose.bind_mount" && /docker socket/i.test(finding.message)) {
+			message = "Docker socket mount in docker-compose — container can control host Docker daemon";
+		} else if (finding.category === "compose.network") {
+			message = "Host network mode in docker-compose — bypasses network isolation";
+		} else if (finding.category === "compose.privileged") {
+			message = "Privileged mode in docker-compose — disables container security boundaries";
+		}
+
+		const fix =
+			finding.severity === "critical"
+				? "Update docker/docker-compose.yml to remove dangerous sandbox settings."
+				: finding.severity === "warning"
+					? "Review docker/.env and compose settings for least-privilege posture."
+					: undefined;
+		return {
+			severity: finding.severity,
+			category: "sandbox",
+			message,
+			fix,
+		};
+	});
+
+	// Compatibility fallback: support coarse docker.sock pattern matches even when
+	// the compose snippet is not under a parsed service block.
+	const composeContent = fs.readFileSync(composePath, "utf8");
+	const hasDockerSocket = /(?:^|[\s"'])\/(?:var\/run|run)\/docker\.sock(?:[\s"':]|$)/im.test(
+		composeContent,
+	);
+	if (
+		hasDockerSocket &&
+		!mappedFindings.some((finding) => finding.message.includes("Docker socket mount"))
+	) {
+		mappedFindings.push({
+			severity: "critical",
+			category: "sandbox",
+			message: "Docker socket mount in docker-compose — container can control host Docker daemon",
+			fix: "Remove docker.sock bind mounts from docker/docker-compose.yml.",
+		});
+	}
+
+	return mappedFindings;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Main runner
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run all audit collectors and return a structured report.
+ */
+export function runAuditCollectors(
+	cfg: TelclaudeConfig,
+	cwd: string,
+	env: NodeJS.ProcessEnv = process.env,
+): AuditReport {
+	const findings: AuditFinding[] = [];
+
+	findings.push(...collectConfigFindings(cfg, env));
+	findings.push(...collectFilesystemFindings(cwd));
+	findings.push(...collectSkillTrustFindings(cwd));
+	findings.push(...collectHookHardeningFindings(cwd));
+	findings.push(...collectExposureMatrixFindings(cfg));
+	findings.push(...collectDockerComposeFindings(cwd));
+
+	return {
+		findings,
+		summary: countBySeverity(findings),
+	};
+}
+
+/**
+ * Format an audit report for console output, grouped by severity.
+ */
+export function formatAuditReport(report: AuditReport): string {
+	const lines: string[] = [];
+	const { findings, summary } = report;
+
+	const severityOrder: AuditSeverity[] = ["critical", "warning", "info"];
+	const severityLabels: Record<AuditSeverity, string> = {
+		critical: "CRITICAL",
+		warning: "WARNING",
+		info: "INFO",
+	};
+	const severityIcons: Record<AuditSeverity, string> = {
+		critical: "\u2717", // ✗
+		warning: "\u26A0", // ⚠
+		info: "\u2139", // ℹ
+	};
+
+	for (const severity of severityOrder) {
+		const group = findings.filter((f) => f.severity === severity);
+		if (group.length === 0) continue;
+
+		lines.push(`\n   ${severityLabels[severity]} (${group.length}):`);
+		for (const finding of group) {
+			lines.push(`     ${severityIcons[severity]} [${finding.category}] ${finding.message}`);
+			if (finding.fix) {
+				lines.push(`       Fix: ${finding.fix}`);
+			}
+		}
+	}
+
+	// Summary line
+	lines.push(
+		`\n   Summary: ${summary.critical} critical, ${summary.warning} warning, ${summary.info} info`,
+	);
+
+	if (summary.critical > 0) {
+		lines.push("   Status: FAIL — critical issues require immediate attention");
+	} else if (summary.warning > 0) {
+		lines.push("   Status: WARN — review warnings for potential improvements");
+	} else {
+		lines.push("   Status: PASS — no issues found");
+	}
+
+	return lines.join("\n");
+}

--- a/src/commands/audit-collectors.ts
+++ b/src/commands/audit-collectors.ts
@@ -519,8 +519,8 @@ export function collectExposureMatrixFindings(cfg: TelclaudeConfig): AuditFindin
 		});
 	}
 
-	// No users configured at all
-	if (Object.keys(users).length === 0 && !cfg.security.permissions) {
+	// No user permissions configured at all
+	if (!cfg.security.permissions) {
 		findings.push({
 			severity: "warning",
 			category: "exposure",

--- a/src/commands/audit-fixers.ts
+++ b/src/commands/audit-fixers.ts
@@ -1,0 +1,533 @@
+/**
+ * Security auto-remediation for `doctor --security --fix`.
+ *
+ * Applies safe fixes for audit findings:
+ *   - Tighten file permissions on config/auth files
+ *   - Set conservative config defaults for flagged settings
+ *   - Report what was changed with before/after state
+ *
+ * Inspired by OpenClaw's fix.ts pattern: safeChmod, atomic config write + backup.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { TelclaudeConfig } from "../config/config.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export type FixActionKind = "chmod" | "config" | "create";
+
+export type FixAction = {
+	/** What kind of fix was applied. */
+	kind: FixActionKind;
+	/** Target file or config key. */
+	target: string;
+	/** Description of the fix. */
+	description: string;
+	/** Value before the fix (null if not applicable). */
+	before: string | null;
+	/** Value after the fix. */
+	after: string;
+	/** Whether the fix was actually applied. */
+	applied: boolean;
+	/** Reason if skipped (e.g., "already correct", "file not found", "symlink"). */
+	skipped?: string;
+	/** Error message if the fix failed. */
+	error?: string;
+};
+
+export type FixReport = {
+	actions: FixAction[];
+	configBackupPath: string | null;
+	summary: {
+		applied: number;
+		skipped: number;
+		errors: number;
+	};
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Safe chmod helper (adapted from OpenClaw's safeChmod)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function safeChmod(filePath: string, targetMode: number, label: string): FixAction {
+	try {
+		if (!fs.existsSync(filePath)) {
+			return {
+				kind: "chmod",
+				target: filePath,
+				description: `Tighten permissions on ${label}`,
+				before: null,
+				after: targetMode.toString(8),
+				applied: false,
+				skipped: "file not found",
+			};
+		}
+
+		const stat = fs.lstatSync(filePath);
+
+		// Never follow symlinks
+		if (stat.isSymbolicLink()) {
+			return {
+				kind: "chmod",
+				target: filePath,
+				description: `Tighten permissions on ${label}`,
+				before: null,
+				after: targetMode.toString(8),
+				applied: false,
+				skipped: "symlink — refusing to follow",
+			};
+		}
+
+		const currentMode = stat.mode & 0o777;
+
+		// Already correct
+		if (currentMode === targetMode) {
+			return {
+				kind: "chmod",
+				target: filePath,
+				description: `Tighten permissions on ${label}`,
+				before: currentMode.toString(8),
+				after: targetMode.toString(8),
+				applied: false,
+				skipped: "already correct",
+			};
+		}
+
+		// Only tighten — never loosen permissions
+		if (currentMode < targetMode) {
+			return {
+				kind: "chmod",
+				target: filePath,
+				description: `Tighten permissions on ${label}`,
+				before: currentMode.toString(8),
+				after: targetMode.toString(8),
+				applied: false,
+				skipped: "current permissions are already stricter",
+			};
+		}
+
+		fs.chmodSync(filePath, targetMode);
+
+		return {
+			kind: "chmod",
+			target: filePath,
+			description: `Tighten permissions on ${label}`,
+			before: currentMode.toString(8),
+			after: targetMode.toString(8),
+			applied: true,
+		};
+	} catch (err) {
+		return {
+			kind: "chmod",
+			target: filePath,
+			description: `Tighten permissions on ${label}`,
+			before: null,
+			after: targetMode.toString(8),
+			applied: false,
+			error: String(err),
+		};
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Atomic config write with backup
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Write config atomically: write to .tmp, create .bak of original, rename .tmp to target.
+ * Returns the backup path on success, null if no write was needed.
+ */
+function atomicConfigWrite(configPath: string, content: string): { backupPath: string } {
+	const tmpPath = `${configPath}.tmp`;
+	const bakPath = `${configPath}.bak`;
+
+	// Write new content to temp file
+	fs.writeFileSync(tmpPath, content, "utf-8");
+
+	// Backup original
+	if (fs.existsSync(configPath)) {
+		fs.copyFileSync(configPath, bakPath);
+	}
+
+	// Atomic rename
+	fs.renameSync(tmpPath, configPath);
+
+	// Preserve restrictive permissions on the new file
+	try {
+		fs.chmodSync(configPath, 0o600);
+	} catch {
+		// Non-fatal — the file was written successfully
+	}
+
+	return { backupPath: bakPath };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Config fixers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Apply safe config fixes. Returns the modified config and a list of actions taken.
+ * Only modifies values that the audit collectors flagged as dangerous.
+ */
+function applyConfigFixes(
+	cfg: TelclaudeConfig,
+	env: NodeJS.ProcessEnv,
+): { config: TelclaudeConfig; actions: FixAction[] } {
+	const actions: FixAction[] = [];
+
+	// Deep clone to avoid mutating the original
+	const next = JSON.parse(JSON.stringify(cfg)) as TelclaudeConfig;
+
+	// 1. Test profile → simple
+	if (next.security.profile === "test") {
+		const isTestEnvEnabled = env.TELCLAUDE_ENABLE_TEST_PROFILE === "1";
+		if (!isTestEnvEnabled) {
+			actions.push({
+				kind: "config",
+				target: "security.profile",
+				description: "Change test profile to simple (production-safe default)",
+				before: "test",
+				after: "simple",
+				applied: true,
+			});
+			next.security.profile = "simple";
+		} else {
+			actions.push({
+				kind: "config",
+				target: "security.profile",
+				description: "Test profile is active but TELCLAUDE_ENABLE_TEST_PROFILE=1 is set",
+				before: "test",
+				after: "test",
+				applied: false,
+				skipped: "TELCLAUDE_ENABLE_TEST_PROFILE=1 is set — intentional test mode",
+			});
+		}
+	}
+
+	// 2. FULL_ACCESS default tier → READ_ONLY
+	const defaultTier = next.security.permissions?.defaultTier;
+	if (defaultTier === "FULL_ACCESS") {
+		if (!next.security.permissions) {
+			next.security.permissions = { defaultTier: "READ_ONLY", users: {} };
+		} else {
+			next.security.permissions.defaultTier = "READ_ONLY";
+		}
+		actions.push({
+			kind: "config",
+			target: "security.permissions.defaultTier",
+			description: "Lower default tier from FULL_ACCESS to READ_ONLY",
+			before: "FULL_ACCESS",
+			after: "READ_ONLY",
+			applied: true,
+		});
+	}
+
+	// 3. Audit logging disabled → enable
+	if (next.security.audit?.enabled === false) {
+		next.security.audit.enabled = true;
+		actions.push({
+			kind: "config",
+			target: "security.audit.enabled",
+			description: "Enable audit logging for forensic trail",
+			before: "false",
+			after: "true",
+			applied: true,
+		});
+	}
+
+	// 4. Observer disabled in strict profile → enable
+	if (next.security.profile === "strict" && next.security.observer?.enabled === false) {
+		next.security.observer.enabled = true;
+		actions.push({
+			kind: "config",
+			target: "security.observer.enabled",
+			description: "Enable observer in strict profile for LLM classification",
+			before: "false",
+			after: "true",
+			applied: true,
+		});
+	}
+
+	return { config: next, actions };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// File permission fixers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function applyFilesystemFixes(cwd: string): FixAction[] {
+	const actions: FixAction[] = [];
+	const homeDir = os.homedir();
+
+	// Config files — should be 600 (files) or 700 (dirs)
+	const configFiles = [
+		{
+			label: "telclaude.json (policy config)",
+			path: path.join(cwd, "docker", "telclaude.json"),
+			mode: 0o600,
+		},
+		{
+			label: "telclaude-private.json (private config)",
+			path: path.join(cwd, "docker", "telclaude-private.json"),
+			mode: 0o600,
+		},
+		{ label: "docker/.env (secrets)", path: path.join(cwd, "docker", ".env"), mode: 0o600 },
+	];
+
+	for (const { label, path: filePath, mode } of configFiles) {
+		actions.push(safeChmod(filePath, mode, label));
+	}
+
+	// Sensitive system paths
+	const sensitivePaths = [
+		{ label: "SSH directory", path: path.join(homeDir, ".ssh"), mode: 0o700 },
+		{ label: "AWS credentials", path: path.join(homeDir, ".aws", "credentials"), mode: 0o600 },
+		{ label: "telclaude data dir", path: path.join(homeDir, ".telclaude"), mode: 0o700 },
+		{
+			label: "telclaude database",
+			path: path.join(homeDir, ".telclaude", "telclaude.db"),
+			mode: 0o600,
+		},
+		{ label: "Audit log directory", path: path.join(homeDir, ".telclaude", "logs"), mode: 0o700 },
+	];
+
+	for (const { label, path: filePath, mode } of sensitivePaths) {
+		actions.push(safeChmod(filePath, mode, label));
+	}
+
+	return actions;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hook hardening fixers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function applyHookHardeningFixes(cwd: string): FixAction[] {
+	const actions: FixAction[] = [];
+	const claudeDir = path.join(cwd, ".claude");
+	const settingsFile = path.join(claudeDir, "settings.json");
+
+	if (fs.existsSync(settingsFile)) {
+		try {
+			const raw = fs.readFileSync(settingsFile, "utf-8");
+			const settings = JSON.parse(raw) as Record<string, unknown>;
+			let modified = false;
+
+			// Fix: add settingSources if missing
+			if (!settings.settingSources) {
+				settings.settingSources = ["project"];
+				actions.push({
+					kind: "config",
+					target: ".claude/settings.json → settingSources",
+					description: "Add settingSources restriction to prevent user-level overrides",
+					before: "undefined",
+					after: '["project"]',
+					applied: true,
+				});
+				modified = true;
+			}
+
+			// Fix: remove disableAllHooks if true
+			if (settings.disableAllHooks === true) {
+				delete settings.disableAllHooks;
+				actions.push({
+					kind: "config",
+					target: ".claude/settings.json → disableAllHooks",
+					description: "Remove disableAllHooks to restore PreToolUse security hooks",
+					before: "true",
+					after: "(removed)",
+					applied: true,
+				});
+				modified = true;
+			}
+
+			if (modified) {
+				fs.writeFileSync(settingsFile, `${JSON.stringify(settings, null, "\t")}\n`, "utf-8");
+			}
+		} catch {
+			// Parse error — don't touch a broken file
+		}
+
+		// Tighten permissions on settings.json
+		actions.push(safeChmod(settingsFile, 0o600, ".claude/settings.json"));
+	} else {
+		// Create settings.json with proper isolation
+		if (!fs.existsSync(claudeDir)) {
+			fs.mkdirSync(claudeDir, { recursive: true });
+		}
+		const content = JSON.stringify({ settingSources: ["project"] }, null, "\t");
+		fs.writeFileSync(settingsFile, `${content}\n`, "utf-8");
+		fs.chmodSync(settingsFile, 0o600);
+		actions.push({
+			kind: "create",
+			target: settingsFile,
+			description: "Create .claude/settings.json with settingSources isolation",
+			before: null,
+			after: '{"settingSources": ["project"]}',
+			applied: true,
+		});
+	}
+
+	// Fix settings.local.json disableAllHooks
+	const localSettingsFile = path.join(claudeDir, "settings.local.json");
+	if (fs.existsSync(localSettingsFile)) {
+		try {
+			const raw = fs.readFileSync(localSettingsFile, "utf-8");
+			const localSettings = JSON.parse(raw) as Record<string, unknown>;
+
+			if (localSettings.disableAllHooks === true) {
+				delete localSettings.disableAllHooks;
+				fs.writeFileSync(
+					localSettingsFile,
+					`${JSON.stringify(localSettings, null, "\t")}\n`,
+					"utf-8",
+				);
+				actions.push({
+					kind: "config",
+					target: ".claude/settings.local.json → disableAllHooks",
+					description: "Remove disableAllHooks from local settings to restore security hooks",
+					before: "true",
+					after: "(removed)",
+					applied: true,
+				});
+			}
+		} catch {
+			// Parse error — skip
+		}
+
+		actions.push(safeChmod(localSettingsFile, 0o600, ".claude/settings.local.json"));
+	}
+
+	return actions;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Main runner
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run all auto-remediation fixers.
+ *
+ * Only applies "safe" fixes:
+ *   - Permission tightening (never loosens)
+ *   - Conservative config defaults (test → simple, FULL_ACCESS → READ_ONLY)
+ *   - settingSources isolation
+ *
+ * Config writes use atomic write + backup (write to .tmp, rename, keep .bak).
+ */
+export function runAutoFix(
+	cfg: TelclaudeConfig,
+	configPath: string,
+	cwd: string,
+	env: NodeJS.ProcessEnv = process.env,
+): FixReport {
+	const allActions: FixAction[] = [];
+	let configBackupPath: string | null = null;
+
+	// 1. Config fixes (requires atomic write)
+	const configResult = applyConfigFixes(cfg, env);
+	const configActionsApplied = configResult.actions.filter((a) => a.applied);
+
+	if (configActionsApplied.length > 0) {
+		try {
+			const content = `${JSON.stringify(configResult.config, null, "\t")}\n`;
+			const { backupPath } = atomicConfigWrite(configPath, content);
+			configBackupPath = backupPath;
+		} catch (err) {
+			// Mark all config actions as failed
+			for (const action of configResult.actions) {
+				if (action.applied) {
+					action.applied = false;
+					action.error = `Atomic write failed: ${String(err)}`;
+				}
+			}
+		}
+	}
+	allActions.push(...configResult.actions);
+
+	// 2. Filesystem permission fixes
+	allActions.push(...applyFilesystemFixes(cwd));
+
+	// 3. Hook hardening fixes
+	allActions.push(...applyHookHardeningFixes(cwd));
+
+	// Build summary
+	let applied = 0;
+	let skipped = 0;
+	let errors = 0;
+	for (const action of allActions) {
+		if (action.applied) applied++;
+		else if (action.error) errors++;
+		else skipped++;
+	}
+
+	return {
+		actions: allActions,
+		configBackupPath,
+		summary: { applied, skipped, errors },
+	};
+}
+
+/**
+ * Format a fix report for console output.
+ */
+export function formatFixReport(report: FixReport): string {
+	const lines: string[] = [];
+	const { actions, configBackupPath, summary } = report;
+
+	// Show applied fixes
+	const applied = actions.filter((a) => a.applied);
+	if (applied.length > 0) {
+		lines.push("\n   APPLIED:");
+		for (const action of applied) {
+			const arrow = action.before ? `${action.before} -> ${action.after}` : action.after;
+			lines.push(`     [${action.kind}] ${action.description}`);
+			lines.push(`       ${action.target}: ${arrow}`);
+		}
+	}
+
+	// Show skipped (only interesting ones — not "file not found")
+	const skippedInteresting = actions.filter(
+		(a) => !a.applied && !a.error && a.skipped && a.skipped !== "file not found",
+	);
+	if (skippedInteresting.length > 0) {
+		lines.push("\n   SKIPPED:");
+		for (const action of skippedInteresting) {
+			lines.push(`     [${action.kind}] ${action.description}: ${action.skipped}`);
+		}
+	}
+
+	// Show errors
+	const errored = actions.filter((a) => a.error);
+	if (errored.length > 0) {
+		lines.push("\n   ERRORS:");
+		for (const action of errored) {
+			lines.push(`     [${action.kind}] ${action.description}: ${action.error}`);
+		}
+	}
+
+	// Backup info
+	if (configBackupPath) {
+		lines.push(`\n   Config backup: ${configBackupPath}`);
+	}
+
+	// Summary
+	lines.push(
+		`\n   Summary: ${summary.applied} applied, ${summary.skipped} skipped, ${summary.errors} errors`,
+	);
+
+	if (summary.errors > 0) {
+		lines.push("   Status: PARTIAL — some fixes could not be applied");
+	} else if (summary.applied > 0) {
+		lines.push("   Status: FIXED — all applicable remediations applied");
+	} else {
+		lines.push("   Status: CLEAN — nothing to fix");
+	}
+
+	return lines.join("\n");
+}

--- a/src/commands/audit-fixers.ts
+++ b/src/commands/audit-fixers.ts
@@ -399,10 +399,7 @@ function applyHookHardeningFixes(cwd: string): FixAction[] {
 
 			if (localSettings.disableAllHooks === true) {
 				delete localSettings.disableAllHooks;
-				atomicJsonWrite(
-					localSettingsFile,
-					`${JSON.stringify(localSettings, null, "\t")}\n`,
-				);
+				atomicJsonWrite(localSettingsFile, `${JSON.stringify(localSettings, null, "\t")}\n`);
 				actions.push({
 					kind: "config",
 					target: ".claude/settings.local.json → disableAllHooks",

--- a/src/commands/summarize.ts
+++ b/src/commands/summarize.ts
@@ -5,6 +5,7 @@
 
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
+import { initializeOpenAIKey } from "../services/openai-client.js";
 import { summarizeUrl } from "../services/summarize.js";
 
 const logger = getChildLogger({ module: "cmd-summarize" });
@@ -53,6 +54,9 @@ export function registerSummarizeCommand(program: Command): void {
 						process.exit(1);
 					}
 				}
+
+				// Prewarm OpenAI key so getCachedOpenAIKey() works for Whisper transcription
+				await initializeOpenAIKey();
 
 				const result = await summarizeUrl(url, {
 					maxCharacters,

--- a/src/sandbox/fetch-guard.ts
+++ b/src/sandbox/fetch-guard.ts
@@ -1,0 +1,344 @@
+/**
+ * DNS-Pinned Fetch Guard
+ *
+ * Prevents SSRF via DNS rebinding and redirect-based attacks:
+ * 1. Resolves hostname via cachedDNSLookup() — validates ALL IPs
+ * 2. Creates undici Agent with pinned DNS lookup (TCP uses validated IPs only)
+ * 3. Follows redirects manually, re-validating each hop's hostname
+ * 4. Caps redirect count and detects loops
+ *
+ * Backported from OpenClaw's fetch-guard pattern.
+ */
+
+import type { LookupAddress, LookupOptions } from "node:dns";
+import { Agent } from "undici";
+import { getChildLogger } from "../logging.js";
+import { cachedDNSLookup, isBlockedIP, isNonOverridableBlock } from "./network-proxy.js";
+
+const logger = getChildLogger({ module: "fetch-guard" });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export type FetchWithGuardOptions = {
+	/** URL to fetch */
+	url: string;
+	/** Standard fetch RequestInit (headers, method, body, etc.) */
+	init?: RequestInit;
+	/** Maximum number of redirects to follow (default: 3) */
+	maxRedirects?: number;
+	/** Timeout in milliseconds */
+	timeoutMs?: number;
+	/** External abort signal */
+	signal?: AbortSignal;
+	/** Context string for audit logging */
+	auditContext?: string;
+};
+
+export type FetchWithGuardResult = {
+	/** The final HTTP response */
+	response: Response;
+	/** The final URL after all redirects */
+	finalUrl: string;
+	/** Call to release the underlying dispatcher resources */
+	release: () => Promise<void>;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Pinned DNS Lookup
+// ═══════════════════════════════════════════════════════════════════════════════
+
+type DnsLookupCallback = (
+	err: NodeJS.ErrnoException | null,
+	address: string | LookupAddress[],
+	family?: number,
+) => void;
+
+/**
+ * Create a DNS lookup function that returns pre-resolved (pinned) IP addresses
+ * for a specific hostname. All other hostnames fall through to the system resolver.
+ *
+ * SECURITY: This ensures the TCP connection uses the exact IPs we validated,
+ * preventing TOCTOU races between DNS resolution and connection establishment.
+ */
+export function createPinnedLookup(
+	hostname: string,
+	addresses: string[],
+): (hostname: string, options: LookupOptions, callback: DnsLookupCallback) => void {
+	const pinnedHost = hostname.toLowerCase();
+	const records: LookupAddress[] = addresses.map((addr) => ({
+		address: addr,
+		family: addr.includes(":") ? 6 : 4,
+	}));
+	let index = 0;
+
+	return (host: string, options: LookupOptions, callback: DnsLookupCallback) => {
+		if (host.toLowerCase() !== pinnedHost) {
+			// Not our pinned host — reject (we should only see the pinned hostname)
+			callback(
+				Object.assign(new Error(`Unexpected hostname in lookup: ${host}`), { code: "ENOTFOUND" }),
+				"",
+			);
+			return;
+		}
+
+		if (options?.all) {
+			callback(null, records);
+			return;
+		}
+
+		// Round-robin single result
+		const chosen = records[index % records.length];
+		index += 1;
+		callback(null, chosen.address, chosen.family);
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const DEFAULT_MAX_REDIRECTS = 3;
+
+function isRedirectStatus(status: number): boolean {
+	return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+/**
+ * Resolve hostname and validate all IPs against blocked ranges.
+ * Returns the validated IP addresses, or throws on blocked/unresolvable hosts.
+ */
+async function resolveAndValidate(hostname: string): Promise<string[]> {
+	// Fast-path: literal IP addresses
+	if (isNonOverridableBlock(hostname)) {
+		throw new FetchGuardError(`Blocked: non-overridable IP (metadata/link-local): ${hostname}`);
+	}
+	if (isBlockedIP(hostname)) {
+		throw new FetchGuardError(`Blocked: private/internal IP address: ${hostname}`);
+	}
+
+	const addresses = await cachedDNSLookup(hostname);
+	if (!addresses || addresses.length === 0) {
+		throw new FetchGuardError(`DNS resolution failed for: ${hostname}`);
+	}
+
+	// Validate ALL resolved IPs — a dual-stack hostname with one private
+	// IP and one public IP is still dangerous (attacker controls which gets used)
+	for (const addr of addresses) {
+		if (isNonOverridableBlock(addr)) {
+			throw new FetchGuardError(`Blocked: ${hostname} resolves to non-overridable IP: ${addr}`);
+		}
+		if (isBlockedIP(addr)) {
+			throw new FetchGuardError(`Blocked: ${hostname} resolves to private/internal IP: ${addr}`);
+		}
+	}
+
+	return addresses;
+}
+
+/**
+ * Create an undici Agent pinned to the given addresses for a hostname.
+ */
+function createPinnedAgent(hostname: string, addresses: string[]): Agent {
+	const lookup = createPinnedLookup(hostname, addresses);
+	return new Agent({
+		connect: { lookup },
+	});
+}
+
+/**
+ * Safely close an undici dispatcher.
+ */
+async function closeAgent(agent: Agent | null): Promise<void> {
+	if (!agent) return;
+	try {
+		await agent.close();
+	} catch {
+		// Ignore cleanup errors
+	}
+}
+
+/**
+ * Build a combined AbortSignal from timeout and external signal.
+ */
+function buildAbortSignal(opts: { timeoutMs?: number; signal?: AbortSignal }): {
+	signal?: AbortSignal;
+	cleanup: () => void;
+} {
+	const { timeoutMs, signal } = opts;
+
+	if (!timeoutMs && !signal) {
+		return { signal: undefined, cleanup: () => {} };
+	}
+
+	if (!timeoutMs) {
+		return { signal, cleanup: () => {} };
+	}
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(new Error("fetch timeout")), timeoutMs);
+
+	const onExternalAbort = () => controller.abort(signal?.reason);
+	if (signal) {
+		if (signal.aborted) {
+			controller.abort(signal.reason);
+		} else {
+			signal.addEventListener("abort", onExternalAbort, { once: true });
+		}
+	}
+
+	return {
+		signal: controller.signal,
+		cleanup: () => {
+			clearTimeout(timeoutId);
+			signal?.removeEventListener("abort", onExternalAbort);
+		},
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Error class
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export class FetchGuardError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "FetchGuardError";
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Main entry point
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Fetch a URL with DNS pinning and redirect validation.
+ *
+ * SECURITY PROPERTIES:
+ * - All resolved IPs validated before any TCP connection
+ * - DNS lookup pinned so TCP cannot connect to a different IP than validated
+ * - Each redirect hop re-resolves and re-validates DNS
+ * - Redirect count capped (default 3) with loop detection
+ * - Timeout via AbortSignal
+ *
+ * IMPORTANT: Caller MUST call `release()` on the result when done reading
+ * the response body (or on error) to free the underlying dispatcher.
+ */
+export async function fetchWithGuard(opts: FetchWithGuardOptions): Promise<FetchWithGuardResult> {
+	const maxRedirects =
+		typeof opts.maxRedirects === "number" && Number.isFinite(opts.maxRedirects)
+			? Math.max(0, Math.floor(opts.maxRedirects))
+			: DEFAULT_MAX_REDIRECTS;
+
+	const { signal, cleanup: cleanupSignal } = buildAbortSignal({
+		timeoutMs: opts.timeoutMs,
+		signal: opts.signal,
+	});
+
+	let released = false;
+	const release = async (agent: Agent | null) => {
+		if (released) return;
+		released = true;
+		cleanupSignal();
+		await closeAgent(agent);
+	};
+
+	const visited = new Set<string>();
+	let currentUrl = opts.url;
+	visited.add(currentUrl); // Track initial URL for loop detection
+	let redirectCount = 0;
+
+	while (true) {
+		// Parse and validate URL
+		let parsedUrl: URL;
+		try {
+			parsedUrl = new URL(currentUrl);
+		} catch {
+			await release(null);
+			throw new FetchGuardError(`Invalid URL: ${currentUrl}`);
+		}
+
+		if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+			await release(null);
+			throw new FetchGuardError("URL must use http or https protocol");
+		}
+
+		let agent: Agent | null = null;
+		try {
+			// Resolve and validate DNS
+			const addresses = await resolveAndValidate(parsedUrl.hostname);
+
+			// Create pinned dispatcher
+			agent = createPinnedAgent(parsedUrl.hostname, addresses);
+
+			// Execute fetch with pinned DNS and manual redirect handling
+			// Note: undici's Agent type doesn't perfectly align with the
+			// Dispatcher type on RequestInit due to dual package versions;
+			// the cast is safe since Agent extends Dispatcher at runtime.
+			const init: RequestInit = {
+				...(opts.init ?? {}),
+				redirect: "manual",
+				dispatcher: agent as never,
+				...(signal ? { signal } : {}),
+			};
+
+			const response = await fetch(parsedUrl.toString(), init);
+
+			// Handle redirects
+			if (isRedirectStatus(response.status)) {
+				const location = response.headers.get("location");
+				if (!location) {
+					await release(agent);
+					throw new FetchGuardError(`Redirect (${response.status}) missing Location header`);
+				}
+
+				redirectCount += 1;
+				if (redirectCount > maxRedirects) {
+					await release(agent);
+					throw new FetchGuardError(`Too many redirects (limit: ${maxRedirects})`);
+				}
+
+				const nextUrl = new URL(location, parsedUrl).toString();
+				if (visited.has(nextUrl)) {
+					await release(agent);
+					throw new FetchGuardError("Redirect loop detected");
+				}
+
+				visited.add(nextUrl);
+
+				// Drain the redirect response body and close the agent for this hop
+				try {
+					await response.body?.cancel();
+				} catch {
+					// Ignore body cancel errors
+				}
+				await closeAgent(agent);
+
+				currentUrl = nextUrl;
+				continue;
+			}
+
+			// Non-redirect response — return to caller
+			return {
+				response,
+				finalUrl: currentUrl,
+				release: () => release(agent),
+			};
+		} catch (err) {
+			if (err instanceof FetchGuardError) {
+				const ctx = opts.auditContext ?? "url-fetch";
+				logger.warn(
+					{
+						context: ctx,
+						target: `${parsedUrl.origin}${parsedUrl.pathname}`,
+						reason: err.message,
+					},
+					"fetch-guard: blocked URL fetch",
+				);
+			}
+			await release(agent);
+			throw err;
+		}
+	}
+}

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -22,6 +22,14 @@ export {
 	domainMatchesPattern,
 	OPENAI_DOMAINS,
 } from "./domains.js";
+// Fetch guard (DNS-pinned fetch with redirect validation)
+export {
+	createPinnedLookup,
+	FetchGuardError,
+	type FetchWithGuardOptions,
+	type FetchWithGuardResult,
+	fetchWithGuard,
+} from "./fetch-guard.js";
 // Mode detection
 export {
 	getSandboxMode,
@@ -29,7 +37,6 @@ export {
 	type SandboxMode,
 	shouldEnableSdkSandbox,
 } from "./mode.js";
-
 // Network proxy (for isBlockedHost in canUseTool)
 export {
 	checkNetworkRequest,

--- a/src/sandbox/validate-config.ts
+++ b/src/sandbox/validate-config.ts
@@ -1,0 +1,480 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type SandboxPostureSeverity = "critical" | "warning" | "info";
+
+export type SandboxPostureFinding = {
+	severity: SandboxPostureSeverity;
+	category: string;
+	message: string;
+};
+
+export type SandboxPostureAuditOptions = {
+	composePath?: string;
+	envPath?: string;
+	cwd?: string;
+};
+
+type ComposeSection = "volumes" | "environment" | "security_opt" | null;
+
+type ComposeService = {
+	name: string;
+	networkMode?: string;
+	privileged?: boolean;
+	securityOpts: string[];
+	volumes: string[];
+	envKeys: string[];
+};
+
+const BLOCKED_HOST_PATHS = [
+	"/",
+	"/etc",
+	"/private/etc",
+	"/proc",
+	"/sys",
+	"/dev",
+	"/root",
+	"/boot",
+	"/run",
+	"/var/run",
+	"/private/var/run",
+	"/var/run/docker.sock",
+	"/private/var/run/docker.sock",
+	"/run/docker.sock",
+];
+
+const AGENT_SENSITIVE_ENV_KEYS = new Set([
+	"TELEGRAM_BOT_TOKEN",
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GITHUB_TOKEN",
+	"GH_TOKEN",
+	"CLAUDE_CODE_OAUTH_TOKEN",
+	"SECRETS_ENCRYPTION_KEY",
+	"TOTP_ENCRYPTION_KEY",
+]);
+
+const PERMISSIVE_NETWORK_MODES = new Set(["open", "permissive"]);
+
+function toPosixPath(input: string): string {
+	return path.resolve(input).replaceAll("\\", "/");
+}
+
+function stripInlineComment(value: string): string {
+	const hashIndex = value.indexOf("#");
+	if (hashIndex === -1) {
+		return value;
+	}
+	return value.slice(0, hashIndex);
+}
+
+function normalizeBoolean(input: string | undefined): boolean | undefined {
+	if (!input) {
+		return undefined;
+	}
+	const normalized = input.trim().toLowerCase();
+	if (normalized === "true" || normalized === '"true"' || normalized === "'true'") {
+		return true;
+	}
+	if (normalized === "false" || normalized === '"false"' || normalized === "'false'") {
+		return false;
+	}
+	return undefined;
+}
+
+function unquote(value: string): string {
+	const trimmed = value.trim();
+	if (
+		(trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+		(trimmed.startsWith("'") && trimmed.endsWith("'"))
+	) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+function extractEnvKey(entry: string): string | null {
+	const cleaned = unquote(stripInlineComment(entry).trim());
+	if (!cleaned) {
+		return null;
+	}
+	const eqIndex = cleaned.indexOf("=");
+	if (eqIndex <= 0) {
+		return null;
+	}
+	const key = cleaned.slice(0, eqIndex).trim();
+	return key || null;
+}
+
+function parseBindSource(entry: string): string | null {
+	const cleaned = unquote(stripInlineComment(entry).trim());
+	if (!cleaned) {
+		return null;
+	}
+	const firstColon = cleaned.indexOf(":");
+	if (firstColon <= 0) {
+		return cleaned;
+	}
+	return cleaned.slice(0, firstColon).trim();
+}
+
+function isLikelyHostPath(source: string): boolean {
+	return (
+		source.startsWith("/") ||
+		source.startsWith("./") ||
+		source.startsWith("../") ||
+		source === "." ||
+		source === ".." ||
+		source.startsWith("~/")
+	);
+}
+
+function resolveHostPath(source: string, composeDir: string): string | null {
+	if (!source || source.startsWith("${")) {
+		return null;
+	}
+	if (!isLikelyHostPath(source)) {
+		return null;
+	}
+	if (source.startsWith("~/")) {
+		return path.resolve(os.homedir(), source.slice(2));
+	}
+	if (source.startsWith("/")) {
+		return path.resolve(source);
+	}
+	return path.resolve(composeDir, source);
+}
+
+function toDisplayRelative(target: string, baseDir: string): string {
+	const relative = path.relative(baseDir, target);
+	if (!relative || relative === ".") {
+		return ".";
+	}
+	if (relative.startsWith("..")) {
+		return target;
+	}
+	return `./${relative.replaceAll("\\", "/")}`;
+}
+
+function getBlockedPathMatch(resolvedPath: string): string | null {
+	const normalized = toPosixPath(resolvedPath);
+	for (const blocked of BLOCKED_HOST_PATHS) {
+		if (normalized === blocked || normalized.startsWith(`${blocked}/`)) {
+			return blocked;
+		}
+	}
+	return null;
+}
+
+function parseEnvFile(envPath: string): Record<string, string> {
+	if (!fs.existsSync(envPath)) {
+		return {};
+	}
+	const output: Record<string, string> = {};
+	const content = fs.readFileSync(envPath, "utf8");
+	for (const rawLine of content.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#")) {
+			continue;
+		}
+		const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+		if (!match) {
+			continue;
+		}
+		const key = match[1];
+		const value = unquote(stripInlineComment(match[2]).trim());
+		output[key] = value;
+	}
+	return output;
+}
+
+function parseComposeServices(content: string): ComposeService[] {
+	const services: ComposeService[] = [];
+	let inServicesBlock = false;
+	let currentService: ComposeService | null = null;
+	let currentSection: ComposeSection = null;
+
+	for (const rawLine of content.split(/\r?\n/)) {
+		const line = rawLine.replace(/\t/g, "  ");
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) {
+			continue;
+		}
+		const indent = line.length - line.trimStart().length;
+
+		if (!inServicesBlock) {
+			if (trimmed === "services:") {
+				inServicesBlock = true;
+			}
+			continue;
+		}
+
+		// Left top-level services block.
+		if (indent === 0 && trimmed !== "services:") {
+			break;
+		}
+
+		const serviceMatch = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+		if (serviceMatch) {
+			currentService = {
+				name: serviceMatch[1],
+				securityOpts: [],
+				volumes: [],
+				envKeys: [],
+			};
+			services.push(currentService);
+			currentSection = null;
+			continue;
+		}
+
+		if (!currentService) {
+			continue;
+		}
+
+		const keyMatch = line.match(/^ {4}([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$/);
+		if (keyMatch) {
+			const key = keyMatch[1];
+			const value = stripInlineComment(keyMatch[2]).trim();
+			if (key === "network_mode") {
+				currentService.networkMode = unquote(value);
+			} else if (key === "privileged") {
+				currentService.privileged = normalizeBoolean(value);
+			}
+			if (key === "volumes" || key === "environment" || key === "security_opt") {
+				currentSection = key;
+			} else {
+				currentSection = null;
+			}
+			continue;
+		}
+
+		if (indent < 6 || !currentSection) {
+			continue;
+		}
+
+		const listMatch = line.match(/^ {6}-\s*(.+)$/);
+		if (listMatch) {
+			const value = listMatch[1].trim();
+			if (currentSection === "volumes") {
+				currentService.volumes.push(value);
+			} else if (currentSection === "security_opt") {
+				currentService.securityOpts.push(value);
+			} else if (currentSection === "environment") {
+				const envKey = extractEnvKey(value);
+				if (envKey) {
+					currentService.envKeys.push(envKey);
+				}
+			}
+			continue;
+		}
+
+		if (currentSection === "environment") {
+			const envMapMatch = line.match(/^ {6}([A-Za-z_][A-Za-z0-9_]*)\s*:/);
+			if (envMapMatch) {
+				currentService.envKeys.push(envMapMatch[1]);
+			}
+		}
+	}
+
+	return services;
+}
+
+function hasUnconfinedSecurityOpt(value: string, kind: "seccomp" | "apparmor"): boolean {
+	const normalized = unquote(stripInlineComment(value).trim()).toLowerCase();
+	return normalized === `${kind}:unconfined`;
+}
+
+function isDockerSocketPath(value: string): boolean {
+	const normalized = toPosixPath(value);
+	return normalized === "/var/run/docker.sock" || normalized === "/run/docker.sock";
+}
+
+function addServiceSettingFindings(
+	findings: SandboxPostureFinding[],
+	service: ComposeService,
+): void {
+	if (service.networkMode?.trim().toLowerCase() === "host") {
+		findings.push({
+			severity: "critical",
+			category: "compose.network",
+			message: `Service "${service.name}" uses network_mode=host (breaks network isolation).`,
+		});
+	}
+
+	if (service.privileged === true) {
+		findings.push({
+			severity: "critical",
+			category: "compose.privileged",
+			message: `Service "${service.name}" runs privileged=true.`,
+		});
+	}
+
+	for (const option of service.securityOpts) {
+		if (hasUnconfinedSecurityOpt(option, "seccomp")) {
+			findings.push({
+				severity: "critical",
+				category: "compose.security_opt",
+				message: `Service "${service.name}" sets seccomp:unconfined.`,
+			});
+		}
+		if (hasUnconfinedSecurityOpt(option, "apparmor")) {
+			findings.push({
+				severity: "critical",
+				category: "compose.security_opt",
+				message: `Service "${service.name}" sets apparmor:unconfined.`,
+			});
+		}
+	}
+}
+
+function addBindMountFindings(
+	findings: SandboxPostureFinding[],
+	service: ComposeService,
+	composeDir: string,
+): void {
+	for (const volumeEntry of service.volumes) {
+		const source = parseBindSource(volumeEntry);
+		if (!source) {
+			continue;
+		}
+
+		if (source.toLowerCase().includes("docker.sock")) {
+			findings.push({
+				severity: "critical",
+				category: "compose.bind_mount",
+				message: `Service "${service.name}" bind-mounts Docker socket via "${volumeEntry}".`,
+			});
+			continue;
+		}
+
+		const resolvedPath = resolveHostPath(source, composeDir);
+		if (!resolvedPath) {
+			continue;
+		}
+
+		const blocked = getBlockedPathMatch(resolvedPath);
+		if (blocked) {
+			findings.push({
+				severity: "critical",
+				category: "compose.bind_mount",
+				message:
+					`Service "${service.name}" mount source "${source}" resolves to blocked path "${blocked}". ` +
+					`Resolved path: ${resolvedPath}`,
+			});
+			continue;
+		}
+
+		if (isDockerSocketPath(resolvedPath)) {
+			findings.push({
+				severity: "critical",
+				category: "compose.bind_mount",
+				message: `Service "${service.name}" mount source "${source}" resolves to Docker socket.`,
+			});
+			continue;
+		}
+
+		try {
+			const stat = fs.lstatSync(resolvedPath);
+			if (!stat.isSymbolicLink()) {
+				continue;
+			}
+			const realPath = fs.realpathSync.native(resolvedPath);
+			const realBlocked = getBlockedPathMatch(realPath);
+			if (realBlocked) {
+				findings.push({
+					severity: "critical",
+					category: "compose.bind_mount",
+					message:
+						`Service "${service.name}" mount source "${source}" is a symlink that resolves to blocked path ` +
+						`"${realBlocked}" (${realPath}).`,
+				});
+			}
+		} catch {
+			// Ignore missing paths and realpath errors in static checks.
+		}
+	}
+}
+
+function addEnvironmentFindings(
+	findings: SandboxPostureFinding[],
+	services: ComposeService[],
+	envMap: Record<string, string>,
+	composeDir: string,
+): void {
+	for (const service of services) {
+		const isAgentService = service.name.includes("agent");
+		if (!isAgentService) {
+			continue;
+		}
+
+		for (const key of service.envKeys) {
+			if (!AGENT_SENSITIVE_ENV_KEYS.has(key)) {
+				continue;
+			}
+			findings.push({
+				severity: "warning",
+				category: "compose.environment",
+				message: `Agent service "${service.name}" exposes sensitive env key "${key}".`,
+			});
+		}
+	}
+
+	const networkMode = (envMap.TELCLAUDE_NETWORK_MODE ?? "").trim().toLowerCase();
+	if (PERMISSIVE_NETWORK_MODES.has(networkMode)) {
+		findings.push({
+			severity: "warning",
+			category: "environment.network",
+			message:
+				`docker/.env sets TELCLAUDE_NETWORK_MODE=${networkMode}, which broadens egress policy. ` +
+				"Use only with explicit operator justification.",
+		});
+	}
+
+	const workspacePath = (envMap.WORKSPACE_PATH ?? "").trim();
+	if (workspacePath) {
+		const normalized = toPosixPath(workspacePath);
+		const blocked = getBlockedPathMatch(normalized);
+		if (blocked && blocked !== "/") {
+			findings.push({
+				severity: "warning",
+				category: "environment.workspace",
+				message:
+					`WORKSPACE_PATH in docker/.env points at sensitive path "${blocked}" (${workspacePath}). ` +
+					`Expected a project workspace under ${toDisplayRelative(composeDir, composeDir)}.`,
+			});
+		}
+	}
+}
+
+export function auditSandboxPosture(
+	options: SandboxPostureAuditOptions = {},
+): SandboxPostureFinding[] {
+	const cwd = options.cwd ?? process.cwd();
+	const composePath = options.composePath ?? path.join(cwd, "docker", "docker-compose.yml");
+	const envPath = options.envPath ?? path.join(cwd, "docker", ".env");
+	const composeDir = path.dirname(composePath);
+	const findings: SandboxPostureFinding[] = [];
+
+	if (!fs.existsSync(composePath)) {
+		return [
+			{
+				severity: "warning",
+				category: "compose.file",
+				message: `Compose file not found: ${composePath}`,
+			},
+		];
+	}
+
+	const composeContent = fs.readFileSync(composePath, "utf8");
+	const services = parseComposeServices(composeContent);
+	for (const service of services) {
+		addServiceSettingFindings(findings, service);
+		addBindMountFindings(findings, service, composeDir);
+	}
+
+	const envMap = parseEnvFile(envPath);
+	addEnvironmentFindings(findings, services, envMap, composeDir);
+
+	return findings;
+}

--- a/src/sandbox/validate-config.ts
+++ b/src/sandbox/validate-config.ts
@@ -189,6 +189,18 @@ function parseEnvFile(envPath: string): Record<string, string> {
 	return output;
 }
 
+/**
+ * Best-effort compose parser used by static sandbox posture checks.
+ *
+ * Indentation assumption:
+ * - services are indented with 2 spaces
+ * - service keys with 4 spaces
+ * - list/map entries with 6 spaces
+ * Tabs are normalized to two spaces before matching.
+ *
+ * Non-standard indentation can cause services/keys to be skipped silently.
+ * This is acceptable here because the audit is heuristic and not a full YAML parse.
+ */
 function parseComposeServices(content: string): ComposeService[] {
 	const services: ComposeService[] = [];
 	let inServicesBlock = false;

--- a/src/sdk/output-guard.ts
+++ b/src/sdk/output-guard.ts
@@ -189,7 +189,7 @@ export function guardToolResultOutput(
 
 	// Return as string (the model handles string tool results fine)
 	return {
-		output: typeof output === "string" ? result.content : result.content,
+		output: result.content,
 		truncation: result,
 	};
 }

--- a/src/sdk/output-guard.ts
+++ b/src/sdk/output-guard.ts
@@ -1,0 +1,223 @@
+/**
+ * Stream Output Size Guard.
+ *
+ * Caps oversized tool-result content before it exhausts the context window,
+ * and detects context overflow errors for graceful recovery.
+ *
+ * Adapted from OpenClaw's tool-result-truncation.ts and session-tool-result-guard.ts.
+ * Since telclaude doesn't own transcript storage (the SDK handles persistence),
+ * this guard operates on the streaming layer only — truncating tool results as
+ * they flow through processMessageStream().
+ */
+
+import { getChildLogger } from "../logging.js";
+
+const logger = getChildLogger({ module: "output-guard" });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Constants
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Default maximum characters for a single tool result.
+ * ~100KB is conservative — a single tool result should not dominate the context.
+ * At ~4 chars/token, this is ~25K tokens.
+ */
+export const DEFAULT_MAX_TOOL_RESULT_CHARS = 100_000;
+
+/**
+ * Absolute minimum characters to keep when truncating.
+ * Always preserve enough context for the model to understand the result.
+ */
+const MIN_KEEP_CHARS = 2_000;
+
+/**
+ * Characters to keep from the end of truncated content.
+ * Tail content often contains summaries, error messages, or final output.
+ */
+const TAIL_KEEP_CHARS = 500;
+
+/**
+ * Marker inserted where content was removed.
+ */
+const TRUNCATION_MARKER = "\n\n[... truncated %SIZE% ...]\n\n";
+
+/**
+ * Error patterns that indicate context window overflow.
+ * These are matched against SDK error messages.
+ */
+const CONTEXT_OVERFLOW_PATTERNS = [
+	/context.*(window|length|limit).*exceed/i,
+	/maximum.*context.*length/i,
+	/token.*limit.*exceeded/i,
+	/too.*many.*tokens/i,
+	/prompt.*too.*long/i,
+	/input.*too.*large/i,
+	/request.*too.*large/i,
+	/max_tokens_exceeded/i,
+	/context_length_exceeded/i,
+	/prompt_too_long/i,
+];
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export type TruncationResult = {
+	/** The (possibly truncated) content. */
+	content: string;
+	/** Original size in characters. */
+	originalSize: number;
+	/** Whether truncation was applied. */
+	wasTruncated: boolean;
+};
+
+export type OutputGuardConfig = {
+	/** Maximum characters per tool result (default: DEFAULT_MAX_TOOL_RESULT_CHARS). */
+	maxToolResultChars?: number;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Truncation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Format a byte/char count for human display.
+ */
+function formatSize(chars: number): string {
+	if (chars >= 1_000_000) {
+		return `${(chars / 1_000_000).toFixed(1)}M chars`;
+	}
+	if (chars >= 1_000) {
+		return `${(chars / 1_000).toFixed(1)}K chars`;
+	}
+	return `${chars} chars`;
+}
+
+/**
+ * Truncate a tool result string, keeping the beginning and end
+ * with a marker in the middle showing what was removed.
+ *
+ * Strategy: keep first portion + last TAIL_KEEP_CHARS, insert marker in between.
+ * The first portion gets the remaining budget after tail + marker.
+ * Tries to break at newline boundaries to avoid cutting mid-line.
+ */
+export function truncateToolResult(
+	content: string,
+	maxSize: number = DEFAULT_MAX_TOOL_RESULT_CHARS,
+): TruncationResult {
+	const originalSize = content.length;
+
+	if (originalSize <= maxSize) {
+		return { content, originalSize, wasTruncated: false };
+	}
+
+	const effectiveMax = Math.max(MIN_KEEP_CHARS, maxSize);
+	const removedSize = originalSize - effectiveMax;
+	const marker = TRUNCATION_MARKER.replace("%SIZE%", formatSize(removedSize));
+
+	// Budget for head = total budget - tail - marker
+	const tailSize = Math.min(TAIL_KEEP_CHARS, Math.floor(effectiveMax * 0.1));
+	const headBudget = effectiveMax - tailSize - marker.length;
+
+	if (headBudget < MIN_KEEP_CHARS) {
+		// Not enough room for head+tail split; just keep the head
+		let cutPoint = effectiveMax - marker.length;
+		const lastNewline = content.lastIndexOf("\n", cutPoint);
+		if (lastNewline > cutPoint * 0.8) {
+			cutPoint = lastNewline;
+		}
+		const truncated = content.slice(0, cutPoint) + marker;
+		return { content: truncated, originalSize, wasTruncated: true };
+	}
+
+	// Find clean break points
+	let headEnd = headBudget;
+	const headNewline = content.lastIndexOf("\n", headBudget);
+	if (headNewline > headBudget * 0.8) {
+		headEnd = headNewline;
+	}
+
+	let tailStart = originalSize - tailSize;
+	const tailNewline = content.indexOf("\n", tailStart);
+	if (tailNewline !== -1 && tailNewline < tailStart + tailSize * 0.2) {
+		tailStart = tailNewline + 1;
+	}
+
+	const truncated = content.slice(0, headEnd) + marker + content.slice(tailStart);
+	return { content: truncated, originalSize, wasTruncated: true };
+}
+
+/**
+ * Apply truncation to a tool result output value from the SDK stream.
+ * Handles string outputs directly; for structured outputs, serializes and truncates.
+ *
+ * Returns the original output unchanged if under the limit.
+ */
+export function guardToolResultOutput(
+	output: unknown,
+	maxSize: number = DEFAULT_MAX_TOOL_RESULT_CHARS,
+): { output: unknown; truncation?: TruncationResult } {
+	let content: string;
+
+	if (typeof output === "string") {
+		content = output;
+	} else if (output == null) {
+		return { output };
+	} else {
+		try {
+			content = JSON.stringify(output);
+		} catch {
+			content = String(output);
+		}
+	}
+
+	const result = truncateToolResult(content, maxSize);
+
+	if (!result.wasTruncated) {
+		return { output };
+	}
+
+	logger.info(
+		{
+			originalSize: result.originalSize,
+			truncatedSize: result.content.length,
+			reduction: `${((1 - result.content.length / result.originalSize) * 100).toFixed(1)}%`,
+		},
+		"tool result truncated by output guard",
+	);
+
+	// Return as string (the model handles string tool results fine)
+	return {
+		output: typeof output === "string" ? result.content : result.content,
+		truncation: result,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Context Overflow Detection
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Check if an error message indicates a context window overflow.
+ */
+export function isContextOverflowError(error: string | Error | unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error ?? "");
+	return CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+/**
+ * Build a recovery summary for context overflow.
+ * This provides context to the user about what happened and the recovery action.
+ */
+export function buildOverflowRecoverySummary(opts: {
+	poolKey?: string;
+	error: string;
+	numTurns: number;
+}): string {
+	return (
+		`[Context overflow detected after ${opts.numTurns} turn(s). ` +
+		`The conversation exceeded the model's context window. ` +
+		`Session will be reset. Error: ${opts.error}]`
+	);
+}

--- a/src/services/summarize.ts
+++ b/src/services/summarize.ts
@@ -9,6 +9,7 @@ import { getChildLogger } from "../logging.js";
 import { relaySummarize } from "../relay/capabilities-client.js";
 import { fetchWithGuard } from "../sandbox/fetch-guard.js";
 import { getMultimediaRateLimiter } from "./multimedia-rate-limit.js";
+import { getCachedOpenAIKey } from "./openai-client.js";
 
 const logger = getChildLogger({ module: "summarize" });
 
@@ -111,7 +112,10 @@ let clientPromise: Promise<import("@steipete/summarize-core/content").LinkPrevie
 async function getClient(): Promise<import("@steipete/summarize-core/content").LinkPreviewClient> {
 	if (!clientPromise) {
 		clientPromise = import("@steipete/summarize-core/content").then((mod) =>
-			mod.createLinkPreviewClient({ fetch: guardedFetch as typeof fetch }),
+			mod.createLinkPreviewClient({
+				fetch: guardedFetch as typeof fetch,
+				openaiApiKey: getCachedOpenAIKey() ?? undefined,
+			}),
 		);
 	}
 	return clientPromise;

--- a/src/telegram/types.ts
+++ b/src/telegram/types.ts
@@ -34,6 +34,7 @@ export type TelegramInboundMessage = {
 	from: string; // Normalized sender ID (tg:123456)
 	to: string; // Bot's ID
 	body: string; // Text content or caption
+	normalizedBody?: string; // Normalized body used for security classification/prompting
 	pushName?: string; // User's display name
 	username?: string; // @username if available
 	chatType?: "private" | "group" | "supergroup" | "channel"; // Chat type for security checks

--- a/tests/commands/audit-collectors.test.ts
+++ b/tests/commands/audit-collectors.test.ts
@@ -1,0 +1,678 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	collectConfigFindings,
+	collectDockerComposeFindings,
+	collectExposureMatrixFindings,
+	collectFilesystemFindings,
+	collectHookHardeningFindings,
+	collectSkillTrustFindings,
+	formatAuditReport,
+	runAuditCollectors,
+	type AuditFinding,
+	type AuditReport,
+} from "../../src/commands/audit-collectors.js";
+import type { TelclaudeConfig } from "../../src/config/config.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function makeMinimalConfig(overrides: Record<string, unknown> = {}): TelclaudeConfig {
+	return {
+		security: {
+			profile: "simple",
+			permissions: {
+				defaultTier: "READ_ONLY",
+				users: {},
+			},
+			...(overrides.security as Record<string, unknown> | undefined),
+		},
+		telegram: { heartbeatSeconds: 60 },
+		inbound: { reply: { enabled: true, timeoutSeconds: 600, typingIntervalSeconds: 8 } },
+		logging: {},
+		sdk: { betas: [] },
+		openai: {},
+		transcription: { provider: "openai", model: "whisper-1", timeoutSeconds: 60 },
+		imageGeneration: {
+			provider: "gpt-image",
+			model: "gpt-image-1.5",
+			size: "1024x1024",
+			quality: "medium",
+			maxPerHourPerUser: 10,
+			maxPerDayPerUser: 50,
+		},
+		videoProcessing: {
+			enabled: false,
+			frameInterval: 1,
+			maxFrames: 30,
+			maxDurationSeconds: 300,
+			extractAudio: true,
+		},
+		tts: {
+			provider: "openai",
+			voice: "alloy",
+			speed: 1.0,
+			autoReadResponses: false,
+			maxPerHourPerUser: 30,
+			maxPerDayPerUser: 100,
+		},
+		summarize: {
+			maxPerHourPerUser: 30,
+			maxPerDayPerUser: 100,
+			maxCharacters: 8000,
+			timeoutMs: 30000,
+		},
+		providers: [],
+		socialServices: [],
+		...overrides,
+	} as TelclaudeConfig;
+}
+
+function findBySeverity(findings: AuditFinding[], severity: string): AuditFinding[] {
+	return findings.filter((f) => f.severity === severity);
+}
+
+function findByCategory(findings: AuditFinding[], category: string): AuditFinding[] {
+	return findings.filter((f) => f.category === category);
+}
+
+function findByMessage(findings: AuditFinding[], substring: string): AuditFinding | undefined {
+	return findings.find((f) => f.message.includes(substring));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Config collector tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("collectConfigFindings", () => {
+	it("flags test profile as critical", () => {
+		const cfg = makeMinimalConfig({ security: { profile: "test" } });
+		const findings = collectConfigFindings(cfg, {});
+		const finding = findByMessage(findings, "test");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+		expect(finding!.category).toBe("config");
+	});
+
+	it("flags test profile as warning when env guard is set", () => {
+		const cfg = makeMinimalConfig({ security: { profile: "test" } });
+		const findings = collectConfigFindings(cfg, { TELCLAUDE_ENABLE_TEST_PROFILE: "1" });
+		const finding = findByMessage(findings, "test");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("flags open network mode as critical", () => {
+		const cfg = makeMinimalConfig();
+		const findings = collectConfigFindings(cfg, { TELCLAUDE_NETWORK_MODE: "open" });
+		const finding = findByMessage(findings, "TELCLAUDE_NETWORK_MODE=open");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("flags permissive network mode as warning", () => {
+		const cfg = makeMinimalConfig();
+		const findings = collectConfigFindings(cfg, { TELCLAUDE_NETWORK_MODE: "permissive" });
+		const finding = findByMessage(findings, "permissive");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("flags FULL_ACCESS default tier as critical", () => {
+		const cfg = makeMinimalConfig({
+			security: { profile: "simple", permissions: { defaultTier: "FULL_ACCESS", users: {} } },
+		});
+		const findings = collectConfigFindings(cfg, {});
+		const finding = findByMessage(findings, "FULL_ACCESS");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("flags WRITE_LOCAL default tier as warning", () => {
+		const cfg = makeMinimalConfig({
+			security: { profile: "simple", permissions: { defaultTier: "WRITE_LOCAL", users: {} } },
+		});
+		const findings = collectConfigFindings(cfg, {});
+		const finding = findByMessage(findings, "WRITE_LOCAL");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("does not flag READ_ONLY default tier", () => {
+		const cfg = makeMinimalConfig();
+		const findings = collectConfigFindings(cfg, {});
+		const finding = findByMessage(findings, "Default permission tier");
+		expect(finding).toBeUndefined();
+	});
+
+	it("flags disabled audit logging as warning", () => {
+		const cfg = makeMinimalConfig({
+			security: { profile: "simple", audit: { enabled: false } },
+		});
+		const findings = collectConfigFindings(cfg, {});
+		const finding = findByMessage(findings, "Audit logging is disabled");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("flags video processing enabled as warning", () => {
+		const cfg = makeMinimalConfig({
+			videoProcessing: {
+				enabled: true,
+				frameInterval: 1,
+				maxFrames: 30,
+				maxDurationSeconds: 300,
+				extractAudio: true,
+			},
+		});
+		const findings = collectConfigFindings(cfg, {});
+		const finding = findByMessage(findings, "Video processing");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("flags very long TOTP TTL as warning", () => {
+		const cfg = makeMinimalConfig({
+			security: { profile: "simple", totp: { sessionTtlMinutes: 720 } },
+		});
+		const findings = collectConfigFindings(cfg, {});
+		const finding = findByMessage(findings, "TOTP session TTL");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("clean config produces no critical findings", () => {
+		const cfg = makeMinimalConfig();
+		const findings = collectConfigFindings(cfg, {});
+		const critical = findBySeverity(findings, "critical");
+		expect(critical).toHaveLength(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Filesystem collector tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("collectFilesystemFindings", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-fs-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("flags world-readable config file as critical", () => {
+		const dockerDir = path.join(tempDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		const configFile = path.join(dockerDir, "telclaude.json");
+		fs.writeFileSync(configFile, "{}", "utf-8");
+		fs.chmodSync(configFile, 0o644);
+
+		const findings = collectFilesystemFindings(tempDir);
+		const finding = findByMessage(findings, "telclaude.json");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("flags group-writable config file as critical", () => {
+		const dockerDir = path.join(tempDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		const configFile = path.join(dockerDir, "telclaude-private.json");
+		fs.writeFileSync(configFile, "{}", "utf-8");
+		fs.chmodSync(configFile, 0o660);
+
+		const findings = collectFilesystemFindings(tempDir);
+		const finding = findByMessage(findings, "telclaude-private.json");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("no findings for properly secured config files", () => {
+		const dockerDir = path.join(tempDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		const configFile = path.join(dockerDir, "telclaude.json");
+		fs.writeFileSync(configFile, "{}", "utf-8");
+		fs.chmodSync(configFile, 0o600);
+
+		const findings = collectFilesystemFindings(tempDir);
+		const configFindings = findByCategory(findings, "fs").filter((f) =>
+			f.message.includes("telclaude.json"),
+		);
+		expect(configFindings).toHaveLength(0);
+	});
+
+	it("flags .env in project root", () => {
+		fs.writeFileSync(path.join(tempDir, ".env"), "SECRET=foo", "utf-8");
+		const findings = collectFilesystemFindings(tempDir);
+		const finding = findByMessage(findings, ".env file exists in project root");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Skill trust collector tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("collectSkillTrustFindings", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-skills-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("reports info when all skills are clean", () => {
+		const skillDir = path.join(tempDir, ".claude", "skills", "test-skill");
+		fs.mkdirSync(skillDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(skillDir, "SKILL.md"),
+			"# Test Skill\nA clean skill that does nothing dangerous.",
+			"utf-8",
+		);
+
+		const findings = collectSkillTrustFindings(tempDir);
+		// Should have an info finding about skills being clean (no critical or warning)
+		const skillFindings = findByCategory(findings, "skills");
+		expect(skillFindings.length).toBeGreaterThan(0);
+		const criticalSkill = skillFindings.filter((f) => f.severity === "critical");
+		expect(criticalSkill).toHaveLength(0);
+	});
+
+	it("flags skills-draft directory with contents", () => {
+		const draftDir = path.join(tempDir, ".claude", "skills-draft", "unvetted-skill");
+		fs.mkdirSync(draftDir, { recursive: true });
+		fs.writeFileSync(path.join(draftDir, "SKILL.md"), "# Unvetted", "utf-8");
+
+		const findings = collectSkillTrustFindings(tempDir);
+		const finding = findByMessage(findings, "skills-draft");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("returns empty for non-existent skills directory", () => {
+		const findings = collectSkillTrustFindings(tempDir);
+		// No skills dir means no findings
+		expect(findings).toHaveLength(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hook hardening collector tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("collectHookHardeningFindings", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-hooks-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("flags missing settings.json", () => {
+		const claudeDir = path.join(tempDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		// No settings.json created
+
+		const findings = collectHookHardeningFindings(tempDir);
+		const finding = findByMessage(findings, "settings.json not found");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("flags missing settingSources", () => {
+		const claudeDir = path.join(tempDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		fs.writeFileSync(path.join(claudeDir, "settings.json"), "{}", "utf-8");
+
+		const findings = collectHookHardeningFindings(tempDir);
+		const finding = findByMessage(findings, "settingSources not configured");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("flags disableAllHooks=true as critical", () => {
+		const claudeDir = path.join(tempDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(claudeDir, "settings.json"),
+			JSON.stringify({ settingSources: ["project"], disableAllHooks: true }),
+			"utf-8",
+		);
+
+		const findings = collectHookHardeningFindings(tempDir);
+		const finding = findByMessage(findings, "disableAllHooks is TRUE");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("flags user in settingSources as warning", () => {
+		const claudeDir = path.join(tempDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(claudeDir, "settings.json"),
+			JSON.stringify({ settingSources: ["project", "user"] }),
+			"utf-8",
+		);
+
+		const findings = collectHookHardeningFindings(tempDir);
+		const finding = findByMessage(findings, '"user"');
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("passes with correct settingSources", () => {
+		const claudeDir = path.join(tempDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		const settingsPath = path.join(claudeDir, "settings.json");
+		fs.writeFileSync(settingsPath, JSON.stringify({ settingSources: ["project"] }), "utf-8");
+		fs.chmodSync(settingsPath, 0o600);
+
+		const findings = collectHookHardeningFindings(tempDir);
+		const critical = findBySeverity(findings, "critical");
+		expect(critical).toHaveLength(0);
+	});
+
+	it("flags disableAllHooks in settings.local.json", () => {
+		const claudeDir = path.join(tempDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(claudeDir, "settings.json"),
+			JSON.stringify({ settingSources: ["project"] }),
+			"utf-8",
+		);
+		fs.writeFileSync(
+			path.join(claudeDir, "settings.local.json"),
+			JSON.stringify({ disableAllHooks: true }),
+			"utf-8",
+		);
+
+		const findings = collectHookHardeningFindings(tempDir);
+		const finding = findByMessage(findings, "settings.local.json");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Exposure matrix collector tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("collectExposureMatrixFindings", () => {
+	it("includes tier-to-tool matrix as info", () => {
+		const cfg = makeMinimalConfig();
+		const findings = collectExposureMatrixFindings(cfg);
+		const matrixFinding = findByMessage(findings, "Tier-to-tool exposure matrix");
+		expect(matrixFinding).toBeDefined();
+		expect(matrixFinding!.severity).toBe("info");
+		expect(matrixFinding!.category).toBe("exposure");
+	});
+
+	it("reports FULL_ACCESS users", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "simple",
+				permissions: {
+					defaultTier: "READ_ONLY",
+					users: {
+						admin123: { tier: "FULL_ACCESS" },
+					},
+				},
+			},
+		});
+		const findings = collectExposureMatrixFindings(cfg);
+		const finding = findByMessage(findings, "user(s) with FULL_ACCESS");
+		expect(finding).toBeDefined();
+		expect(finding!.message).toContain("admin123");
+	});
+
+	it("warns when no user permissions configured", () => {
+		const cfg = makeMinimalConfig({
+			security: { profile: "simple" },
+		});
+		const findings = collectExposureMatrixFindings(cfg);
+		const finding = findByMessage(findings, "No user permissions configured");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("warns about social services with enableSkills", () => {
+		const cfg = makeMinimalConfig({
+			socialServices: [
+				{
+					id: "moltbook",
+					type: "moltbook",
+					enabled: true,
+					enableSkills: true,
+					heartbeatIntervalHours: 4,
+					notifyOnHeartbeat: "activity",
+				},
+			],
+		});
+		const findings = collectExposureMatrixFindings(cfg);
+		const finding = findByMessage(findings, "enableSkills=true");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Docker compose collector tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("collectDockerComposeFindings", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-docker-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("flags docker socket mount as critical", () => {
+		const dockerDir = path.join(tempDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dockerDir, "docker-compose.yml"),
+			"volumes:\n  - /var/run/docker.sock:/var/run/docker.sock\n",
+			"utf-8",
+		);
+
+		const findings = collectDockerComposeFindings(tempDir);
+		const finding = findByMessage(findings, "Docker socket mount");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("flags host network mode as critical", () => {
+		const dockerDir = path.join(tempDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dockerDir, "docker-compose.yml"),
+			"services:\n  app:\n    network_mode: host\n",
+			"utf-8",
+		);
+
+		const findings = collectDockerComposeFindings(tempDir);
+		const finding = findByMessage(findings, "Host network mode");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("flags privileged mode as critical", () => {
+		const dockerDir = path.join(tempDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dockerDir, "docker-compose.yml"),
+			"services:\n  app:\n    privileged: true\n",
+			"utf-8",
+		);
+
+		const findings = collectDockerComposeFindings(tempDir);
+		const finding = findByMessage(findings, "Privileged mode");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("critical");
+	});
+
+	it("returns no findings for clean compose file", () => {
+		const dockerDir = path.join(tempDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dockerDir, "docker-compose.yml"),
+			"services:\n  app:\n    image: telclaude:latest\n",
+			"utf-8",
+		);
+
+		const findings = collectDockerComposeFindings(tempDir);
+		expect(findings).toHaveLength(0);
+	});
+
+	it("returns no findings when compose file does not exist", () => {
+		const findings = collectDockerComposeFindings(tempDir);
+		expect(findings).toHaveLength(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Integration: runAuditCollectors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("runAuditCollectors", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-integration-test-"));
+		// Create minimal directory structure with proper permissions
+		fs.mkdirSync(path.join(tempDir, ".claude"), { recursive: true });
+		const settingsPath = path.join(tempDir, ".claude", "settings.json");
+		fs.writeFileSync(settingsPath, JSON.stringify({ settingSources: ["project"] }), "utf-8");
+		fs.chmodSync(settingsPath, 0o600);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns structured report with summary", () => {
+		const cfg = makeMinimalConfig();
+		const report = runAuditCollectors(cfg, tempDir, {});
+		expect(report).toHaveProperty("findings");
+		expect(report).toHaveProperty("summary");
+		expect(report.summary).toHaveProperty("critical");
+		expect(report.summary).toHaveProperty("warning");
+		expect(report.summary).toHaveProperty("info");
+	});
+
+	it("clean config produces no critical findings", () => {
+		const cfg = makeMinimalConfig();
+		const report = runAuditCollectors(cfg, tempDir, {});
+		expect(report.summary.critical).toBe(0);
+	});
+
+	it("vulnerable config produces critical findings", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "test",
+				permissions: { defaultTier: "FULL_ACCESS", users: {} },
+			},
+		});
+
+		// Also add a docker-compose with dangerous mount
+		const dockerDir = path.join(tempDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dockerDir, "docker-compose.yml"),
+			"volumes:\n  - /var/run/docker.sock:/var/run/docker.sock\n",
+			"utf-8",
+		);
+
+		// Also set disableAllHooks
+		fs.writeFileSync(
+			path.join(tempDir, ".claude", "settings.json"),
+			JSON.stringify({ disableAllHooks: true }),
+			"utf-8",
+		);
+
+		const report = runAuditCollectors(cfg, tempDir, {});
+		expect(report.summary.critical).toBeGreaterThan(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// formatAuditReport tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("formatAuditReport", () => {
+	it("formats critical findings first", () => {
+		const report: AuditReport = {
+			findings: [
+				{ severity: "info", category: "config", message: "Info message" },
+				{ severity: "critical", category: "config", message: "Critical issue", fix: "Fix it" },
+				{ severity: "warning", category: "fs", message: "Warning message" },
+			],
+			summary: { critical: 1, warning: 1, info: 1 },
+		};
+
+		const output = formatAuditReport(report);
+		const criticalIdx = output.indexOf("CRITICAL");
+		const warningIdx = output.indexOf("WARNING");
+		const infoIdx = output.indexOf("INFO");
+
+		expect(criticalIdx).toBeLessThan(warningIdx);
+		expect(warningIdx).toBeLessThan(infoIdx);
+	});
+
+	it("shows FAIL status for critical findings", () => {
+		const report: AuditReport = {
+			findings: [{ severity: "critical", category: "config", message: "Bad" }],
+			summary: { critical: 1, warning: 0, info: 0 },
+		};
+
+		const output = formatAuditReport(report);
+		expect(output).toContain("FAIL");
+	});
+
+	it("shows PASS status when no issues", () => {
+		const report: AuditReport = {
+			findings: [],
+			summary: { critical: 0, warning: 0, info: 0 },
+		};
+
+		const output = formatAuditReport(report);
+		expect(output).toContain("PASS");
+	});
+
+	it("shows WARN status for warnings only", () => {
+		const report: AuditReport = {
+			findings: [{ severity: "warning", category: "fs", message: "Not great" }],
+			summary: { critical: 0, warning: 1, info: 0 },
+		};
+
+		const output = formatAuditReport(report);
+		expect(output).toContain("WARN");
+	});
+
+	it("includes fix instructions when present", () => {
+		const report: AuditReport = {
+			findings: [{ severity: "warning", category: "config", message: "Issue", fix: "chmod 600" }],
+			summary: { critical: 0, warning: 1, info: 0 },
+		};
+
+		const output = formatAuditReport(report);
+		expect(output).toContain("Fix: chmod 600");
+	});
+});

--- a/tests/commands/audit-fixers.test.ts
+++ b/tests/commands/audit-fixers.test.ts
@@ -1,0 +1,700 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FixAction, FixReport } from "../../src/commands/audit-fixers.js";
+import { formatFixReport, runAutoFix } from "../../src/commands/audit-fixers.js";
+import type { TelclaudeConfig } from "../../src/config/config.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+let tmpDir: string;
+
+function makeMinimalConfig(overrides?: Partial<TelclaudeConfig>): TelclaudeConfig {
+	const base: TelclaudeConfig = {
+		telegram: { heartbeatSeconds: 60 },
+		inbound: { reply: { enabled: true, timeoutSeconds: 600, typingIntervalSeconds: 8 } },
+		transcription: { provider: "openai", model: "whisper-1", timeoutSeconds: 60 },
+		imageGeneration: {
+			provider: "gpt-image",
+			model: "gpt-image-1.5",
+			size: "1024x1024",
+			quality: "medium",
+			maxPerHourPerUser: 10,
+			maxPerDayPerUser: 50,
+		},
+		videoProcessing: {
+			enabled: false,
+			frameInterval: 1,
+			maxFrames: 30,
+			maxDurationSeconds: 300,
+			extractAudio: true,
+		},
+		tts: {
+			provider: "openai",
+			voice: "alloy",
+			speed: 1.0,
+			autoReadResponses: false,
+			maxPerHourPerUser: 30,
+			maxPerDayPerUser: 100,
+		},
+		security: {
+			profile: "simple",
+			permissions: { defaultTier: "READ_ONLY", users: {} },
+			rateLimits: {
+				global: { perMinute: 100, perHour: 1000 },
+				perUser: { perMinute: 10, perHour: 100 },
+			},
+			audit: { enabled: true },
+		},
+		socialServices: [],
+		sdk: { betas: [] },
+	} as unknown as TelclaudeConfig;
+
+	if (overrides) {
+		return { ...base, ...overrides } as TelclaudeConfig;
+	}
+	return base;
+}
+
+function writeJsonFile(filePath: string, content: unknown): void {
+	const dir = path.dirname(filePath);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(filePath, `${JSON.stringify(content, null, "\t")}\n`, "utf-8");
+}
+
+function findByKind(actions: FixAction[], kind: string): FixAction[] {
+	return actions.filter((a) => a.kind === kind);
+}
+
+function findApplied(actions: FixAction[]): FixAction[] {
+	return actions.filter((a) => a.applied);
+}
+
+function findByTarget(actions: FixAction[], substring: string): FixAction | undefined {
+	return actions.find((a) => a.target.includes(substring));
+}
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-fixers-test-"));
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Config fixes
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("config fixes", () => {
+	it("changes test profile to simple", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "test",
+				permissions: { defaultTier: "READ_ONLY", users: {} },
+				rateLimits: { global: { perMinute: 100, perHour: 1000 }, perUser: { perMinute: 10, perHour: 100 } },
+				audit: { enabled: true },
+			},
+		} as Partial<TelclaudeConfig>);
+
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+		const profileFix = findByTarget(report.actions, "security.profile");
+		expect(profileFix).toBeDefined();
+		expect(profileFix!.applied).toBe(true);
+		expect(profileFix!.before).toBe("test");
+		expect(profileFix!.after).toBe("simple");
+
+		// Verify atomic write created backup
+		expect(report.configBackupPath).toBeTruthy();
+		expect(fs.existsSync(report.configBackupPath!)).toBe(true);
+
+		// Verify the config was actually written
+		const written = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+		expect(written.security.profile).toBe("simple");
+	});
+
+	it("skips test profile fix when TELCLAUDE_ENABLE_TEST_PROFILE=1", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "test",
+				permissions: { defaultTier: "READ_ONLY", users: {} },
+				rateLimits: { global: { perMinute: 100, perHour: 1000 }, perUser: { perMinute: 10, perHour: 100 } },
+				audit: { enabled: true },
+			},
+		} as Partial<TelclaudeConfig>);
+
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {
+			TELCLAUDE_ENABLE_TEST_PROFILE: "1",
+		});
+
+		const profileFix = findByTarget(report.actions, "security.profile");
+		expect(profileFix).toBeDefined();
+		expect(profileFix!.applied).toBe(false);
+		expect(profileFix!.skipped).toContain("intentional test mode");
+	});
+
+	it("lowers FULL_ACCESS default tier to READ_ONLY", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "simple",
+				permissions: { defaultTier: "FULL_ACCESS", users: {} },
+				rateLimits: { global: { perMinute: 100, perHour: 1000 }, perUser: { perMinute: 10, perHour: 100 } },
+				audit: { enabled: true },
+			},
+		} as Partial<TelclaudeConfig>);
+
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+		const tierFix = findByTarget(report.actions, "defaultTier");
+		expect(tierFix).toBeDefined();
+		expect(tierFix!.applied).toBe(true);
+		expect(tierFix!.before).toBe("FULL_ACCESS");
+		expect(tierFix!.after).toBe("READ_ONLY");
+
+		const written = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+		expect(written.security.permissions.defaultTier).toBe("READ_ONLY");
+	});
+
+	it("enables audit logging when disabled", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "simple",
+				permissions: { defaultTier: "READ_ONLY", users: {} },
+				rateLimits: { global: { perMinute: 100, perHour: 1000 }, perUser: { perMinute: 10, perHour: 100 } },
+				audit: { enabled: false },
+			},
+		} as Partial<TelclaudeConfig>);
+
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+		const auditFix = findByTarget(report.actions, "audit.enabled");
+		expect(auditFix).toBeDefined();
+		expect(auditFix!.applied).toBe(true);
+
+		const written = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+		expect(written.security.audit.enabled).toBe(true);
+	});
+
+	it("does not write config when no config changes needed", () => {
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+		expect(report.configBackupPath).toBeNull();
+		// No .bak file should exist
+		expect(fs.existsSync(`${configPath}.bak`)).toBe(false);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Atomic write + backup
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("atomic write + backup", () => {
+	it("creates .bak with original content", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "test",
+				permissions: { defaultTier: "READ_ONLY", users: {} },
+				rateLimits: { global: { perMinute: 100, perHour: 1000 }, perUser: { perMinute: 10, perHour: 100 } },
+				audit: { enabled: true },
+			},
+		} as Partial<TelclaudeConfig>);
+
+		const configPath = path.join(tmpDir, "telclaude.json");
+		const originalContent = `${JSON.stringify(cfg, null, "\t")}\n`;
+		writeJsonFile(configPath, cfg);
+
+		runAutoFix(cfg, configPath, tmpDir, {});
+
+		const bakPath = `${configPath}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(true);
+
+		// Backup should contain the original config
+		const bakContent = fs.readFileSync(bakPath, "utf-8");
+		const bakParsed = JSON.parse(bakContent);
+		expect(bakParsed.security.profile).toBe("test");
+	});
+
+	it("sets 600 permissions on written config", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "test",
+				permissions: { defaultTier: "READ_ONLY", users: {} },
+				rateLimits: { global: { perMinute: 100, perHour: 1000 }, perUser: { perMinute: 10, perHour: 100 } },
+				audit: { enabled: true },
+			},
+		} as Partial<TelclaudeConfig>);
+
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+		fs.chmodSync(configPath, 0o644); // Start with loose permissions
+
+		runAutoFix(cfg, configPath, tmpDir, {});
+
+		const mode = fs.statSync(configPath).mode & 0o777;
+		expect(mode).toBe(0o600);
+	});
+
+	it("no .tmp file left behind after write", () => {
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "test",
+				permissions: { defaultTier: "READ_ONLY", users: {} },
+				rateLimits: { global: { perMinute: 100, perHour: 1000 }, perUser: { perMinute: 10, perHour: 100 } },
+				audit: { enabled: true },
+			},
+		} as Partial<TelclaudeConfig>);
+
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		runAutoFix(cfg, configPath, tmpDir, {});
+
+		expect(fs.existsSync(`${configPath}.tmp`)).toBe(false);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Filesystem permission fixes
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("filesystem permission fixes", () => {
+	it("tightens world-readable config files", () => {
+		const dockerDir = path.join(tmpDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+
+		const configFile = path.join(dockerDir, "telclaude.json");
+		fs.writeFileSync(configFile, "{}", "utf-8");
+		fs.chmodSync(configFile, 0o644); // world-readable
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "main-config.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const chmodActions = findByKind(report.actions, "chmod").filter(
+			(a) => a.target === configFile,
+		);
+		expect(chmodActions.length).toBe(1);
+		expect(chmodActions[0].applied).toBe(true);
+		expect(chmodActions[0].before).toBe("644");
+		expect(chmodActions[0].after).toBe("600");
+
+		const mode = fs.statSync(configFile).mode & 0o777;
+		expect(mode).toBe(0o600);
+	});
+
+	it("skips files with correct permissions", () => {
+		const dockerDir = path.join(tmpDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+
+		const configFile = path.join(dockerDir, "telclaude.json");
+		fs.writeFileSync(configFile, "{}", "utf-8");
+		fs.chmodSync(configFile, 0o600); // already correct
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "main-config.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const chmodAction = findByKind(report.actions, "chmod").find(
+			(a) => a.target === configFile,
+		);
+		expect(chmodAction).toBeDefined();
+		expect(chmodAction!.applied).toBe(false);
+		expect(chmodAction!.skipped).toBe("already correct");
+	});
+
+	it("never loosens permissions", () => {
+		const dockerDir = path.join(tmpDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+
+		const configFile = path.join(dockerDir, "telclaude.json");
+		fs.writeFileSync(configFile, "{}", "utf-8");
+		fs.chmodSync(configFile, 0o400); // stricter than target 600
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "main-config.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const chmodAction = findByKind(report.actions, "chmod").find(
+			(a) => a.target === configFile,
+		);
+		expect(chmodAction).toBeDefined();
+		expect(chmodAction!.applied).toBe(false);
+		expect(chmodAction!.skipped).toBe("current permissions are already stricter");
+
+		// Permissions should remain unchanged
+		const mode = fs.statSync(configFile).mode & 0o777;
+		expect(mode).toBe(0o400);
+	});
+
+	it("skips symlinks", () => {
+		const dockerDir = path.join(tmpDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+
+		const realFile = path.join(tmpDir, "real-config.json");
+		fs.writeFileSync(realFile, "{}", "utf-8");
+
+		const symlinkFile = path.join(dockerDir, "telclaude.json");
+		fs.symlinkSync(realFile, symlinkFile);
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "main-config.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const chmodAction = findByKind(report.actions, "chmod").find(
+			(a) => a.target === symlinkFile,
+		);
+		expect(chmodAction).toBeDefined();
+		expect(chmodAction!.applied).toBe(false);
+		expect(chmodAction!.skipped).toContain("symlink");
+	});
+
+	it("skips missing files without error", () => {
+		// Don't create any docker files
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "main-config.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const missingActions = findByKind(report.actions, "chmod").filter(
+			(a) => a.skipped === "file not found",
+		);
+		expect(missingActions.length).toBeGreaterThan(0);
+		expect(report.summary.errors).toBe(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hook hardening fixes
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("hook hardening fixes", () => {
+	it("creates settings.json when missing", () => {
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const createAction = findByKind(report.actions, "create").find(
+			(a) => a.target.includes("settings.json"),
+		);
+		expect(createAction).toBeDefined();
+		expect(createAction!.applied).toBe(true);
+
+		const settingsFile = path.join(tmpDir, ".claude", "settings.json");
+		expect(fs.existsSync(settingsFile)).toBe(true);
+
+		const settings = JSON.parse(fs.readFileSync(settingsFile, "utf-8"));
+		expect(settings.settingSources).toEqual(["project"]);
+
+		// Should have restrictive permissions
+		const mode = fs.statSync(settingsFile).mode & 0o777;
+		expect(mode).toBe(0o600);
+	});
+
+	it("adds settingSources when missing from existing settings.json", () => {
+		const claudeDir = path.join(tmpDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		const settingsFile = path.join(claudeDir, "settings.json");
+		writeJsonFile(settingsFile, { someOther: "setting" });
+		fs.chmodSync(settingsFile, 0o600);
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const action = findByTarget(report.actions, "settingSources");
+		expect(action).toBeDefined();
+		expect(action!.applied).toBe(true);
+
+		const settings = JSON.parse(fs.readFileSync(settingsFile, "utf-8"));
+		expect(settings.settingSources).toEqual(["project"]);
+		expect(settings.someOther).toBe("setting"); // Preserved existing settings
+	});
+
+	it("removes disableAllHooks from settings.json", () => {
+		const claudeDir = path.join(tmpDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		const settingsFile = path.join(claudeDir, "settings.json");
+		writeJsonFile(settingsFile, {
+			settingSources: ["project"],
+			disableAllHooks: true,
+		});
+		fs.chmodSync(settingsFile, 0o600);
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const action = findByTarget(report.actions, "disableAllHooks");
+		expect(action).toBeDefined();
+		expect(action!.applied).toBe(true);
+		expect(action!.before).toBe("true");
+		expect(action!.after).toBe("(removed)");
+
+		const settings = JSON.parse(fs.readFileSync(settingsFile, "utf-8"));
+		expect(settings.disableAllHooks).toBeUndefined();
+		expect(settings.settingSources).toEqual(["project"]); // Preserved
+	});
+
+	it("removes disableAllHooks from settings.local.json", () => {
+		const claudeDir = path.join(tmpDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+
+		// Main settings file exists and is fine
+		const settingsFile = path.join(claudeDir, "settings.json");
+		writeJsonFile(settingsFile, { settingSources: ["project"] });
+		fs.chmodSync(settingsFile, 0o600);
+
+		// Local settings has the bad flag
+		const localSettingsFile = path.join(claudeDir, "settings.local.json");
+		writeJsonFile(localSettingsFile, {
+			disableAllHooks: true,
+			otherSetting: "keep",
+		});
+		fs.chmodSync(localSettingsFile, 0o600);
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const action = report.actions.find(
+			(a) => a.target.includes("settings.local.json") && a.target.includes("disableAllHooks"),
+		);
+		expect(action).toBeDefined();
+		expect(action!.applied).toBe(true);
+
+		const localSettings = JSON.parse(fs.readFileSync(localSettingsFile, "utf-8"));
+		expect(localSettings.disableAllHooks).toBeUndefined();
+		expect(localSettings.otherSetting).toBe("keep"); // Preserved
+	});
+
+	it("does not touch settings.json when already correct", () => {
+		const claudeDir = path.join(tmpDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		const settingsFile = path.join(claudeDir, "settings.json");
+		writeJsonFile(settingsFile, { settingSources: ["project"] });
+		fs.chmodSync(settingsFile, 0o600);
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		// No "create" or "config" actions for settings.json (only chmod which should be skipped)
+		const settingsActions = report.actions.filter(
+			(a) => a.target.includes("settings.json") && !a.target.includes("local"),
+		);
+		const appliedSettingsActions = settingsActions.filter((a) => a.applied);
+		expect(appliedSettingsActions.length).toBe(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Integration: runAutoFix
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("runAutoFix integration", () => {
+	it("clean config produces no applied actions", () => {
+		const claudeDir = path.join(tmpDir, ".claude");
+		fs.mkdirSync(claudeDir, { recursive: true });
+		const settingsFile = path.join(claudeDir, "settings.json");
+		writeJsonFile(settingsFile, { settingSources: ["project"] });
+		fs.chmodSync(settingsFile, 0o600);
+
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		expect(report.summary.applied).toBe(0);
+		expect(report.summary.errors).toBe(0);
+		expect(report.configBackupPath).toBeNull();
+	});
+
+	it("applies multiple fixes in one run", () => {
+		const dockerDir = path.join(tmpDir, "docker");
+		fs.mkdirSync(dockerDir, { recursive: true });
+		const dockerConfig = path.join(dockerDir, "telclaude.json");
+		fs.writeFileSync(dockerConfig, "{}", "utf-8");
+		fs.chmodSync(dockerConfig, 0o644); // loose permissions
+
+		const cfg = makeMinimalConfig({
+			security: {
+				profile: "test",
+				permissions: { defaultTier: "FULL_ACCESS", users: {} },
+				rateLimits: { global: { perMinute: 100, perHour: 1000 }, perUser: { perMinute: 10, perHour: 100 } },
+				audit: { enabled: false },
+			},
+		} as Partial<TelclaudeConfig>);
+
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		// Should have: profile fix, tier fix, audit fix, chmod fix, settings.json create
+		expect(report.summary.applied).toBeGreaterThanOrEqual(5);
+		expect(report.summary.errors).toBe(0);
+		expect(report.configBackupPath).toBeTruthy();
+	});
+
+	it("report summary counts are correct", () => {
+		const cfg = makeMinimalConfig();
+		const configPath = path.join(tmpDir, "telclaude.json");
+		writeJsonFile(configPath, cfg);
+
+		const report = runAutoFix(cfg, configPath, tmpDir, {});
+
+		const applied = report.actions.filter((a) => a.applied).length;
+		const errored = report.actions.filter((a) => a.error).length;
+		const skipped = report.actions.filter((a) => !a.applied && !a.error).length;
+
+		expect(report.summary.applied).toBe(applied);
+		expect(report.summary.errors).toBe(errored);
+		expect(report.summary.skipped).toBe(skipped);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// formatFixReport
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("formatFixReport", () => {
+	it("shows CLEAN status when nothing to fix", () => {
+		const report: FixReport = {
+			actions: [],
+			configBackupPath: null,
+			summary: { applied: 0, skipped: 0, errors: 0 },
+		};
+
+		const output = formatFixReport(report);
+		expect(output).toContain("CLEAN");
+		expect(output).toContain("nothing to fix");
+	});
+
+	it("shows FIXED status when fixes applied", () => {
+		const report: FixReport = {
+			actions: [
+				{
+					kind: "config",
+					target: "security.profile",
+					description: "Change test profile to simple",
+					before: "test",
+					after: "simple",
+					applied: true,
+				},
+			],
+			configBackupPath: "/tmp/backup.bak",
+			summary: { applied: 1, skipped: 0, errors: 0 },
+		};
+
+		const output = formatFixReport(report);
+		expect(output).toContain("FIXED");
+		expect(output).toContain("APPLIED:");
+		expect(output).toContain("test -> simple");
+		expect(output).toContain("/tmp/backup.bak");
+	});
+
+	it("shows PARTIAL status on errors", () => {
+		const report: FixReport = {
+			actions: [
+				{
+					kind: "chmod",
+					target: "/some/file",
+					description: "Tighten permissions",
+					before: null,
+					after: "600",
+					applied: false,
+					error: "EPERM",
+				},
+			],
+			configBackupPath: null,
+			summary: { applied: 0, skipped: 0, errors: 1 },
+		};
+
+		const output = formatFixReport(report);
+		expect(output).toContain("PARTIAL");
+		expect(output).toContain("ERRORS:");
+		expect(output).toContain("EPERM");
+	});
+
+	it("hides 'file not found' skips", () => {
+		const report: FixReport = {
+			actions: [
+				{
+					kind: "chmod",
+					target: "/missing/file",
+					description: "Tighten permissions",
+					before: null,
+					after: "600",
+					applied: false,
+					skipped: "file not found",
+				},
+				{
+					kind: "chmod",
+					target: "/some/file",
+					description: "Tighten permissions",
+					before: "644",
+					after: "600",
+					applied: false,
+					skipped: "already correct",
+				},
+			],
+			configBackupPath: null,
+			summary: { applied: 0, skipped: 2, errors: 0 },
+		};
+
+		const output = formatFixReport(report);
+		expect(output).toContain("SKIPPED:");
+		expect(output).toContain("already correct");
+		expect(output).not.toContain("file not found");
+	});
+
+	it("shows summary counts", () => {
+		const report: FixReport = {
+			actions: [],
+			configBackupPath: null,
+			summary: { applied: 3, skipped: 5, errors: 1 },
+		};
+
+		const output = formatFixReport(report);
+		expect(output).toContain("3 applied");
+		expect(output).toContain("5 skipped");
+		expect(output).toContain("1 errors");
+	});
+});

--- a/tests/sandbox/fetch-guard.test.ts
+++ b/tests/sandbox/fetch-guard.test.ts
@@ -1,0 +1,489 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	FetchGuardError,
+	createPinnedLookup,
+	fetchWithGuard,
+} from "../../src/sandbox/fetch-guard.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Mock cachedDNSLookup for controlled test scenarios
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const mockDNSResults = new Map<string, string[] | null>();
+
+vi.mock("../../src/sandbox/network-proxy.js", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		cachedDNSLookup: async (host: string): Promise<string[] | null> => {
+			if (mockDNSResults.has(host)) {
+				return mockDNSResults.get(host) ?? null;
+			}
+			// Default: return a public IP for any hostname
+			return ["93.184.216.34"];
+		},
+	};
+});
+
+// Suppress logger output in tests
+vi.mock("../../src/logging.js", () => ({
+	getChildLogger: () => ({
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		debug: () => {},
+	}),
+}));
+
+afterEach(() => {
+	mockDNSResults.clear();
+	vi.restoreAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// createPinnedLookup tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("createPinnedLookup", () => {
+	it("returns pinned addresses for the target hostname", () => {
+		const lookup = createPinnedLookup("example.com", ["1.2.3.4", "5.6.7.8"]);
+		const results: string[] = [];
+
+		lookup("example.com", {}, (err, address) => {
+			expect(err).toBeNull();
+			results.push(address as string);
+		});
+		lookup("example.com", {}, (err, address) => {
+			expect(err).toBeNull();
+			results.push(address as string);
+		});
+
+		// Round-robin
+		expect(results).toEqual(["1.2.3.4", "5.6.7.8"]);
+	});
+
+	it("returns all addresses when options.all is true", () => {
+		const lookup = createPinnedLookup("example.com", ["1.2.3.4", "::1"]);
+
+		lookup("example.com", { all: true }, (err, addresses) => {
+			expect(err).toBeNull();
+			expect(addresses).toEqual([
+				{ address: "1.2.3.4", family: 4 },
+				{ address: "::1", family: 6 },
+			]);
+		});
+	});
+
+	it("rejects lookups for non-pinned hostnames", () => {
+		const lookup = createPinnedLookup("example.com", ["1.2.3.4"]);
+
+		lookup("evil.com", {}, (err) => {
+			expect(err).toBeTruthy();
+			expect((err as NodeJS.ErrnoException).code).toBe("ENOTFOUND");
+		});
+	});
+
+	it("handles case-insensitive hostname matching", () => {
+		const lookup = createPinnedLookup("Example.COM", ["1.2.3.4"]);
+
+		lookup("example.com", {}, (err, address) => {
+			expect(err).toBeNull();
+			expect(address).toBe("1.2.3.4");
+		});
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// fetchWithGuard tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("fetchWithGuard", () => {
+	// ─── Blocking tests (no real server needed) ───
+
+	it("blocks URLs resolving to private IPs", async () => {
+		mockDNSResults.set("evil-redirect.example", ["192.168.1.1"]);
+
+		await expect(
+			fetchWithGuard({ url: "http://evil-redirect.example/foo" }),
+		).rejects.toThrow(FetchGuardError);
+
+		await expect(
+			fetchWithGuard({ url: "http://evil-redirect.example/foo" }),
+		).rejects.toThrow(/private\/internal IP/);
+	});
+
+	it("blocks URLs resolving to metadata IPs (non-overridable)", async () => {
+		mockDNSResults.set("sneaky.example", ["169.254.169.254"]);
+
+		await expect(
+			fetchWithGuard({ url: "http://sneaky.example/latest/meta-data" }),
+		).rejects.toThrow(FetchGuardError);
+
+		await expect(
+			fetchWithGuard({ url: "http://sneaky.example/latest/meta-data" }),
+		).rejects.toThrow(/non-overridable/);
+	});
+
+	it("blocks literal private IP URLs", async () => {
+		await expect(fetchWithGuard({ url: "http://10.0.0.1/admin" })).rejects.toThrow(
+			FetchGuardError,
+		);
+	});
+
+	it("blocks literal metadata IP URLs", async () => {
+		await expect(
+			fetchWithGuard({ url: "http://169.254.169.254/latest/meta-data" }),
+		).rejects.toThrow(FetchGuardError);
+	});
+
+	it("blocks CGNAT range IPs", async () => {
+		mockDNSResults.set("tailscale-peer.example", ["100.100.0.1"]);
+
+		await expect(fetchWithGuard({ url: "http://tailscale-peer.example/" })).rejects.toThrow(
+			FetchGuardError,
+		);
+	});
+
+	it("blocks when DNS resolves to mixed public+private IPs (dual-stack bypass)", async () => {
+		mockDNSResults.set("dual.example", ["93.184.216.34", "10.0.0.1"]);
+
+		await expect(fetchWithGuard({ url: "http://dual.example/" })).rejects.toThrow(
+			FetchGuardError,
+		);
+
+		await expect(fetchWithGuard({ url: "http://dual.example/" })).rejects.toThrow(
+			/private\/internal IP/,
+		);
+	});
+
+	it("blocks when DNS fails to resolve", async () => {
+		mockDNSResults.set("nonexistent.invalid", null);
+
+		await expect(fetchWithGuard({ url: "http://nonexistent.invalid/" })).rejects.toThrow(
+			FetchGuardError,
+		);
+
+		await expect(fetchWithGuard({ url: "http://nonexistent.invalid/" })).rejects.toThrow(
+			/DNS resolution failed/,
+		);
+	});
+
+	it("blocks non-http(s) protocols", async () => {
+		await expect(fetchWithGuard({ url: "ftp://example.com/file" })).rejects.toThrow(
+			FetchGuardError,
+		);
+
+		await expect(fetchWithGuard({ url: "file:///etc/passwd" })).rejects.toThrow(FetchGuardError);
+	});
+
+	it("rejects invalid URLs", async () => {
+		await expect(fetchWithGuard({ url: "not-a-url" })).rejects.toThrow(FetchGuardError);
+	});
+
+	// ─── IPv6 blocking ───
+
+	it("blocks IPv6 link-local addresses", async () => {
+		mockDNSResults.set("v6local.example", ["fe80::1"]);
+
+		await expect(fetchWithGuard({ url: "http://v6local.example/" })).rejects.toThrow(
+			FetchGuardError,
+		);
+	});
+
+	it("blocks IPv6 unique-local addresses", async () => {
+		mockDNSResults.set("v6ula.example", ["fd12:3456::1"]);
+
+		await expect(fetchWithGuard({ url: "http://v6ula.example/" })).rejects.toThrow(
+			FetchGuardError,
+		);
+	});
+
+	it("blocks IPv4-mapped IPv6 private addresses", async () => {
+		mockDNSResults.set("v4mapped.example", ["::ffff:192.168.1.1"]);
+
+		await expect(fetchWithGuard({ url: "http://v4mapped.example/" })).rejects.toThrow(
+			FetchGuardError,
+		);
+	});
+
+	it("includes auditContext in error logging", async () => {
+		mockDNSResults.set("audit-test.example", ["10.0.0.1"]);
+
+		await expect(
+			fetchWithGuard({
+				url: "http://audit-test.example/",
+				auditContext: "test-consumer",
+			}),
+		).rejects.toThrow(FetchGuardError);
+	});
+
+	// ─── Happy path (with mocked global fetch) ───
+
+	it("allows URLs resolving to public IPs", async () => {
+		mockDNSResults.set("safe.example", ["93.184.216.34"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response("hello world", {
+				status: 200,
+				headers: { "Content-Type": "text/plain" },
+			}),
+		);
+
+		const result = await fetchWithGuard({
+			url: "http://safe.example/page",
+		});
+
+		expect(result.response.status).toBe(200);
+		expect(result.finalUrl).toBe("http://safe.example/page");
+		expect(typeof result.release).toBe("function");
+
+		const body = await result.response.text();
+		expect(body).toBe("hello world");
+		await result.release();
+
+		expect(mockFetch).toHaveBeenCalledOnce();
+		// Verify fetch was called with redirect: "manual" and a dispatcher
+		const callInit = mockFetch.mock.calls[0][1] as RequestInit & { dispatcher?: unknown };
+		expect(callInit.redirect).toBe("manual");
+		expect(callInit.dispatcher).toBeTruthy();
+	});
+
+	// ─── Redirect handling (with mocked global fetch) ───
+
+	it("follows redirects and re-validates each hop", async () => {
+		mockDNSResults.set("start.example", ["93.184.216.34"]);
+		mockDNSResults.set("middle.example", ["93.184.216.35"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch");
+
+		// First call: redirect
+		mockFetch.mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { Location: "http://middle.example/final" },
+			}),
+		);
+
+		// Second call: final response
+		mockFetch.mockResolvedValueOnce(
+			new Response("redirected content", {
+				status: 200,
+				headers: { "Content-Type": "text/plain" },
+			}),
+		);
+
+		const result = await fetchWithGuard({
+			url: "http://start.example/begin",
+		});
+
+		expect(result.response.status).toBe(200);
+		expect(result.finalUrl).toBe("http://middle.example/final");
+		const body = await result.response.text();
+		expect(body).toBe("redirected content");
+		await result.release();
+
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("blocks redirect to private IP (SSRF redirect bypass)", async () => {
+		mockDNSResults.set("legit.example", ["93.184.216.34"]);
+		mockDNSResults.set("internal.corp", ["192.168.1.100"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch");
+
+		// First call: redirect to private host
+		mockFetch.mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { Location: "http://internal.corp/secret" },
+			}),
+		);
+
+		const err = await fetchWithGuard({ url: "http://legit.example/go" }).catch((e) => e);
+		expect(err).toBeInstanceOf(FetchGuardError);
+		expect(err.message).toMatch(/private\/internal IP/);
+	});
+
+	it("blocks redirect to metadata IP (SSRF redirect bypass)", async () => {
+		mockDNSResults.set("legit2.example", ["93.184.216.34"]);
+		mockDNSResults.set("sneaky-meta.example", ["169.254.169.254"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch");
+		mockFetch.mockResolvedValueOnce(
+			new Response(null, {
+				status: 301,
+				headers: { Location: "http://sneaky-meta.example/latest/meta-data" },
+			}),
+		);
+
+		await expect(
+			fetchWithGuard({ url: "http://legit2.example/" }),
+		).rejects.toThrow(/non-overridable/);
+	});
+
+	it("enforces max redirect cap", async () => {
+		mockDNSResults.set("chain.example", ["93.184.216.34"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch");
+
+		// Create 4 redirects (exceeds default cap of 3)
+		for (let i = 0; i < 4; i++) {
+			mockFetch.mockResolvedValueOnce(
+				new Response(null, {
+					status: 302,
+					headers: { Location: `http://chain.example/step${i + 1}` },
+				}),
+			);
+		}
+
+		await expect(
+			fetchWithGuard({ url: "http://chain.example/start" }),
+		).rejects.toThrow(/Too many redirects/);
+	});
+
+	it("detects redirect loops", async () => {
+		mockDNSResults.set("loop.example", ["93.184.216.34"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch");
+
+		// First redirect: /a -> /b
+		mockFetch.mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { Location: "http://loop.example/b" },
+			}),
+		);
+
+		// Second redirect: /b -> /a (loop! — /a is the initial URL, already in visited)
+		mockFetch.mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { Location: "http://loop.example/a" },
+			}),
+		);
+
+		await expect(
+			fetchWithGuard({ url: "http://loop.example/a" }),
+		).rejects.toThrow(/Redirect loop detected/);
+	});
+
+	it("handles redirect with missing Location header", async () => {
+		mockDNSResults.set("bad.example", ["93.184.216.34"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch");
+		mockFetch.mockResolvedValueOnce(
+			new Response(null, { status: 302 }),
+		);
+
+		await expect(
+			fetchWithGuard({ url: "http://bad.example/" }),
+		).rejects.toThrow(/missing Location header/);
+	});
+
+	it("respects custom maxRedirects option", async () => {
+		mockDNSResults.set("custom.example", ["93.184.216.34"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch");
+
+		// 2 redirects (exceeds custom cap of 1)
+		mockFetch.mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { Location: "http://custom.example/step1" },
+			}),
+		);
+		mockFetch.mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { Location: "http://custom.example/step2" },
+			}),
+		);
+
+		await expect(
+			fetchWithGuard({ url: "http://custom.example/start", maxRedirects: 1 }),
+		).rejects.toThrow(/Too many redirects \(limit: 1\)/);
+	});
+
+	// ─── Timeout tests ───
+
+	it("aborts on timeout", async () => {
+		mockDNSResults.set("slow.example", ["93.184.216.34"]);
+
+		// Mock fetch to hang indefinitely
+		const mockFetch = vi.spyOn(globalThis, "fetch").mockImplementation(
+			(_url, init) =>
+				new Promise((_resolve, reject) => {
+					// Listen for abort signal
+					const signal = (init as RequestInit)?.signal;
+					if (signal?.aborted) {
+						reject(signal.reason);
+						return;
+					}
+					signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+				}),
+		);
+
+		await expect(
+			fetchWithGuard({
+				url: "http://slow.example/",
+				timeoutMs: 50,
+			}),
+		).rejects.toThrow();
+
+		mockFetch.mockRestore();
+	});
+
+	it("respects external abort signal", async () => {
+		mockDNSResults.set("abortable.example", ["93.184.216.34"]);
+		const controller = new AbortController();
+
+		const mockFetch = vi.spyOn(globalThis, "fetch").mockImplementation(
+			(_url, init) =>
+				new Promise((_resolve, reject) => {
+					const signal = (init as RequestInit)?.signal;
+					if (signal?.aborted) {
+						reject(signal.reason);
+						return;
+					}
+					signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+				}),
+		);
+
+		// Abort immediately
+		controller.abort(new Error("user cancelled"));
+
+		await expect(
+			fetchWithGuard({
+				url: "http://abortable.example/",
+				signal: controller.signal,
+			}),
+		).rejects.toThrow();
+
+		mockFetch.mockRestore();
+	});
+
+	// ─── DNS rebinding simulation ───
+
+	it("prevents DNS rebinding via pinned lookup", async () => {
+		// Even if DNS would return a different IP on second resolution,
+		// the pinned lookup ensures the original validated IPs are used
+		// for the actual TCP connection.
+		mockDNSResults.set("rebind.example", ["93.184.216.34"]);
+
+		const mockFetch = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response("safe", { status: 200 }),
+		);
+
+		const result = await fetchWithGuard({
+			url: "http://rebind.example/",
+		});
+
+		expect(result.response.status).toBe(200);
+		await result.release();
+
+		// Verify dispatcher was passed (proving DNS was pinned)
+		const callInit = mockFetch.mock.calls[0][1] as RequestInit & { dispatcher?: unknown };
+		expect(callInit.dispatcher).toBeTruthy();
+	});
+});

--- a/tests/sandbox/validate-config.test.ts
+++ b/tests/sandbox/validate-config.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { auditSandboxPosture } from "../../src/sandbox/validate-config.js";
+
+const TEMP_DIRS: string[] = [];
+
+function createFixture(params: {
+	composeContent: string;
+	envContent?: string;
+}): {
+	rootDir: string;
+	composePath: string;
+	envPath: string;
+} {
+	const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "telclaude-sandbox-audit-"));
+	TEMP_DIRS.push(rootDir);
+
+	const dockerDir = path.join(rootDir, "docker");
+	fs.mkdirSync(dockerDir, { recursive: true });
+
+	const composePath = path.join(dockerDir, "docker-compose.yml");
+	fs.writeFileSync(composePath, params.composeContent, "utf8");
+
+	const envPath = path.join(dockerDir, ".env");
+	fs.writeFileSync(envPath, params.envContent ?? "", "utf8");
+
+	return { rootDir, composePath, envPath };
+}
+
+describe("auditSandboxPosture", () => {
+	afterEach(() => {
+		for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("flags dangerous compose settings and docker socket mounts", () => {
+		const fixture = createFixture({
+			composeContent: `
+services:
+  telclaude-agent:
+    network_mode: host
+    privileged: true
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+`,
+		});
+
+		const findings = auditSandboxPosture({
+			composePath: fixture.composePath,
+			envPath: fixture.envPath,
+		});
+
+		expect(findings.some((f) => f.message.includes("network_mode=host"))).toBe(true);
+		expect(findings.some((f) => f.message.includes("privileged=true"))).toBe(true);
+		expect(findings.some((f) => f.message.includes("seccomp:unconfined"))).toBe(true);
+		expect(findings.some((f) => f.message.includes("apparmor:unconfined"))).toBe(true);
+		expect(findings.some((f) => f.message.includes("Docker socket"))).toBe(true);
+		expect(findings.every((f) => f.severity === "critical")).toBe(true);
+	});
+
+	it("detects symlink bind-mount escape to blocked host paths", () => {
+		const fixture = createFixture({
+			composeContent: `
+services:
+  telclaude-agent:
+    volumes:
+      - ./escape-link:/workspace:ro
+`,
+		});
+		const escapeLink = path.join(path.dirname(fixture.composePath), "escape-link");
+		fs.symlinkSync("/etc", escapeLink);
+
+		const findings = auditSandboxPosture({
+			composePath: fixture.composePath,
+			envPath: fixture.envPath,
+		});
+
+		expect(findings.some((f) => f.message.includes("symlink"))).toBe(true);
+		expect(findings.some((f) => f.message.includes("/etc"))).toBe(true);
+	});
+
+	it("flags permissive network mode and sensitive env exposure for agent services", () => {
+		const fixture = createFixture({
+			composeContent: `
+services:
+  telclaude-agent:
+    environment:
+      - TELEGRAM_BOT_TOKEN=\${TELEGRAM_BOT_TOKEN:-}
+`,
+			envContent: `
+TELCLAUDE_NETWORK_MODE=permissive
+`,
+		});
+
+		const findings = auditSandboxPosture({
+			composePath: fixture.composePath,
+			envPath: fixture.envPath,
+		});
+
+		expect(findings.some((f) => f.message.includes("TELEGRAM_BOT_TOKEN"))).toBe(true);
+		expect(findings.some((f) => f.message.includes("TELCLAUDE_NETWORK_MODE=permissive"))).toBe(
+			true,
+		);
+		expect(findings.every((f) => f.severity === "warning")).toBe(true);
+	});
+
+	it("returns no findings for clean compose/env posture", () => {
+		const fixture = createFixture({
+			composeContent: `
+services:
+  telclaude-agent:
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - ./telclaude.json:/data/telclaude.json:ro
+`,
+			envContent: `
+TELCLAUDE_LOG_LEVEL=info
+`,
+		});
+
+		const findings = auditSandboxPosture({
+			composePath: fixture.composePath,
+			envPath: fixture.envPath,
+		});
+
+		expect(findings).toEqual([]);
+	});
+});

--- a/tests/sdk/output-guard.test.ts
+++ b/tests/sdk/output-guard.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildOverflowRecoverySummary,
+	DEFAULT_MAX_TOOL_RESULT_CHARS,
+	guardToolResultOutput,
+	isContextOverflowError,
+	truncateToolResult,
+} from "../../src/sdk/output-guard.js";
+
+describe("truncateToolResult", () => {
+	it("returns content unchanged when under the limit", () => {
+		const content = "short content";
+		const result = truncateToolResult(content, 1000);
+		expect(result.wasTruncated).toBe(false);
+		expect(result.content).toBe(content);
+		expect(result.originalSize).toBe(content.length);
+	});
+
+	it("returns content unchanged when exactly at the limit", () => {
+		const content = "x".repeat(1000);
+		const result = truncateToolResult(content, 1000);
+		expect(result.wasTruncated).toBe(false);
+		expect(result.content).toBe(content);
+	});
+
+	it("truncates content exceeding the limit", () => {
+		const content = "x".repeat(10_000);
+		const result = truncateToolResult(content, 5000);
+		expect(result.wasTruncated).toBe(true);
+		expect(result.content.length).toBeLessThanOrEqual(5500); // allow marker overhead
+		expect(result.originalSize).toBe(10_000);
+		expect(result.content).toContain("[... truncated");
+	});
+
+	it("keeps head and tail portions", () => {
+		const head = "HEAD_MARKER_" + "a".repeat(5000);
+		const middle = "b".repeat(90_000);
+		const tail = "c".repeat(4000) + "_TAIL_MARKER";
+		const content = head + middle + tail;
+		const result = truncateToolResult(content, 10_000);
+
+		expect(result.wasTruncated).toBe(true);
+		expect(result.content).toContain("HEAD_MARKER_");
+		expect(result.content).toContain("_TAIL_MARKER");
+		expect(result.content).toContain("[... truncated");
+	});
+
+	it("tries to break at newline boundaries", () => {
+		const lines = Array.from({ length: 200 }, (_, i) => `line ${i}: ${"x".repeat(50)}`).join(
+			"\n",
+		);
+		const result = truncateToolResult(lines, 5000);
+		expect(result.wasTruncated).toBe(true);
+		// Head portion should end at a newline (not mid-line)
+		const markerIdx = result.content.indexOf("[... truncated");
+		const beforeMarker = result.content.slice(0, markerIdx);
+		expect(beforeMarker.endsWith("\n")).toBe(true);
+	});
+
+	it("uses default max size when none specified", () => {
+		const content = "x".repeat(DEFAULT_MAX_TOOL_RESULT_CHARS + 1000);
+		const result = truncateToolResult(content);
+		expect(result.wasTruncated).toBe(true);
+		expect(result.content.length).toBeLessThan(content.length);
+	});
+
+	it("respects minimum keep size", () => {
+		// Even with a very small maxSize, we keep at least MIN_KEEP_CHARS (2000)
+		const content = "x".repeat(10_000);
+		const result = truncateToolResult(content, 100);
+		expect(result.wasTruncated).toBe(true);
+		// The result should be at least 2000 chars (MIN_KEEP_CHARS)
+		expect(result.content.length).toBeGreaterThanOrEqual(2000);
+	});
+
+	it("includes human-readable size in marker", () => {
+		const content = "x".repeat(150_000);
+		const result = truncateToolResult(content, 10_000);
+		expect(result.content).toMatch(/\[... truncated \d+(\.\d+)?K chars .../);
+	});
+
+	it("shows M chars for very large truncations", () => {
+		const content = "x".repeat(2_000_000);
+		const result = truncateToolResult(content, 10_000);
+		expect(result.content).toMatch(/\d+(\.\d+)?M chars/);
+	});
+});
+
+describe("guardToolResultOutput", () => {
+	it("passes through small string outputs unchanged", () => {
+		const { output, truncation } = guardToolResultOutput("small output", 1000);
+		expect(output).toBe("small output");
+		expect(truncation).toBeUndefined();
+	});
+
+	it("passes through null/undefined unchanged", () => {
+		expect(guardToolResultOutput(null).output).toBeNull();
+		expect(guardToolResultOutput(undefined).output).toBeUndefined();
+	});
+
+	it("truncates large string outputs", () => {
+		const large = "x".repeat(10_000);
+		const { output, truncation } = guardToolResultOutput(large, 5000);
+		expect(typeof output).toBe("string");
+		expect((output as string).length).toBeLessThan(large.length);
+		expect(truncation).toBeDefined();
+		expect(truncation?.wasTruncated).toBe(true);
+		expect(truncation?.originalSize).toBe(10_000);
+	});
+
+	it("handles object outputs by serializing", () => {
+		const obj = { data: "x".repeat(10_000) };
+		const { output, truncation } = guardToolResultOutput(obj, 5000);
+		expect(typeof output).toBe("string");
+		expect(truncation?.wasTruncated).toBe(true);
+	});
+
+	it("does not truncate small object outputs", () => {
+		const obj = { result: "ok" };
+		const { output, truncation } = guardToolResultOutput(obj);
+		expect(output).toEqual(obj);
+		expect(truncation).toBeUndefined();
+	});
+});
+
+describe("isContextOverflowError", () => {
+	it("detects context length exceeded errors", () => {
+		expect(isContextOverflowError("context_length_exceeded")).toBe(true);
+		expect(isContextOverflowError("Error: context window limit exceeded")).toBe(true);
+		expect(isContextOverflowError("maximum context length reached")).toBe(true);
+		expect(isContextOverflowError("too many tokens in request")).toBe(true);
+		expect(isContextOverflowError("prompt too long for model")).toBe(true);
+		expect(isContextOverflowError("input too large")).toBe(true);
+		expect(isContextOverflowError("request too large")).toBe(true);
+		expect(isContextOverflowError("max_tokens_exceeded")).toBe(true);
+		expect(isContextOverflowError("prompt_too_long")).toBe(true);
+	});
+
+	it("handles Error objects", () => {
+		expect(isContextOverflowError(new Error("context_length_exceeded"))).toBe(true);
+		expect(isContextOverflowError(new Error("token limit exceeded"))).toBe(true);
+	});
+
+	it("returns false for unrelated errors", () => {
+		expect(isContextOverflowError("network timeout")).toBe(false);
+		expect(isContextOverflowError("rate limit exceeded")).toBe(false);
+		expect(isContextOverflowError("authentication failed")).toBe(false);
+		expect(isContextOverflowError("")).toBe(false);
+		expect(isContextOverflowError(null)).toBe(false);
+		expect(isContextOverflowError(undefined)).toBe(false);
+	});
+});
+
+describe("buildOverflowRecoverySummary", () => {
+	it("includes turn count and error info", () => {
+		const summary = buildOverflowRecoverySummary({
+			poolKey: "chat-123",
+			error: "context_length_exceeded",
+			numTurns: 5,
+		});
+		expect(summary).toContain("5 turn(s)");
+		expect(summary).toContain("context_length_exceeded");
+		expect(summary).toContain("Session will be reset");
+	});
+});

--- a/tests/telegram/auto-reply.test.ts
+++ b/tests/telegram/auto-reply.test.ts
@@ -191,4 +191,14 @@ describe("auto-reply control commands", () => {
 			expect.objectContaining({ errorType: "identity_link_group_rejected" }),
 		);
 	});
+
+	it("uses raw body for command parsing and normalized body for processing", () => {
+		const msg = {
+			body: "/approve\u200B 123456",
+			normalizedBody: "/approve 123456",
+		} as any;
+
+		expect(autoReplyTest.resolveCommandBody(msg)).toBe("/approve\u200B 123456");
+		expect(autoReplyTest.resolveProcessingBody(msg)).toBe("/approve 123456");
+	});
 });

--- a/tests/telegram/inbound-normalization.test.ts
+++ b/tests/telegram/inbound-normalization.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInboundBody } from "../../src/telegram/inbound.js";
+
+describe("normalizeInboundBody", () => {
+	it("folds homoglyphs and strips zero-width characters", () => {
+		const input = "Ｈｅｌｌｏ\u200B Ｗｏｒｌｄ";
+		const result = normalizeInboundBody(input);
+
+		expect(result.normalized).toBe("Hello World");
+		expect(result.changed).toBe(true);
+		expect(result.hadHomoglyphs).toBe(true);
+		expect(result.hadZeroWidth).toBe(true);
+	});
+
+	it("preserves raw command body while providing normalized variant", () => {
+		const raw = "/approve\u200B 123456";
+		const result = normalizeInboundBody(raw);
+
+		// Raw command parsing still sees the original string.
+		expect(raw.startsWith("/approve ")).toBe(false);
+		// Normalized body restores canonical command spacing.
+		expect(result.normalized.startsWith("/approve ")).toBe(true);
+	});
+
+	it("returns unchanged for already clean input", () => {
+		const input = "normal message";
+		const result = normalizeInboundBody(input);
+
+		expect(result.normalized).toBe(input);
+		expect(result.changed).toBe(false);
+		expect(result.hadHomoglyphs).toBe(false);
+		expect(result.hadZeroWidth).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- **DNS-pinned fetch guard** (`src/sandbox/fetch-guard.ts`): SSRF-hardened fetch with undici dispatcher pinning, redirect hop re-validation, loop detection. Integrated into `summarize.ts` as first consumer.
- **Sandbox posture audit** (`src/sandbox/validate-config.ts`): Static docker-compose analysis flagging host network, privileged mode, socket mounts, symlink escapes. Wired into `doctor --security`.
- **Inbound message sanitization** (`src/telegram/inbound.ts`): Dual-field homoglyph/zero-width normalization — `normalizedBody` for observer/classification, raw `body` preserved for command parsing.
- **Deep security audit collectors** (`src/commands/audit-collectors.ts`): Structured severity-based collectors (config, filesystem, skill trust, hook hardening, exposure matrix) for `doctor --security`.
- **Auto-remediation** (`src/commands/audit-fixers.ts`): `doctor --security --fix` with atomic writes + backup, permission tightening, conservative defaults. No-op without `--fix`.
- **Stream output size guard** (`src/sdk/output-guard.ts`): Tool-result truncation (100KB cap, head+tail strategy) + context overflow detection and session recovery.

20 files changed, +4898 lines. 551 tests pass, typecheck clean.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` — 551 tests pass (48 files)
- [ ] Verify `fetchWithGuard()` blocks private IP redirects (unit tests)
- [ ] Verify `doctor --security` shows structured findings
- [ ] Verify `doctor --security --fix` creates backups before applying fixes
- [ ] Verify inbound homoglyph normalization doesn't break `/approve`, `/link` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)