### PR TITLE
refactor: Mega-C data/service layer (Units 13+14+16)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -44,6 +44,7 @@ e20d117c101c3c1b9a6844ac8c3ca110c27a62e3:src/sandbox/config.ts:credentials-javas
 e82ee12ace184aece9e37ee32666802d1e8efa43:src/security/streaming-redactor.ts:generic-api-key:7
 5ed752ae82c86f5e10f32b2c4eb5ec7248af65f0:src/security/output-filter.ts:credentials-javascript:582
 103c4bd94feec6d6d59b1e3b9c397b26dd456bd4:src/security/output-filter.ts:credentials-javascript:330
+e33e93fd814c48bd7a95205dd272ffc2214be337:src/security/output-filter.ts:credentials-javascript:406
 cb853d9b343174696ced01e3cab2198c15e26fe5:src/telegram/auto-reply.ts:credentials-javascript:704
 
 # OpenAI client - credential proxy sentinel value (not a real key)

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -5,6 +5,7 @@ import { buildInternalAuthHeaders, type InternalAuthScope } from "../internal-au
 import { getChildLogger } from "../logging.js";
 import { issueToken, isTokenManagerActive } from "../relay/token-manager.js";
 import type { PooledQueryOptions, StreamChunk } from "../sdk/client.js";
+import { stripTrailingSlash } from "../utils.js";
 
 const logger = getChildLogger({ module: "agent-client" });
 
@@ -74,7 +75,7 @@ export async function* executeRemoteQuery(
 			sessionToken,
 			outputFormat: options.outputFormat,
 		});
-		const endpoint = `${agentUrl.replace(/\/+$/, "")}${path}`;
+		const endpoint = `${stripTrailingSlash(agentUrl)}${path}`;
 		const scope = options.scope ?? "telegram";
 
 		// Retry the initial fetch on transient network errors (2 attempts, 1s base delay)

--- a/src/agent/memory-client.ts
+++ b/src/agent/memory-client.ts
@@ -4,6 +4,7 @@ import { getChildLogger } from "../logging.js";
 import type { MemorySnapshotRequest, MemorySnapshotResponse } from "../memory/rpc.js";
 import type { MemoryEntryInput } from "../memory/store.js";
 import type { MemoryEntry } from "../memory/types.js";
+import { stripTrailingSlash } from "../utils.js";
 
 const logger = getChildLogger({ module: "agent-memory-client" });
 
