### PR TITLE
refactor: remove dead code and consolidate duplicated helpers

### DIFF
--- a/src/config/path.ts
+++ b/src/config/path.ts
@@ -38,13 +38,6 @@ export function setConfigPath(configPath: string | null): void {
 }
 
 /**
- * Get the current config path override (for testing).
- */
-export function getConfigPathOverride(): string | null {
-	return configPathOverride;
-}
-
-/**
  * Reset config path to default (for testing).
  */
 export function resetConfigPath(): void {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -180,16 +180,6 @@ export function setLoggerOverride(settings: LoggerSettings | null) {
 	cachedSettings = null;
 }
 
-export function resetLogger() {
-	cachedLogger = null;
-	cachedSettings = null;
-	if (cachedDestination) {
-		closeDestination(cachedDestination);
-		cachedDestination = null;
-	}
-	overrideSettings = null;
-}
-
 export function closeLogger(): void {
 	if (cachedDestination) {
 		closeDestination(cachedDestination);
@@ -197,4 +187,5 @@ export function closeLogger(): void {
 	}
 	cachedLogger = null;
 	cachedSettings = null;
+	overrideSettings = null;
 }

--- a/src/security/approvals.ts
+++ b/src/security/approvals.ts
@@ -290,20 +290,6 @@ export function cleanupExpiredApprovals(): number {
 }
 
 /**
- * Get the count of pending approvals.
- */
-export function getPendingApprovalCount(): number {
-	const db = getDb();
-	const now = Date.now();
-
-	const row = db.prepare("SELECT COUNT(*) as count FROM approvals WHERE expires_at > ?").get(now) as
-		| { count: number }
-		| undefined;
-
-	return row?.count ?? 0;
-}
-
-/**
  * Determine if a request requires approval based on tier and classification.
  *
  * @param tier - The user's permission tier

--- a/src/security/circuit-breaker.ts
+++ b/src/security/circuit-breaker.ts
@@ -202,13 +202,3 @@ export class CircuitBreaker {
 		logger.info({ name: this.name }, "circuit breaker manually reset");
 	}
 }
-
-/**
- * Create a circuit breaker.
- */
-export function createCircuitBreaker(
-	name: string,
-	config?: Partial<CircuitBreakerConfig>,
-): CircuitBreaker {
-	return new CircuitBreaker(name, config);
-}

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -94,11 +94,7 @@ export {
 // Streaming redactor for chunk boundary handling
 export {
 	createStreamingRedactor,
-	getLongestPatternLength,
-	getPatternNames,
-	processChunks,
 	type RedactionStats,
-	redactStream,
 	StreamingRedactor,
 } from "./streaming-redactor.js";
 export * from "./totp-session.js";

--- a/src/security/permissions.ts
+++ b/src/security/permissions.ts
@@ -544,23 +544,10 @@ function isSensitiveBasename(name: string): boolean {
 }
 
 /**
- * Expand ~ to home directory for path comparison.
- */
-function expandHome(p: string): string {
-	if (p.startsWith("~/")) {
-		return path.join(process.env.HOME ?? "", p.slice(2));
-	}
-	if (p === "~") {
-		return process.env.HOME ?? "";
-	}
-	return p;
-}
-
-/**
  * Normalize a path for comparison (resolve ~, make absolute).
  */
 function normalizePath(inputPath: string): string {
-	const expanded = expandHome(inputPath);
+	const expanded = expandHomeLike(inputPath);
 	// Handle relative paths
 	if (!path.isAbsolute(expanded)) {
 		return path.resolve(process.cwd(), expanded);

--- a/src/security/streaming-redactor.ts
+++ b/src/security/streaming-redactor.ts
@@ -17,7 +17,6 @@ import {
 	filterOutputWithConfig,
 	redactSecrets,
 	redactSecretsWithConfig,
-	SECRET_PATTERNS,
 	type SecretFilterConfig,
 } from "./output-filter.js";
 
@@ -172,84 +171,14 @@ export class StreamingRedactor {
 	}
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// Convenience Functions
-// ═══════════════════════════════════════════════════════════════════════════════
-
 /**
  * Create a streaming redactor with default settings.
- *
- * @param overlapSize - Characters to keep in buffer for overlap detection.
- * @param secretFilterConfig - Optional config for additional patterns and entropy detection.
  */
 export function createStreamingRedactor(
 	overlapSize?: number,
 	secretFilterConfig?: SecretFilterConfig,
 ): StreamingRedactor {
 	return new StreamingRedactor(overlapSize, secretFilterConfig);
-}
-
-/**
- * Process an array of chunks through a redactor.
- * Useful for testing or batch processing.
- *
- * @param chunks - Array of text chunks
- * @returns Fully redacted text
- */
-export function processChunks(chunks: string[]): string {
-	const redactor = new StreamingRedactor();
-	let result = "";
-
-	for (const chunk of chunks) {
-		result += redactor.processChunk(chunk);
-	}
-
-	result += redactor.flush();
-	return result;
-}
-
-/**
- * Create an async generator that wraps another generator with redaction.
- *
- * @param source - Source async generator of text chunks
- * @returns Async generator yielding redacted chunks
- */
-export async function* redactStream(
-	source: AsyncGenerator<string, void, unknown>,
-): AsyncGenerator<string, void, unknown> {
-	const redactor = new StreamingRedactor();
-
-	for await (const chunk of source) {
-		const redacted = redactor.processChunk(chunk);
-		if (redacted.length > 0) {
-			yield redacted;
-		}
-	}
-
-	const final = redactor.flush();
-	if (final.length > 0) {
-		yield final;
-	}
-}
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// Pattern Info Export
-// ═══════════════════════════════════════════════════════════════════════════════
-
-/**
- * Get the longest pattern length for sizing the overlap buffer.
- */
-export function getLongestPatternLength(): number {
-	// Estimate based on known patterns (GitHub PAT is ~40 chars, etc.)
-	// Add buffer for context around the match
-	return 100;
-}
-
-/**
- * Get pattern names for logging/debugging.
- */
-export function getPatternNames(): string[] {
-	return SECRET_PATTERNS.map((p) => p.name);
 }
 
 // Re-export SecretFilterConfig for convenience

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -202,30 +202,6 @@ export async function generateImage(
 }
 
 /**
- * Generate multiple images from a prompt.
- */
-export async function generateImages(
-	prompt: string,
-	count: number,
-	options?: ImageGenerationOptions,
-): Promise<GeneratedImage[]> {
-	const results: GeneratedImage[] = [];
-
-	// Generate one at a time to handle failures gracefully
-	for (let i = 0; i < count; i++) {
-		try {
-			const image = await generateImage(prompt, options);
-			results.push(image);
-		} catch (error) {
-			logger.error({ index: i, error }, "failed to generate image in batch");
-			// Continue with remaining images
-		}
-	}
-
-	return results;
-}
-
-/**
  * Check if image generation is available.
  * Uses sync check for env/config; keychain key will be found at runtime.
  */

--- a/src/services/openai-client.ts
+++ b/src/services/openai-client.ts
@@ -207,12 +207,10 @@ export async function isOpenAIConfigured(): Promise<boolean> {
 
 /**
  * Initialize OpenAI key lookup (call at startup).
- * This populates the cache so isOpenAIConfiguredSync() works correctly.
+ * Populates the cache so isOpenAIConfiguredSync() works correctly.
+ * Functionally equivalent to isOpenAIConfigured() but named for intent clarity at callsites.
  */
-export async function initializeOpenAIKey(): Promise<boolean> {
-	const apiKey = await getApiKey();
-	return !!apiKey;
-}
+export const initializeOpenAIKey = isOpenAIConfigured;
 
 /**
  * Synchronous check if OpenAI is configured.
@@ -257,15 +255,6 @@ export function getCachedOpenAIKey(): string | null {
 }
 
 /**
- * Pre-warm the OpenAI key cache.
- * Call this at startup so getCachedOpenAIKey() works for sandbox env injection.
- */
-export async function prewarmOpenAIKey(): Promise<boolean> {
-	const key = await getApiKey();
-	return key !== null;
-}
-
-/**
  * Get OpenAI API key fresh from storage (async).
  * Use this for hot-loading support - always reads from keychain/env/config.
  * Returns null if not configured.
@@ -276,11 +265,4 @@ export async function getOpenAIKey(): Promise<string | null> {
 	keySourceChecked = false;
 	usingCredentialProxy = false;
 	return getApiKey();
-}
-
-/**
- * Reset the client (for testing).
- */
-export function resetOpenAIClient(): void {
-	client = null;
 }

--- a/src/services/transcription.ts
+++ b/src/services/transcription.ts
@@ -149,9 +149,7 @@ export async function transcribeAudio(
 	}
 
 	const config = loadConfig();
-	const { useRelay: _useRelay, userId: _userId, ...localOptions } = options ?? {};
-	void _useRelay;
-	void _userId;
+	const { useRelay: _, userId: _u, ...localOptions } = options ?? {};
 	const transcriptionConfig = resolveTranscriptionConfig(config, localOptions);
 
 	logger.debug({ filePath, provider: transcriptionConfig.provider }, "starting transcription");
@@ -314,13 +312,6 @@ export function isTranscriptionAvailable(): boolean {
 		default:
 			return false;
 	}
-}
-
-/**
- * Get supported audio formats for transcription.
- */
-export function getSupportedAudioFormats(): string[] {
-	return ["mp3", "mp4", "mpeg", "mpga", "m4a", "wav", "webm", "ogg"];
 }
 
 /**

--- a/src/telegram/outbound.ts
+++ b/src/telegram/outbound.ts
@@ -576,20 +576,6 @@ export function createInputFile(source: string | Buffer): InputFile {
 }
 
 /**
- * Send typing indicator (chat action).
- */
-export async function sendTypingIndicator(bot: Bot, chatId: number): Promise<void> {
-	await bot.api.sendChatAction(chatId, "typing");
-}
-
-/**
- * Get bot info.
- */
-export async function getBotInfo(bot: Bot) {
-	return bot.api.getMe();
-}
-
-/**
  * Send a message using just a token (creates temporary bot instance).
  */
 export type SendTelegramMessageOptions = {

--- a/src/telegram/reconnect.ts
+++ b/src/telegram/reconnect.ts
@@ -62,10 +62,3 @@ export function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> 
 		});
 	});
 }
-
-/**
- * Generate a unique connection ID.
- */
-export function newConnectionId(): string {
-	return `conn_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-}

--- a/src/telegram/sanitize.ts
+++ b/src/telegram/sanitize.ts
@@ -24,47 +24,6 @@ const MAX_TOTAL_RESPONSE_SIZE = 500 * 1024; // 500KB
 const TRUNCATION_WARNING = "\n\n⚠️ [Response truncated - exceeded 500KB limit]";
 
 /**
- * Escape special characters for Telegram MarkdownV2.
- * @deprecated Use telegram-markdown-v2 library instead (see outbound.ts).
- * Kept for potential future use with system messages.
- */
-export function escapeMarkdownV2(text: string): string {
-	return text.replace(/([_*[\]()~`>#+\-=|{}.!\\])/g, "\\$1");
-}
-
-/**
- * Escape special characters for legacy Telegram Markdown.
- * Used by formatSystemMessage() for controlled system output.
- */
-export function escapeMarkdown(text: string): string {
-	return text.replace(/([_*`[])/g, "\\$1");
-}
-
-/**
- * Strip all markdown formatting from text.
- * @deprecated No longer used - we now convert to MarkdownV2 instead.
- * Kept for potential fallback scenarios.
- */
-export function stripMarkdown(text: string): string {
-	return (
-		text
-			// Remove code blocks
-			.replace(/```[\s\S]*?```/g, (match) => match.replace(/```/g, ""))
-			// Remove inline code
-			.replace(/`([^`]+)`/g, "$1")
-			// Remove bold/italic markers (but keep content)
-			.replace(/\*\*([^*]+)\*\*/g, "$1")
-			.replace(/\*([^*]+)\*/g, "$1")
-			.replace(/__([^_]+)__/g, "$1")
-			.replace(/_([^_]+)_/g, "$1")
-			// Remove links but show URL
-			.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)")
-			// Remove strikethrough
-			.replace(/~~([^~]+)~~/g, "$1")
-	);
-}
-
-/**
  * Find the best split point in text, preferring natural boundaries.
  * Priority: paragraph break > line break > sentence end > word boundary > hard cut
  */
@@ -152,15 +111,6 @@ function removeDangerousChars(text: string): string {
 }
 
 /**
- * Sanitize Claude's response for safe display in Telegram.
- * Removes potentially dangerous formatting while preserving readability.
- * @deprecated Use sanitizeAndSplitResponse() instead which handles both.
- */
-export function sanitizeClaudeResponse(text: string): string {
-	return removeDangerousChars(text);
-}
-
-/**
  * Sanitize and split a long response into multiple Telegram-safe chunks.
  * Combines sanitization with intelligent splitting at natural boundaries.
  *
@@ -190,18 +140,4 @@ export function sanitizeAndSplitResponse(text: string): string[] {
 	}
 
 	return splitMessage(sanitized);
-}
-
-/**
- * Format a system message with controlled markdown.
- * Only use for messages we fully control (not user/Claude content).
- */
-export function formatSystemMessage(template: string, vars: Record<string, string> = {}): string {
-	let result = template;
-	for (const [key, value] of Object.entries(vars)) {
-		// Escape the value to prevent injection
-		const escaped = escapeMarkdown(value);
-		result = result.replace(new RegExp(`\\{${key}\\}`, "g"), escaped);
-	}
-	return result;
 }

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -93,18 +93,6 @@ const DEFAULT_CONFIG: Required<Omit<StreamingConfig, "secretFilterConfig">> = {
 };
 
 /**
- * Creates the default inline keyboard for responses.
- * Full version with all actions.
- */
-export function createResponseKeyboard(): InlineKeyboard {
-	return new InlineKeyboard()
-		.text("🔄 New", "action:new")
-		.text("🔊 Read Aloud", "action:tts")
-		.row()
-		.text("❓ Help", "action:help");
-}
-
-/**
  * Creates a compact inline keyboard for responses.
  * Single row, icon-only for mobile-friendly display.
  */


### PR DESCRIPTION
## Summary
- Removed 20+ unused exports across 15 files (factory wrappers, deprecated functions, testing utilities, convenience helpers)
- Consolidated 3 identical `resolveXxxDir()` path validators into a single generic `resolveEnvDir(value, label)`
- Net change: **-356 lines, +27 lines**

## Files touched
`src/utils.ts`, `src/logging.ts`, `src/config/path.ts`, `src/security/{approvals,circuit-breaker,index,permissions,streaming-redactor}.ts`, `src/services/{openai-client,image-generation,transcription}.ts`, `src/telegram/{outbound,reconnect,sanitize,streaming}.ts`

## Verification
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm test` — 551 tests, 48 files, all passing
- Grep confirmed zero in-repo references to any removed symbol
- Reviewed by Codex via AMQ — no regressions flagged

## Test plan
- [x] TypeScript compilation passes
- [x] Biome lint passes
- [x] Full test suite passes (551 tests)
- [x] No remaining imports of removed exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)