### PR TITLE
refactor(crypto): extract shared canonical hash

### DIFF
--- a/src/crypto/canonical-hash.ts
+++ b/src/crypto/canonical-hash.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical hash for approval token request binding.
+ *
+ * Deterministic JSON serialization (recursive key sort) + SHA-256.
+ * Used by both the relay (token generation) and the Google services
+ * sidecar (token verification) to produce matching params hashes.
+ */
+
+import crypto from "node:crypto";
+
+export interface CanonicalHashInput {
+	service: string;
+	action: string;
+	params: Record<string, unknown>;
+	actorUserId: string;
+	subjectUserId: string | null;
+}
+
+/**
+ * Compute canonical hash for request binding.
+ * Deterministic JSON serialization (recursive key sort) + SHA-256.
+ */
+export function canonicalHash(input: CanonicalHashInput): string {
+	const canonical = JSON.stringify(sortKeysDeep(input));
+	const hash = crypto.createHash("sha256").update(canonical).digest("hex");
+	return `sha256:${hash}`;
+}
+
+/**
+ * Recursively sort object keys for deterministic serialization.
+ */
+export function sortKeysDeep(value: unknown): unknown {
+	if (value === null || typeof value !== "object") return value;
+	if (Array.isArray(value)) return value.map(sortKeysDeep);
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+		sorted[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+	}
+	return sorted;
+}

--- a/src/google-services/approval.ts
+++ b/src/google-services/approval.ts
@@ -5,44 +5,12 @@
  * Format: v1.<claims_b64url>.<sig_b64url>
  */
 
-import crypto from "node:crypto";
 import path from "node:path";
 import Database from "better-sqlite3";
+import { canonicalHash } from "../crypto/canonical-hash.js";
 import { ApprovalClaimsSchema, type FetchRequest } from "./types.js";
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// Canonical Hash
-// ═══════════════════════════════════════════════════════════════════════════════
-
-/**
- * Compute canonical hash for request binding.
- * Deterministic JSON serialization (recursive key sort) + SHA-256.
- * Keep in sync with src/relay/approval-token.ts.
- */
-export function canonicalHash(input: {
-	service: string;
-	action: string;
-	params: Record<string, unknown>;
-	actorUserId: string;
-	subjectUserId: string | null;
-}): string {
-	const canonical = JSON.stringify(sortKeysDeep(input));
-	const hash = crypto.createHash("sha256").update(canonical).digest("hex");
-	return `sha256:${hash}`;
-}
-
-/**
- * Recursively sort object keys for deterministic serialization.
- */
-function sortKeysDeep(value: unknown): unknown {
-	if (value === null || typeof value !== "object") return value;
-	if (Array.isArray(value)) return value.map(sortKeysDeep);
-	const sorted: Record<string, unknown> = {};
-	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-		sorted[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
-	}
-	return sorted;
-}
+export { canonicalHash };
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // JTI Replay Store

--- a/src/relay/approval-token.ts
+++ b/src/relay/approval-token.ts
@@ -10,6 +10,7 @@
  */
 
 import crypto from "node:crypto";
+import { canonicalHash } from "../crypto/canonical-hash.js";
 import type { VaultClient } from "../vault-daemon/client.js";
 
 const SIGNING_PREFIX = "approval-v1";
@@ -76,30 +77,4 @@ export async function generateApprovalToken(
 	}
 
 	return `v1.${claimsB64}.${signResult.signature}`;
-}
-
-/**
- * Compute canonical hash for request binding.
- * Keep in sync with src/google-services/approval.ts.
- */
-function canonicalHash(input: {
-	service: string;
-	action: string;
-	params: Record<string, unknown>;
-	actorUserId: string;
-	subjectUserId: string | null;
-}): string {
-	const canonical = JSON.stringify(sortKeysDeep(input));
-	const hash = crypto.createHash("sha256").update(canonical).digest("hex");
-	return `sha256:${hash}`;
-}
-
-function sortKeysDeep(value: unknown): unknown {
-	if (value === null || typeof value !== "object") return value;
-	if (Array.isArray(value)) return value.map(sortKeysDeep);
-	const sorted: Record<string, unknown> = {};
-	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-		sorted[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
-	}
-	return sorted;
 }

--- a/tests/relay/approval-token.test.ts
+++ b/tests/relay/approval-token.test.ts
@@ -75,8 +75,8 @@ describe("generateApprovalToken", () => {
 	});
 
 	it("produces same paramsHash as sidecar canonicalHash", async () => {
-		// Import sidecar's canonicalHash to verify consistency
-		const { canonicalHash } = await import("../../src/google-services/approval.js");
+		// Import shared canonicalHash to verify consistency
+		const { canonicalHash } = await import("../../src/crypto/canonical-hash.js");
 
 		const vault = createMockVaultClient();
 		const token = await generateApprovalToken(baseInput, vault);


### PR DESCRIPTION
## Summary
- Extract `canonicalHash()` and `sortKeysDeep()` into new shared module `src/crypto/canonical-hash.ts`
- Remove duplicate implementations from `src/google-services/approval.ts` and `src/relay/approval-token.ts` (previously maintained with "keep in sync" comments)
- Re-export `canonicalHash` from `google-services/approval.ts` for backward compatibility
- Update test cross-import to point at shared module

## Test plan
- [x] All 19 existing approval tests pass (both `tests/google-services/approval.test.ts` and `tests/relay/approval-token.test.ts`)
- [x] Cross-module hash consistency test still validates matching output
- [x] TypeScript type check passes (no errors in changed files)
- [x] Biome format and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)