@@ -12,7 +13,7 @@ function getCapabilitiesUrl(): string {
 	if (!url) {
 		throw new Error("TELCLAUDE_CAPABILITIES_URL is not configured");
 	}
-	return url.replace(/\/+$/, "");
+	return stripTrailingSlash(url);
 }
 
 /**

--- a/src/agent/token-client.ts
+++ b/src/agent/token-client.ts
@@ -13,6 +13,7 @@
 
 import { buildInternalAuthHeaders, type InternalAuthScope } from "../internal-auth.js";
 import { getChildLogger } from "../logging.js";
+import { stripTrailingSlash } from "../utils.js";
 
 const logger = getChildLogger({ module: "agent-token-client" });
 
@@ -63,7 +64,7 @@ export async function bootstrapSessionToken(
 	relayUrl: string,
 	scope: InternalAuthScope,
 ): Promise<boolean> {
-	const endpoint = `${relayUrl.replace(/\/+$/, "")}/v1/auth/token-exchange`;
+	const endpoint = `${stripTrailingSlash(relayUrl)}/v1/auth/token-exchange`;
 	const body = JSON.stringify({ scope });
 
 	try {
@@ -145,7 +146,7 @@ function scheduleRefresh(relayUrl: string): void {
 async function refreshSessionToken(relayUrl: string): Promise<boolean> {
 	if (!currentToken) return false;
 
-	const endpoint = `${relayUrl.replace(/\/+$/, "")}/v1/auth/token-refresh`;
+	const endpoint = `${stripTrailingSlash(relayUrl)}/v1/auth/token-refresh`;
 	const body = JSON.stringify({ token: currentToken.token });
 
 	try {

--- a/src/memory/rpc.ts
+++ b/src/memory/rpc.ts
@@ -242,6 +242,42 @@ export function handleMemoryPropose(
 	}
 }
 
+function validateSnapshotFields(raw: {
+	categories?: string[];
+	trust?: string[];
+	sources?: string[];
+	limit?: number;
+	chatId?: unknown;
+}): MemoryRpcResult<MemorySnapshotRequest> {
+	if (raw.categories && !raw.categories.every(isValidCategory)) {
+		return fail(400, "Invalid categories filter.");
+	}
+	if (raw.trust && !raw.trust.every(isValidTrust)) {
+		return fail(400, "Invalid trust filter.");
+	}
+	if (raw.sources && !raw.sources.every(isValidSource)) {
+		return fail(400, "Invalid sources filter.");
+	}
+
+	let limit: number | undefined;
+	if (raw.limit !== undefined) {
+		if (!Number.isFinite(raw.limit)) {
+			return fail(400, "Invalid limit.");
+		}
+		limit = normalizeLimit(raw.limit);
+	}
+
+	const chatId = validateChatId(raw.chatId);
+
+	return ok({
+		categories: raw.categories as MemoryCategory[] | undefined,
+		trust: raw.trust as TrustLevel[] | undefined,
+		sources: raw.sources as MemorySource[] | undefined,
+		limit,
+		chatId,
+	});
+}
+
 export function parseSnapshotBody(input: unknown): MemoryRpcResult<MemorySnapshotRequest> {
 	if (input === undefined || input === null) {
 		return ok({});
@@ -258,31 +294,13 @@ export function parseSnapshotBody(input: unknown): MemoryRpcResult<MemorySnapsho
 		chatId?: unknown;
 	};
 
-	const categories = normalizeList(raw.categories as MemoryCategory[] | MemoryCategory | undefined);
-	if (categories && !categories.every(isValidCategory)) {
-		return fail(400, "Invalid categories filter.");
-	}
-	const trust = normalizeList(raw.trust as TrustLevel[] | TrustLevel | undefined);
-	if (trust && !trust.every(isValidTrust)) {
-		return fail(400, "Invalid trust filter.");
-	}
-	const sources = normalizeList(raw.sources as MemorySource[] | MemorySource | undefined);
-	if (sources && !sources.every(isValidSource)) {
-		return fail(400, "Invalid sources filter.");
-	}
-
-	let limit: number | undefined;
-	if (raw.limit !== undefined) {
-		const parsed = Number(raw.limit);
-		if (!Number.isFinite(parsed)) {
-			return fail(400, "Invalid limit.");
-		}
-		limit = normalizeLimit(parsed);
-	}
-
-	const chatId = validateChatId(raw.chatId);
-
-	return ok({ categories, trust, sources, limit, chatId });
+	return validateSnapshotFields({
+		categories: normalizeList(raw.categories as MemoryCategory[] | MemoryCategory | undefined),
+		trust: normalizeList(raw.trust as TrustLevel[] | TrustLevel | undefined),
+		sources: normalizeList(raw.sources as MemorySource[] | MemorySource | undefined),
+		limit: raw.limit !== undefined ? Number(raw.limit) : undefined,
+		chatId: raw.chatId,
+	});
 }
 
 export function parseSnapshotQuery(query: URLSearchParams): MemoryRpcResult<MemorySnapshotRequest> {
@@ -294,37 +312,14 @@ export function parseSnapshotQuery(query: URLSearchParams): MemoryRpcResult<Memo
 			.filter(Boolean);
 	};
 
-	const categories = parseList(query.get("categories"));
-	if (categories && !categories.every(isValidCategory)) {
-		return fail(400, "Invalid categories filter.");
-	}
-	const trust = parseList(query.get("trust"));
-	if (trust && !trust.every(isValidTrust)) {
-		return fail(400, "Invalid trust filter.");
-	}
-	const sources = parseList(query.get("sources"));
-	if (sources && !sources.every(isValidSource)) {
-		return fail(400, "Invalid sources filter.");
-	}
-
-	let limit: number | undefined;
 	const rawLimit = query.get("limit");
-	if (rawLimit) {
-		const parsed = Number(rawLimit);
-		if (!Number.isFinite(parsed)) {
-			return fail(400, "Invalid limit.");
-		}
-		limit = normalizeLimit(parsed);
-	}
 
-	const chatId = validateChatId(query.get("chatId"));
-
-	return ok({
-		categories: categories as MemoryCategory[] | undefined,
-		trust: trust as TrustLevel[] | undefined,
-		sources: sources as MemorySource[] | undefined,
-		limit,
-		chatId,
+	return validateSnapshotFields({
+		categories: parseList(query.get("categories")),
+		trust: parseList(query.get("trust")),
+		sources: parseList(query.get("sources")),
+		limit: rawLimit ? Number(rawLimit) : undefined,
+		chatId: query.get("chatId"),
 	});
 }
 
@@ -374,22 +369,15 @@ export function handleMemoryQuarantine(
 	if (!request || typeof request !== "object") {
 		return fail(400, "Invalid request body.");
 	}
-	if (typeof request.id !== "string" || request.id.trim().length === 0) {
-		return fail(400, "Entry id is required.");
-	}
-	const trimmedId = request.id.trim();
-	if (trimmedId.length > MAX_ID_LENGTH) {
-		return fail(400, "Entry id too long.");
-	}
-	if (typeof request.content !== "string" || request.content.trim().length === 0) {
-		return fail(400, "Entry content is required.");
-	}
-	if (request.content.length > MAX_STRING_LENGTH) {
-		return fail(400, "Entry content too long.");
-	}
-	const forbidden = checkForbiddenPatterns(request.content);
-	if (forbidden) {
-		return fail(400, forbidden);
+
+	// Delegate field validation to validateEntry (id, content, category, patterns, secrets)
+	const validationError = validateEntry({
+		id: request.id,
+		category: "posts",
+		content: request.content,
+	});
+	if (validationError) {
+		return fail(400, validationError);
 	}
 
 	const actor = context.userId?.trim() || "agent";
@@ -405,7 +393,7 @@ export function handleMemoryQuarantine(
 
 	try {
 		const entry = createQuarantinedEntry({
-			id: trimmedId,
+			id: request.id.trim(),
 			category: "posts",
 			content: request.content,
 			chatId,

--- a/src/oauth/flow.ts
+++ b/src/oauth/flow.ts
@@ -7,6 +7,7 @@
 
 import { randomBytes } from "node:crypto";
 import { getAuthCode, getRedirectUrl } from "oauth-callback";
+import { fetchWithTimeout } from "../infra/timeout.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuth2ServiceDefinition } from "./registry.js";
 
@@ -209,38 +210,30 @@ async function exchangeCode(params: {
 		body.set("client_secret", params.clientSecret);
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/x-www-form-urlencoded",
-	};
-
-	const controller = new AbortController();
-	const timeoutId = setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS);
-
-	try {
-		const response = await fetch(params.tokenEndpoint, {
+	const response = await fetchWithTimeout(
+		params.tokenEndpoint,
+		{
 			method: "POST",
-			headers,
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
 			body: body.toString(),
-			signal: controller.signal,
 			// SECURITY: Prevent credential leakage on redirects
 			redirect: "error",
-		});
+		},
+		TOKEN_EXCHANGE_TIMEOUT_MS,
+	);
 
-		if (!response.ok) {
-			const errorText = await response.text();
-			throw new Error(`Token endpoint returned ${response.status}: ${errorText}`);
-		}
-
-		const data = (await response.json()) as TokenEndpointResponse;
-
-		if (!data.access_token) {
-			throw new Error("Token endpoint did not return access_token");
-		}
-
-		return data;
-	} finally {
-		clearTimeout(timeoutId);
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Token endpoint returned ${response.status}: ${errorText}`);
 	}
+
+	const data = (await response.json()) as TokenEndpointResponse;
+
+	if (!data.access_token) {
+		throw new Error("Token endpoint did not return access_token");
+	}
+
+	return data;
 }
 
 async function fetchUserId(
@@ -248,14 +241,12 @@ async function fetchUserId(
 	accessToken: string,
 	jsonPath?: string,
 ): Promise<{ id?: string; username?: string }> {
-	const controller = new AbortController();
-	const timeoutId = setTimeout(() => controller.abort(), 10_000);
-
 	try {
-		const response = await fetch(endpoint, {
-			headers: { Authorization: `Bearer ${accessToken}` },
-			signal: controller.signal,
-		});
+		const response = await fetchWithTimeout(
+			endpoint,
+			{ headers: { Authorization: `Bearer ${accessToken}` } },
+			10_000,
+		);
 
 		if (!response.ok) {
 			return {};
@@ -274,8 +265,6 @@ async function fetchUserId(
 	} catch {
 		// User ID fetch is best-effort — don't fail the whole flow
 		return {};
-	} finally {
-		clearTimeout(timeoutId);
 	}
 }
 

--- a/src/providers/external-provider.ts
+++ b/src/providers/external-provider.ts
@@ -1,4 +1,5 @@
 import { type ExternalProviderConfig, loadConfig } from "../config/config.js";
+import { fetchWithTimeout } from "../infra/timeout.js";
 import { getChildLogger } from "../logging.js";
 import { validateProviderBaseUrl } from "./provider-validation.js";
 
@@ -65,11 +66,9 @@ export async function sendProviderOtp(request: ProviderOtpRequest): Promise<Prov
 	const { url } = await validateProviderBaseUrl(provider.baseUrl);
 	const endpoint = new URL("/v1/challenge/respond", url);
 
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), 15000);
-
-	try {
-		const response = await fetch(endpoint.toString(), {
+	const response = await fetchWithTimeout(
+		endpoint.toString(),
+		{
 			method: "POST",
 			headers: {
 				"content-type": "application/json",
@@ -82,27 +81,23 @@ export async function sendProviderOtp(request: ProviderOtpRequest): Promise<Prov
 				challengeId: request.challengeId,
 				actorUserId: request.actorUserId,
 			}),
-			signal: controller.signal,
-		});
+		},
+		15_000,
+	);
 
-		const text = await response.text();
-		if (!response.ok) {
-			const snippet = text.replace(/\s+/g, " ").trim().slice(0, 120);
-			logger.warn(
-				{ status: response.status, provider: provider.id, body: text.slice(0, 200) },
-				"provider OTP request failed",
-			);
-			throw new Error(
-				`Provider responded with ${response.status}${snippet ? `: ${snippet}` : ""}.`,
-			);
-		}
+	const text = await response.text();
+	if (!response.ok) {
+		const snippet = text.replace(/\s+/g, " ").trim().slice(0, 120);
+		logger.warn(
+			{ status: response.status, provider: provider.id, body: text.slice(0, 200) },
+			"provider OTP request failed",
+		);
+		throw new Error(`Provider responded with ${response.status}${snippet ? `: ${snippet}` : ""}.`);
+	}
 
-		try {
-			return JSON.parse(text) as ProviderOtpResponse;
-		} catch {
-			return { status: "ok", message: text };
-		}
-	} finally {
-		clearTimeout(timeout);
+	try {
+		return JSON.parse(text) as ProviderOtpResponse;
+	} catch {
+		return { status: "ok", message: text };
 	}
 }

--- a/src/providers/provider-health.ts
+++ b/src/providers/provider-health.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from "../infra/timeout.js";
 import { getChildLogger } from "../logging.js";
 import { validateProviderBaseUrl } from "./provider-validation.js";
 
@@ -48,37 +49,26 @@ export async function checkProviderHealth(
 		const { url: base } = await validateProviderBaseUrl(baseUrl);
 		const url = new URL("/v1/health", base);
 
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 10000);
+		const response = await fetchWithTimeout(
+			url.toString(),
+			{ method: "GET", headers: { accept: "application/json" } },
+			10_000,
+		);
 
+		if (!response.ok) {
+			result.error = `HTTP ${response.status}: ${response.statusText}`;
+			return result;
+		}
+
+		const text = await response.text();
 		try {
-			const response = await fetch(url.toString(), {
-				method: "GET",
-				headers: {
-					accept: "application/json",
-				},
-				signal: controller.signal,
-			});
-
-			if (!response.ok) {
-				result.error = `HTTP ${response.status}: ${response.statusText}`;
-				return result;
-			}
-
-			const text = await response.text();
-			try {
-				result.response = JSON.parse(text) as ProviderHealthResponse;
-				result.reachable = true;
-			} catch {
-				result.error = "Invalid JSON response from health endpoint";
-			}
-		} finally {
-			clearTimeout(timeout);
+			result.response = JSON.parse(text) as ProviderHealthResponse;
+			result.reachable = true;
+		} catch {
+			result.error = "Invalid JSON response from health endpoint";
 		}
 	} catch (err) {
-		if (err instanceof Error && err.name === "AbortError") {
-			result.error = "Request timeout (10s)";
-		} else if (err instanceof Error && err.message) {
+		if (err instanceof Error && err.message) {
 			result.error = err.message;
 		} else {
 			result.error = String(err);

--- a/src/providers/provider-skill.ts
+++ b/src/providers/provider-skill.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { ExternalProviderConfig } from "../config/config.js";
+import { fetchWithTimeout } from "../infra/timeout.js";
 import { getChildLogger } from "../logging.js";
 import { validateProviderBaseUrl } from "./provider-validation.js";
 
@@ -230,41 +231,27 @@ async function fetchProviderSchema(
 		const { url: base } = await validateProviderBaseUrl(provider.baseUrl);
 		const endpoint = new URL("/v1/schema", base);
 
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 10000);
+		const response = await fetchWithTimeout(
+			endpoint.toString(),
+			{ method: "GET", headers: { accept: "application/json" } },
+			10_000,
+		);
 
+		if (!response.ok) {
+			return {
+				provider,
+				error: `HTTP ${response.status}: ${response.statusText}`,
+			};
+		}
+
+		const text = await response.text();
 		try {
-			const response = await fetch(endpoint.toString(), {
-				method: "GET",
-				headers: {
-					accept: "application/json",
-				},
-				signal: controller.signal,
-			});
-
-			if (!response.ok) {
-				return {
-					provider,
-					error: `HTTP ${response.status}: ${response.statusText}`,
-				};
-			}
-
-			const text = await response.text();
-			try {
-				return { provider, schema: JSON.parse(text) };
-			} catch {
-				return { provider, error: "Invalid JSON response from schema endpoint" };
-			}
-		} finally {
-			clearTimeout(timeout);
+			return { provider, schema: JSON.parse(text) };
+		} catch {
+			return { provider, error: "Invalid JSON response from schema endpoint" };
 		}
 	} catch (err) {
-		const message =
-			err instanceof Error && err.name === "AbortError"
-				? "Request timeout (10s)"
-				: err instanceof Error && err.message
-					? err.message
-					: String(err);
+		const message = err instanceof Error && err.message ? err.message : String(err);
 		return { provider, error: message };
 	}
 }

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -3,14 +3,13 @@
  * Uses GPT Image 1.5 (December 2025).
  */
 
-import fs from "node:fs";
-
 import { type ImageGenerationConfig, loadConfig } from "../config/config.js";
 import { getChildLogger } from "../logging.js";
 import { saveMediaBuffer } from "../media/store.js";
 import { relayGenerateImage } from "../relay/capabilities-client.js";
-import { getMultimediaRateLimiter } from "./multimedia-rate-limit.js";
+import { consumeRateLimit, enforceRateLimit } from "./multimedia-rate-limit.js";
 import { getOpenAIClient, isOpenAIConfigured, isOpenAIConfiguredSync } from "./openai-client.js";
+import { isRelayReachable } from "./relay-routing.js";
 
 const logger = getChildLogger({ module: "image-generation" });
 
@@ -103,21 +102,16 @@ export async function generateImage(
 		throw new Error("Image generation is disabled in config");
 	}
 
-	// Rate limiting check (if userId provided)
 	const userId = options?.userId;
-	if (userId && !options?.skipRateLimit) {
-		const rateLimiter = getMultimediaRateLimiter();
-		const rateLimitConfig = {
+	enforceRateLimit(
+		"image_generation",
+		userId,
+		{
 			maxPerHourPerUser: imageConfig.maxPerHourPerUser,
 			maxPerDayPerUser: imageConfig.maxPerDayPerUser,
-		};
-		const limitResult = rateLimiter.checkLimit("image_generation", userId, rateLimitConfig);
-
-		if (!limitResult.allowed) {
-			logger.warn({ userId, remaining: limitResult.remaining }, "image generation rate limited");
-			throw new Error(limitResult.reason ?? "Image generation rate limit exceeded");
-		}
-	}
+		},
+		options,
+	);
 
 	const client = await getOpenAIClient();
 	const model = imageConfig.model ?? "gpt-image-1.5";
@@ -168,30 +162,24 @@ export async function generateImage(
 			extension: ".png",
 		});
 
-		const stat = await fs.promises.stat(saved.path);
-
 		logger.info(
 			{
 				model,
 				size,
 				quality,
 				durationMs,
-				sizeBytes: stat.size,
+				sizeBytes: buffer.length,
 				revisedPrompt: imageData.revised_prompt?.slice(0, 50),
 			},
 			"image generated successfully",
 		);
 
-		// Consume rate limit point after successful generation
-		if (userId && !options?.skipRateLimit) {
-			const rateLimiter = getMultimediaRateLimiter();
-			rateLimiter.consume("image_generation", userId);
-		}
+		consumeRateLimit("image_generation", userId, options);
 
 		return {
 			path: saved.path,
 			revisedPrompt: imageData.revised_prompt,
-			sizeBytes: stat.size,
+			sizeBytes: buffer.length,
 			model,
 			quality,
 		};
@@ -206,18 +194,10 @@ export async function generateImage(
  * Uses sync check for env/config; keychain key will be found at runtime.
  */
 export function isImageGenerationAvailable(): boolean {
-	// Available via relay when TELCLAUDE_CAPABILITIES_URL is set
-	if (process.env.TELCLAUDE_CAPABILITIES_URL) {
-		return Boolean(
-			process.env.TELCLAUDE_SESSION_TOKEN ?? process.env.TELEGRAM_RPC_AGENT_PRIVATE_KEY,
-		);
-	}
+	if (isRelayReachable()) return true;
 
 	const config = loadConfig();
-
-	if (config.imageGeneration?.provider === "disabled") {
-		return false;
-	}
+	if (config.imageGeneration?.provider === "disabled") return false;
 
 	return isOpenAIConfiguredSync();
 }

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -15,12 +15,9 @@ import {
 } from "../memory/rpc.js";
 import type { MemoryEntryInput } from "../memory/store.js";
 import type { MemoryEntry } from "../memory/types.js";
+import { isAgentSide } from "./relay-routing.js";
 
 const logger = getChildLogger({ module: "memory-service" });
-
-function isAgentSide(): boolean {
-	return Boolean(process.env.TELCLAUDE_CAPABILITIES_URL);
-}
 
 /**
  * Read memory entries. Dual-mode: agent routes through relay, relay reads SQLite directly.

--- a/src/services/multimedia-rate-limit.ts
+++ b/src/services/multimedia-rate-limit.ts
@@ -217,6 +217,38 @@ export class MultimediaRateLimiter {
 	}
 }
 
+/**
+ * Check rate limit for a multimedia operation.
+ * No-ops when userId is absent or skipRateLimit is true.
+ * Throws on limit exceeded (fail-closed).
+ */
+export function enforceRateLimit(
+	feature: MultimediaFeature,
+	userId: string | undefined,
+	config: FeatureRateLimitConfig,
+	opts?: { skipRateLimit?: boolean },
+): void {
+	if (!userId || opts?.skipRateLimit) return;
+	const limiter = getMultimediaRateLimiter();
+	const result = limiter.checkLimit(feature, userId, config);
+	if (!result.allowed) {
+		throw new Error(result.reason ?? `${feature} rate limit exceeded`);
+	}
+}
+
+/**
+ * Consume a rate limit point after a successful operation.
+ * No-ops when userId is absent or skipRateLimit is true.
+ */
+export function consumeRateLimit(
+	feature: MultimediaFeature,
+	userId: string | undefined,
+	opts?: { skipRateLimit?: boolean },
+): void {
+	if (!userId || opts?.skipRateLimit) return;
+	getMultimediaRateLimiter().consume(feature, userId);
+}
+
 /** Singleton instance */
 let instance: MultimediaRateLimiter | null = null;
 

--- a/src/services/relay-routing.ts
+++ b/src/services/relay-routing.ts
@@ -1,0 +1,20 @@
+/**
+ * Relay routing helpers — centralises the repeated environment-variable
+ * checks that every dual-mode service needs.
+ */
+
+/**
+ * True when running inside an agent container (TELCLAUDE_CAPABILITIES_URL set).
+ */
+export function isAgentSide(): boolean {
+	return Boolean(process.env.TELCLAUDE_CAPABILITIES_URL);
+}
+
+/**
+ * True when the relay is reachable (capabilities URL set AND auth credential
+ * available). Used by availability checks in image-gen, TTS, summarize, etc.
+ */
+export function isRelayReachable(): boolean {
+	if (!process.env.TELCLAUDE_CAPABILITIES_URL) return false;
+	return Boolean(process.env.TELCLAUDE_SESSION_TOKEN ?? process.env.TELEGRAM_RPC_AGENT_PRIVATE_KEY);
+}

--- a/src/services/summarize.ts
+++ b/src/services/summarize.ts
@@ -8,8 +8,9 @@ import { loadConfig } from "../config/config.js";
 import { getChildLogger } from "../logging.js";
 import { relaySummarize } from "../relay/capabilities-client.js";
 import { fetchWithGuard } from "../sandbox/fetch-guard.js";
-import { getMultimediaRateLimiter } from "./multimedia-rate-limit.js";
+import { consumeRateLimit, enforceRateLimit } from "./multimedia-rate-limit.js";
 import { getCachedOpenAIKey } from "./openai-client.js";
+import { isRelayReachable } from "./relay-routing.js";
 
 const logger = getChildLogger({ module: "summarize" });
 
@@ -147,19 +148,16 @@ export async function summarizeUrl(
 	const timeoutMs = options?.timeoutMs ?? summarizeConfig.timeoutMs;
 	const format = options?.format ?? "text";
 
-	// Rate limiting (if userId provided and not skipped)
 	const userId = options?.userId;
-	if (userId && !options?.skipRateLimit) {
-		const rateLimiter = getMultimediaRateLimiter();
-		const rateConfig = {
+	enforceRateLimit(
+		"summarize",
+		userId,
+		{
 			maxPerHourPerUser: summarizeConfig.maxPerHourPerUser,
 			maxPerDayPerUser: summarizeConfig.maxPerDayPerUser,
-		};
-		const limitResult = rateLimiter.checkLimit("summarize", userId, rateConfig);
-		if (!limitResult.allowed) {
-			throw new Error(limitResult.reason ?? "Summarize rate limit exceeded");
-		}
-	}
+		},
+		options,
+	);
 
 	logger.info({ url: url.slice(0, 120), maxCharacters, timeoutMs, format }, "extracting content");
 	const startTime = Date.now();
@@ -184,11 +182,7 @@ export async function summarizeUrl(
 			"content extracted",
 		);
 
-		// Consume rate limit point after success
-		if (userId && !options?.skipRateLimit) {
-			const rateLimiter = getMultimediaRateLimiter();
-			rateLimiter.consume("summarize", userId);
-		}
+		consumeRateLimit("summarize", userId, options);
 
 		return {
 			url: result.url,
@@ -209,10 +203,6 @@ export async function summarizeUrl(
  * Check if summarize is available (always true — no API key needed).
  */
 export function isSummarizeAvailable(): boolean {
-	if (process.env.TELCLAUDE_CAPABILITIES_URL) {
-		return Boolean(
-			process.env.TELCLAUDE_SESSION_TOKEN ?? process.env.TELEGRAM_RPC_AGENT_PRIVATE_KEY,
-		);
-	}
-	return true;
+	if (isRelayReachable()) return true;
+	return !process.env.TELCLAUDE_CAPABILITIES_URL;
 }

--- a/src/services/transcription.ts
+++ b/src/services/transcription.ts
@@ -10,6 +10,7 @@ import { loadConfig, type TelclaudeConfig, type TranscriptionConfig } from "../c
 import { getChildLogger } from "../logging.js";
 import { relayTranscribe } from "../relay/capabilities-client.js";
 import { getOpenAIClient, isOpenAIConfigured, isOpenAIConfiguredSync } from "./openai-client.js";
+import { isRelayReachable } from "./relay-routing.js";
 
 const logger = getChildLogger({ module: "transcription" });
 
@@ -64,16 +65,13 @@ export type TranscriptionAvailability = {
  */
 export async function getTranscriptionAvailability(): Promise<TranscriptionAvailability> {
 	if (process.env.TELCLAUDE_CAPABILITIES_URL) {
-		const hasAuth =
-			process.env.TELCLAUDE_SESSION_TOKEN ?? process.env.TELEGRAM_RPC_AGENT_PRIVATE_KEY;
-		if (!hasAuth) {
-			return {
-				available: false,
-				provider: "relay",
-				reason: "Relay auth required (TELEGRAM_RPC_AGENT_PRIVATE_KEY or session token).",
-			};
-		}
-		return { available: true, provider: "relay" };
+		return isRelayReachable()
+			? { available: true, provider: "relay" }
+			: {
+					available: false,
+					provider: "relay",
+					reason: "Relay auth required (TELEGRAM_RPC_AGENT_PRIVATE_KEY or session token).",
+				};
 	}
 
 	const config = loadConfig();

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -4,14 +4,14 @@
  */
 
 import { spawn } from "node:child_process";
-import fs from "node:fs";
 
 import { loadConfig, type TTSConfig } from "../config/config.js";
 import { getChildLogger } from "../logging.js";
 import { saveMediaBuffer } from "../media/store.js";
 import { relayTextToSpeech } from "../relay/capabilities-client.js";
-import { getMultimediaRateLimiter } from "./multimedia-rate-limit.js";
+import { consumeRateLimit, enforceRateLimit } from "./multimedia-rate-limit.js";
 import { getOpenAIClient, isOpenAIConfigured, isOpenAIConfiguredSync } from "./openai-client.js";
+import { isRelayReachable } from "./relay-routing.js";
 
 const logger = getChildLogger({ module: "tts" });
 
@@ -173,21 +173,16 @@ export async function textToSpeech(text: string, options?: TTSOptions): Promise<
 		);
 	}
 
-	// Rate limiting check (if userId provided)
 	const userId = options?.userId;
-	if (userId && !options?.skipRateLimit) {
-		const rateLimiter = getMultimediaRateLimiter();
-		const rateLimitConfig = {
+	enforceRateLimit(
+		"tts",
+		userId,
+		{
 			maxPerHourPerUser: ttsConfig.maxPerHourPerUser,
 			maxPerDayPerUser: ttsConfig.maxPerDayPerUser,
-		};
-		const limitResult = rateLimiter.checkLimit("tts", userId, rateLimitConfig);
-
-		if (!limitResult.allowed) {
-			logger.warn({ userId, remaining: limitResult.remaining }, "TTS rate limited");
-			throw new Error(limitResult.reason ?? "Text-to-speech rate limit exceeded");
-		}
-	}
+		},
+		options,
+	);
 
 	const client = await getOpenAIClient();
 	const voice = options?.voice ?? ttsConfig.voice ?? "alloy";
@@ -250,8 +245,6 @@ export async function textToSpeech(text: string, options?: TTSOptions): Promise<
 			extension: `.${finalFormat}`,
 		});
 
-		const stat = await fs.promises.stat(saved.path);
-
 		// Estimate duration based on text length and speed
 		// Average speaking rate is ~150 words per minute, ~5 chars per word
 		const wordsPerMinute = 150 * speed;
@@ -266,22 +259,18 @@ export async function textToSpeech(text: string, options?: TTSOptions): Promise<
 				voiceMessage,
 				format: finalFormat,
 				durationMs,
-				sizeBytes: stat.size,
+				sizeBytes: buffer.length,
 				estimatedDurationSeconds,
 			},
 			"speech generated successfully",
 		);
 
-		// Consume rate limit point after successful generation
-		if (userId && !options?.skipRateLimit) {
-			const rateLimiter = getMultimediaRateLimiter();
-			rateLimiter.consume("tts", userId);
-		}
+		consumeRateLimit("tts", userId, options);
 
 		return {
 			path: saved.path,
 			format: finalFormat,
-			sizeBytes: stat.size,
+			sizeBytes: buffer.length,
 			voice,
 			speed,
 			estimatedDurationSeconds,
@@ -297,18 +286,10 @@ export async function textToSpeech(text: string, options?: TTSOptions): Promise<
  * Uses sync check for env/config; keychain key will be found at runtime.
  */
 export function isTTSAvailable(): boolean {
-	// Available via relay when TELCLAUDE_CAPABILITIES_URL is set
-	if (process.env.TELCLAUDE_CAPABILITIES_URL) {
-		return Boolean(
-			process.env.TELCLAUDE_SESSION_TOKEN ?? process.env.TELEGRAM_RPC_AGENT_PRIVATE_KEY,
-		);
-	}
+	if (isRelayReachable()) return true;
 
 	const config = loadConfig();
-
-	if (config.tts?.provider === "disabled") {
-		return false;
-	}
+	if (config.tts?.provider === "disabled") return false;
 
 	return isOpenAIConfiguredSync();
 }

--- a/src/storage/attachment-refs.ts
+++ b/src/storage/attachment-refs.ts
@@ -19,6 +19,12 @@ const logger = getChildLogger({ module: "attachment-refs" });
 // Default TTL: 15 minutes (configurable via TELCLAUDE_ATTACHMENT_REF_TTL_MS)
 const DEFAULT_REF_TTL_MS = 15 * 60 * 1000;
 
+/** Number of hex chars to keep from SHA-256 hash for ref uniqueness. */
+const HASH_TRUNCATE_LEN = 8;
+
+/** Number of hex chars to keep from HMAC-SHA256 signature. */
+const SIG_TRUNCATE_LEN = 16;
+
 export type AttachmentRef = {
 	ref: string;
 	actorUserId: string;
@@ -86,7 +92,11 @@ function generateRef(params: {
 
 	// Generate hash for uniqueness
 	const hashInput = `${filepath}|${actorUserId}|${createdAt}`;
-	const hash = crypto.createHash("sha256").update(hashInput).digest("hex").slice(0, 8);
+	const hash = crypto
+		.createHash("sha256")
+		.update(hashInput)
+		.digest("hex")
+		.slice(0, HASH_TRUNCATE_LEN);
 
 	// Ref prefix (without signature)
 	const expiresAtSec = Math.floor(expiresAt / 1000);
@@ -105,7 +115,7 @@ function generateRef(params: {
 		.createHmac("sha256", secret)
 		.update(signatureInput)
 		.digest("hex")
-		.slice(0, 16);
+		.slice(0, SIG_TRUNCATE_LEN);
 
 	return `${refPrefix}.${signature}`;
 }
@@ -136,7 +146,7 @@ function verifyRefSignature(ref: string, stored: AttachmentRef): boolean {
 		.createHmac("sha256", secret)
 		.update(signatureInput)
 		.digest("hex")
-		.slice(0, 16);
+		.slice(0, SIG_TRUNCATE_LEN);
 
 	// Timing-safe comparison
 	if (providedSig.length !== expectedSig.length) return false;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -423,81 +423,64 @@ export function cleanupExpired(): {
 } {
 	const database = getDb();
 	const now = Date.now();
-
-	// Clean expired approvals
-	const approvalsResult = database.prepare("DELETE FROM approvals WHERE expires_at < ?").run(now);
-
-	// Clean expired plan approvals
-	const planApprovalsResult = database
-		.prepare("DELETE FROM plan_approvals WHERE expires_at < ?")
-		.run(now);
-
-	// Clean expired link codes
-	const linkCodesResult = database
-		.prepare("DELETE FROM pending_link_codes WHERE expires_at < ?")
-		.run(now);
-
-	// Clean old rate limit windows (older than 1 hour)
 	const oneHourAgo = now - 3600 * 1000;
-	const rateLimitsResult = database
-		.prepare("DELETE FROM rate_limits WHERE window_start < ?")
-		.run(oneHourAgo);
-
-	// Clean expired TOTP sessions
-	const totpSessionsResult = database
-		.prepare("DELETE FROM totp_sessions WHERE expires_at < ?")
-		.run(now);
-
-	// Clean expired admin claims
-	const adminClaimsResult = database
-		.prepare("DELETE FROM pending_admin_claims WHERE expires_at < ?")
-		.run(now);
-
-	// Clean expired pending TOTP messages
-	const pendingTotpResult = database
-		.prepare("DELETE FROM pending_totp_messages WHERE expires_at < ?")
-		.run(now);
-
-	// Clean old bot messages (older than 24 hours)
 	const oneDayAgo = now - 24 * 3600 * 1000;
-	const botMessagesResult = database
-		.prepare("DELETE FROM bot_messages WHERE sent_at < ?")
-		.run(oneDayAgo);
-
-	// Clean reactions for deleted bot messages (cascade via subquery)
-	const reactionsResult = database
-		.prepare(
-			`DELETE FROM message_reactions
-			 WHERE (chat_id, message_id) NOT IN (
-				 SELECT chat_id, message_id FROM bot_messages
-			 )`,
-		)
-		.run();
-
-	// Clean expired attachment refs
-	const attachmentRefsResult = database
-		.prepare("DELETE FROM attachment_refs WHERE expires_at < ?")
-		.run(now);
-
-	// Keep cron run history for 30 days
 	const thirtyDaysAgo = now - 30 * 24 * 3600 * 1000;
-	const cronRunsResult = database
-		.prepare("DELETE FROM cron_runs WHERE started_at < ?")
-		.run(thirtyDaysAgo);
 
-	const result = {
-		approvals: approvalsResult.changes,
-		planApprovals: planApprovalsResult.changes,
-		linkCodes: linkCodesResult.changes,
-		rateLimits: rateLimitsResult.changes,
-		totpSessions: totpSessionsResult.changes,
-		adminClaims: adminClaimsResult.changes,
-		pendingTotpMessages: pendingTotpResult.changes,
-		botMessages: botMessagesResult.changes,
-		messageReactions: reactionsResult.changes,
-		attachmentRefs: attachmentRefsResult.changes,
-		cronRuns: cronRunsResult.changes,
-	};
+	const run = database.transaction(() => {
+		const approvalsResult = database.prepare("DELETE FROM approvals WHERE expires_at < ?").run(now);
+		const planApprovalsResult = database
+			.prepare("DELETE FROM plan_approvals WHERE expires_at < ?")
+			.run(now);
+		const linkCodesResult = database
+			.prepare("DELETE FROM pending_link_codes WHERE expires_at < ?")
+			.run(now);
+		const rateLimitsResult = database
+			.prepare("DELETE FROM rate_limits WHERE window_start < ?")
+			.run(oneHourAgo);
+		const totpSessionsResult = database
+			.prepare("DELETE FROM totp_sessions WHERE expires_at < ?")
+			.run(now);
+		const adminClaimsResult = database
+			.prepare("DELETE FROM pending_admin_claims WHERE expires_at < ?")
+			.run(now);
+		const pendingTotpResult = database
+			.prepare("DELETE FROM pending_totp_messages WHERE expires_at < ?")
+			.run(now);
+		const botMessagesResult = database
+			.prepare("DELETE FROM bot_messages WHERE sent_at < ?")
+			.run(oneDayAgo);
+		const reactionsResult = database
+			.prepare(
+				`DELETE FROM message_reactions
+				 WHERE (chat_id, message_id) NOT IN (
+					 SELECT chat_id, message_id FROM bot_messages
+				 )`,
+			)
+			.run();
+		const attachmentRefsResult = database
+			.prepare("DELETE FROM attachment_refs WHERE expires_at < ?")
+			.run(now);
+		const cronRunsResult = database
+			.prepare("DELETE FROM cron_runs WHERE started_at < ?")
+			.run(thirtyDaysAgo);
+
+		return {
+			approvals: approvalsResult.changes,
+			planApprovals: planApprovalsResult.changes,
+			linkCodes: linkCodesResult.changes,
+			rateLimits: rateLimitsResult.changes,
+			totpSessions: totpSessionsResult.changes,
+			adminClaims: adminClaimsResult.changes,
+			pendingTotpMessages: pendingTotpResult.changes,
+			botMessages: botMessagesResult.changes,
+			messageReactions: reactionsResult.changes,
+			attachmentRefs: attachmentRefsResult.changes,
+			cronRuns: cronRunsResult.changes,
+		};
+	});
+
+	const result = run();
 
 	logger.info(result, "expired entries cleaned up");
 

--- a/src/storage/reactions.ts
+++ b/src/storage/reactions.ts
@@ -136,48 +136,61 @@ export function getReactionsForMessage(chatId: number, messageId: number): Store
 export function getRecentReactions(chatId: number, limit = 5): ReactionSummary[] {
 	const db = getDb();
 
-	// Get recent bot messages that have at least one reaction
-	const messages = db
+	// Single JOIN query instead of N+1: fetch reactions for recent reacted-to messages
+	const rows = db
 		.prepare(
-			`SELECT DISTINCT bm.message_id
-			 FROM bot_messages bm
-			 INNER JOIN message_reactions mr ON bm.chat_id = mr.chat_id AND bm.message_id = mr.message_id
-			 WHERE bm.chat_id = ?
-			 ORDER BY bm.sent_at DESC
-			 LIMIT ?`,
+			`SELECT mr.message_id, mr.user_id, mr.emoji, mr.reacted_at
+			 FROM message_reactions mr
+			 INNER JOIN bot_messages bm ON bm.chat_id = mr.chat_id AND bm.message_id = mr.message_id
+			 WHERE mr.chat_id = ?
+			   AND bm.message_id IN (
+				 SELECT DISTINCT bm2.message_id
+				 FROM bot_messages bm2
+				 INNER JOIN message_reactions mr2 ON bm2.chat_id = mr2.chat_id AND bm2.message_id = mr2.message_id
+				 WHERE bm2.chat_id = ?
+				 ORDER BY bm2.sent_at DESC
+				 LIMIT ?
+			   )
+			 ORDER BY bm.sent_at DESC, mr.reacted_at ASC`,
 		)
-		.all(chatId, limit) as Array<{ message_id: number }>;
+		.all(chatId, chatId, limit) as Array<{
+		message_id: number;
+		user_id: number;
+		emoji: string;
+		reacted_at: number;
+	}>;
 
-	if (messages.length === 0) {
+	if (rows.length === 0) {
 		return [];
 	}
 
-	// Get reactions for each message
-	const summaries: ReactionSummary[] = [];
-	for (const msg of messages) {
-		const reactions = getReactionsForMessage(chatId, msg.message_id);
-		if (reactions.length > 0) {
-			// Group by emoji
-			const byEmoji = new Map<string, { count: number; userIds: number[] }>();
-			for (const r of reactions) {
-				const existing = byEmoji.get(r.emoji);
-				if (existing) {
-					existing.count++;
-					existing.userIds.push(r.userId);
-				} else {
-					byEmoji.set(r.emoji, { count: 1, userIds: [r.userId] });
-				}
-			}
-
-			summaries.push({
-				messageId: msg.message_id,
-				reactions: Array.from(byEmoji.entries()).map(([emoji, data]) => ({
-					emoji,
-					count: data.count,
-					userIds: data.userIds,
-				})),
-			});
+	// Group by message, then by emoji
+	const byMessage = new Map<number, Map<string, { count: number; userIds: number[] }>>();
+	for (const row of rows) {
+		let emojiMap = byMessage.get(row.message_id);
+		if (!emojiMap) {
+			emojiMap = new Map();
+			byMessage.set(row.message_id, emojiMap);
 		}
+		const existing = emojiMap.get(row.emoji);
+		if (existing) {
+			existing.count++;
+			existing.userIds.push(row.user_id);
+		} else {
+			emojiMap.set(row.emoji, { count: 1, userIds: [row.user_id] });
+		}
+	}
+
+	const summaries: ReactionSummary[] = [];
+	for (const [messageId, emojiMap] of byMessage) {
+		summaries.push({
+			messageId,
+			reactions: Array.from(emojiMap.entries()).map(([emoji, data]) => ({
+				emoji,
+				count: data.count,
+				userIds: data.userIds,
+			})),
+		});
 	}
 
 	return summaries;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,6 +60,13 @@ export function sleep(ms: number) {
 }
 
 /**
+ * Remove one or more trailing slashes from a URL/path string.
+ */
+export function stripTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+/**
  * Validate and resolve an environment variable as an absolute directory path.
  * Rejects: ~ paths (not expanded in env vars), relative paths, empty strings.
  * Returns normalized path (no trailing slash) or null if invalid.

--- a/src/vault-daemon/oauth.ts
+++ b/src/vault-daemon/oauth.ts
@@ -14,6 +14,7 @@
  * - Timeout enforced on token endpoint requests
  */
 
+import { fetchWithTimeout } from "../infra/timeout.js";
 import { getChildLogger } from "../logging.js";
 import { sanitizeError } from "../utils.js";
 import type { OAuth2Credential } from "./protocol.js";
@@ -205,43 +206,33 @@ async function refreshToken(credential: OAuth2Credential): Promise<TokenResponse
 		body.set("scope", credential.scope);
 	}
 
-	// Use AbortController for timeout
-	const controller = new AbortController();
-	const timeoutId = setTimeout(() => controller.abort(), TOKEN_REQUEST_TIMEOUT_MS);
-
-	try {
-		const response = await fetch(credential.tokenEndpoint, {
+	const response = await fetchWithTimeout(
+		credential.tokenEndpoint,
+		{
 			method: "POST",
 			headers: {
 				"Content-Type": "application/x-www-form-urlencoded",
 			},
 			body: body.toString(),
-			signal: controller.signal,
 			// SECURITY: Disable redirects - a redirect from a token endpoint is an error.
 			// Following redirects could leak client_secret and refresh_token.
 			redirect: "error",
-		});
+		},
+		TOKEN_REQUEST_TIMEOUT_MS,
+	);
 
-		if (!response.ok) {
-			const errorText = await response.text();
-			throw new Error(`Token endpoint returned ${response.status}: ${errorText}`);
-		}
-
-		const tokenResponse = (await response.json()) as TokenResponse;
-
-		if (!tokenResponse.access_token) {
-			throw new Error("Token endpoint did not return access_token");
-		}
-
-		return tokenResponse;
-	} catch (err) {
-		if (err instanceof Error && err.name === "AbortError") {
-			throw new Error(`Token endpoint request timed out after ${TOKEN_REQUEST_TIMEOUT_MS}ms`);
-		}
-		throw err;
-	} finally {
-		clearTimeout(timeoutId);
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Token endpoint returned ${response.status}: ${errorText}`);
 	}
+
+	const tokenResponse = (await response.json()) as TokenResponse;
+
+	if (!tokenResponse.access_token) {
+		throw new Error("Token endpoint did not return access_token");
+	}
+
+	return tokenResponse;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- **Unit 13 (Services)**: Extract `relay-routing.ts` with `isAgentSide()`/`isRelayReachable()` replacing 5 inline env checks; extract `enforceRateLimit()`/`consumeRateLimit()` helpers; replace `fs.stat().size` with `buffer.length`; simplify availability checks in image-gen, TTS, summarize, transcription
- **Unit 14 (Use existing utilities)**: Extract `stripTrailingSlash()` in utils.ts replacing 4 inline `.replace()` calls; replace 5 hand-rolled `AbortController+setTimeout` fetch patterns with `fetchWithTimeout()` across oauth, vault, providers
- **Unit 16 (Memory + storage)**: Delegate quarantine validation to `validateEntry()`; extract `validateSnapshotFields()` shared by body/query parsers; wrap `cleanupExpired()` in SQLite transaction; extract HMAC truncation constants; replace N+1 query with single JOIN in `getRecentReactions()`

19 files changed, net -66 lines. All 709 tests pass.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — all 709 tests pass (69 test files)
- [ ] Verify no behavioral changes in relay routing, rate limiting, or storage cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)