### PR TITLE
refactor(commands): extract shared CLI helpers

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -44,6 +44,7 @@ e20d117c101c3c1b9a6844ac8c3ca110c27a62e3:src/sandbox/config.ts:credentials-javas
 e82ee12ace184aece9e37ee32666802d1e8efa43:src/security/streaming-redactor.ts:generic-api-key:7
 5ed752ae82c86f5e10f32b2c4eb5ec7248af65f0:src/security/output-filter.ts:credentials-javascript:582
 103c4bd94feec6d6d59b1e3b9c397b26dd456bd4:src/security/output-filter.ts:credentials-javascript:330
+e33e93fd814c48bd7a95205dd272ffc2214be337:src/security/output-filter.ts:credentials-javascript:406
 cb853d9b343174696ced01e3cab2198c15e26fe5:src/telegram/auto-reply.ts:credentials-javascript:704
 
 # OpenAI client - credential proxy sentinel value (not a real key)

--- a/src/commands/access-control.ts
+++ b/src/commands/access-control.ts
@@ -22,6 +22,7 @@ import {
 } from "../security/banned-chats.js";
 import { getIdentityLink } from "../security/linking.js";
 import { invalidateTOTPSession } from "../security/totp-session.js";
+import { parseChatId } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-access-control" });
 
@@ -36,11 +37,7 @@ export function registerAccessControlCommands(program: Command): void {
 		.option("-r, --reason <reason>", "Reason for the ban")
 		.action(async (chatIdStr: string, options: { reason?: string }) => {
 			try {
-				const chatId = Number.parseInt(chatIdStr, 10);
-				if (Number.isNaN(chatId)) {
-					console.error(`Invalid chat ID: ${chatIdStr}`);
-					process.exit(1);
-				}
+				const chatId = parseChatId(chatIdStr);
 
 				const result = banChat(chatId, "cli:admin", options.reason);
 
@@ -69,11 +66,7 @@ export function registerAccessControlCommands(program: Command): void {
 		.description("Restore access for a banned chat")
 		.action(async (chatIdStr: string) => {
 			try {
-				const chatId = Number.parseInt(chatIdStr, 10);
-				if (Number.isNaN(chatId)) {
-					console.error(`Invalid chat ID: ${chatIdStr}`);
-					process.exit(1);
-				}
+				const chatId = parseChatId(chatIdStr);
 
 				const result = unbanChat(chatId);
 
@@ -99,11 +92,7 @@ export function registerAccessControlCommands(program: Command): void {
 		.description("Invalidate TOTP session for a chat, requiring re-verification")
 		.action(async (chatIdStr: string) => {
 			try {
-				const chatId = Number.parseInt(chatIdStr, 10);
-				if (Number.isNaN(chatId)) {
-					console.error(`Invalid chat ID: ${chatIdStr}`);
-					process.exit(1);
-				}
+				const chatId = parseChatId(chatIdStr);
 
 				// Get identity link to find the local user
 				const link = getIdentityLink(chatId);

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -9,6 +9,7 @@ import { refreshExternalProviderSkill } from "../providers/provider-skill.js";
 import { relayGetProviders } from "../relay/capabilities-client.js";
 import { getSandboxMode } from "../sandbox/index.js";
 import { buildRuntimeSnapshot } from "../system-metadata.js";
+import { runDaemon } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-agent" });
 
@@ -127,7 +128,7 @@ export function registerAgentCommand(program: Command): void {
 			}
 
 			// Keep the process alive (server runs indefinitely)
-			await new Promise(() => {});
+			await runDaemon();
 		});
 }
 

--- a/src/commands/cli-guards.ts
+++ b/src/commands/cli-guards.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared CLI precondition guards.
+ *
+ * Consolidates duplicate "is X available? if not, exit(1)" patterns from
+ * setup-openai, setup-git, setup-google, oauth, vault, provider-query,
+ * fetch-attachment, send-attachment, and send-local-file commands.
+ */
+
+import { isSecretsStorageAvailable } from "../secrets/index.js";
+import { getVaultClient, isVaultAvailable, type VaultClient } from "../vault-daemon/index.js";
+
+/**
+ * Require TELCLAUDE_CAPABILITIES_URL to be set (relay available).
+ * Exits with code 1 if missing.
+ */
+export function requireRelay(): string {
+	const url = process.env.TELCLAUDE_CAPABILITIES_URL;
+	if (!url) {
+		console.error("Error: TELCLAUDE_CAPABILITIES_URL is not configured.");
+		console.error("This command requires the relay capabilities server.");
+		process.exit(1);
+	}
+	return url;
+}
+
+/**
+ * Require vault daemon to be running.
+ * Exits with code 1 if unavailable.
+ */
+export async function requireVault(): Promise<VaultClient> {
+	if (!(await isVaultAvailable())) {
+		console.error("Error: Vault daemon is not running.");
+		console.error("Start it with: telclaude vault-daemon");
+		process.exit(1);
+	}
+	return getVaultClient();
+}
+
+/**
+ * Require secrets storage to be available (keychain or encrypted file).
+ * Exits with code 1 if unavailable.
+ */
+export async function requireSecretsStorage(): Promise<void> {
+	if (!(await isSecretsStorageAvailable())) {
+		console.error(
+			"Error: Secrets storage not available.\n" +
+				"On Linux, install libsecret-1-dev, or set SECRETS_ENCRYPTION_KEY for file storage.",
+		);
+		process.exit(1);
+	}
+}

--- a/src/commands/cli-mask.ts
+++ b/src/commands/cli-mask.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared masking utility for CLI display.
+ *
+ * Consolidates duplicate mask/maskApiKey/maskToken functions from
+ * setup-openai, setup-git, setup-google, setup-github-app, and oauth commands.
+ */
+
+export type MaskOptions = {
+	/** Min length before masking applies (default: 8) */
+	threshold?: number;
+	/** Number of visible prefix chars (default: 4) */
+	prefix?: number;
+	/** Number of visible suffix chars (default: 4) */
+	suffix?: number;
+};
+
+/**
+ * Mask a sensitive value for display, showing only a prefix and suffix.
+ *
+ * Examples (with defaults):
+ *   mask("sk-proj-abc123xyz789") => "sk-p...z789"
+ *   mask("short") => "****"
+ */
+export function mask(value: string, opts?: MaskOptions): string {
+	const threshold = opts?.threshold ?? 8;
+	const prefix = opts?.prefix ?? 4;
+	const suffix = opts?.suffix ?? 4;
+
+	if (value.length <= threshold) {
+		return `****${"*".repeat(Math.max(0, threshold - 4))}`;
+	}
+
+	return `${value.slice(0, prefix)}...${value.slice(-suffix)}`;
+}

--- a/src/commands/cli-prompt.ts
+++ b/src/commands/cli-prompt.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared CLI prompt helpers.
+ *
+ * Consolidates duplicate readline prompt implementations from setup-openai,
+ * setup-git, setup-google, oauth, vault, totp-setup, quickstart, reset-auth,
+ * and reset-db commands.
+ */
+
+import * as readline from "node:readline";
+
+/**
+ * Prompt for visible text input.
+ * Returns null on EOF or Ctrl+C.
+ */
+export async function promptLine(question: string): Promise<string | null> {
+	return new Promise((resolve) => {
+		const rl = readline.createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+
+		rl.question(question, (answer) => {
+			rl.close();
+			resolve(answer.trim() || null);
+		});
+
+		rl.on("close", () => {
+			resolve(null);
+		});
+	});
+}
+
+/**
+ * Prompt for secret input (hidden, echoes asterisks on TTY).
+ * Returns null on EOF or Ctrl+C.
+ */
+export async function promptSecret(prompt: string): Promise<string | null> {
+	return new Promise((resolve) => {
+		const rl = readline.createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+
+		const stdin = process.stdin;
+		const wasRaw = stdin.isRaw;
+
+		if (stdin.isTTY) {
+			process.stdout.write(prompt);
+			stdin.setRawMode(true);
+
+			let secret = "";
+			stdin.resume();
+			const handler = (char: Buffer) => {
+				const c = char.toString();
+				if (c === "\n" || c === "\r" || c === "\u0004") {
+					stdin.setRawMode(wasRaw ?? false);
+					stdin.removeListener("data", handler);
+					process.stdout.write("\n");
+					rl.close();
+					resolve(secret.trim() || null);
+				} else if (c === "\u0003") {
+					stdin.setRawMode(wasRaw ?? false);
+					stdin.removeListener("data", handler);
+					process.stdout.write("\n");
+					rl.close();
+					resolve(null);
+				} else if (c === "\u007F" || c === "\b") {
+					if (secret.length > 0) {
+						secret = secret.slice(0, -1);
+						process.stdout.write("\b \b");
+					}
+				} else if (c.charCodeAt(0) >= 32) {
+					secret += c;
+					process.stdout.write("*");
+				}
+			};
+			stdin.on("data", handler);
+		} else {
+			rl.question(prompt, (answer) => {
+				rl.close();
+				resolve(answer.trim() || null);
+			});
+		}
+	});
+}
+
+/**
+ * Prompt for yes/no confirmation.
+ * Returns true for "y" or "yes" (case-insensitive), false otherwise.
+ */
+export async function promptYesNo(question: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const rl = readline.createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+
+		rl.question(`${question} (y/N): `, (answer) => {
+			rl.close();
+			resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+		});
+
+		rl.on("close", () => {
+			resolve(false);
+		});
+	});
+}

--- a/src/commands/cli-utils.ts
+++ b/src/commands/cli-utils.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared CLI utilities.
+ *
+ * Consolidates duplicate helper functions from various command files:
+ * - parseChatId: access-control, send, link
+ * - copyDirRecursive: skills-promote, skills-import
+ * - formatDuration: sessions (formatAge)
+ * - formatUptime: status
+ * - confirmDangerousReset: reset-auth, reset-db
+ * - runDaemon: totp-daemon, vault-daemon, git-proxy-init, agent
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { promptLine } from "./cli-prompt.js";
+
+/**
+ * Parse a string as a chat ID (integer). Exits on failure.
+ */
+export function parseChatId(raw: string): number {
+	const id = Number.parseInt(raw, 10);
+	if (Number.isNaN(id)) {
+		console.error(`Invalid chat ID: ${raw}`);
+		process.exit(1);
+	}
+	return id;
+}
+
+/**
+ * Recursively copy a directory.
+ */
+export function copyDirRecursive(source: string, target: string): void {
+	fs.mkdirSync(target, { recursive: true });
+	const entries = fs.readdirSync(source, { withFileTypes: true });
+	for (const entry of entries) {
+		const srcPath = path.join(source, entry.name);
+		const tgtPath = path.join(target, entry.name);
+		if (entry.isDirectory()) {
+			copyDirRecursive(srcPath, tgtPath);
+		} else if (entry.isFile()) {
+			fs.copyFileSync(srcPath, tgtPath);
+		}
+	}
+}
+
+/**
+ * Format a duration in ms as a short human string (e.g., "5s", "3m", "2h", "1d").
+ */
+export function formatDuration(ms: number): string {
+	const seconds = Math.floor(ms / 1000);
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+	const days = Math.floor(hours / 24);
+	return `${days}d`;
+}
+
+/**
+ * Format an uptime in seconds as a compound string (e.g., "2h 15m 30s").
+ */
+export function formatUptime(seconds: number): string {
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	const remainingSeconds = seconds % 60;
+
+	if (hours > 0) return `${hours}h ${remainingMinutes}m ${remainingSeconds}s`;
+	if (minutes > 0) return `${minutes}m ${remainingSeconds}s`;
+	return `${remainingSeconds}s`;
+}
+
+/**
+ * Two-step dangerous reset confirmation.
+ * 1. User types the label (e.g., "RESET") to confirm.
+ * 2. On TTY, user must also enter a random confirmation code.
+ *
+ * Returns true if confirmed, false if aborted.
+ * --force skips confirmation in non-TTY environments only.
+ */
+export async function confirmDangerousReset(opts: {
+	label: string;
+	force?: boolean;
+}): Promise<boolean> {
+	const isTty = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+	if (opts.force && isTty) {
+		console.log("--force ignored on TTY; interactive confirmations are required.");
+	}
+
+	if (!opts.force || isTty) {
+		const answer = await promptLine(`Type "${opts.label}" to confirm: `);
+		if (answer?.trim().toUpperCase() !== opts.label.toUpperCase()) {
+			console.log("");
+			console.log("Aborted. No changes made.");
+			return false;
+		}
+	}
+
+	if (isTty) {
+		const code = crypto.randomBytes(3).toString("hex").toUpperCase();
+		const codeAnswer = await promptLine(`Enter confirmation code ${code}: `);
+		if (codeAnswer?.trim().toUpperCase() !== code) {
+			console.log("");
+			console.log("Aborted. No changes made.");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Keep a daemon process alive until SIGINT/SIGTERM.
+ * Optionally runs cleanup before exit.
+ */
+export async function runDaemon(opts?: {
+	onShutdown?: () => Promise<void> | void;
+}): Promise<never> {
+	const shutdown = async (signal: string) => {
+		console.log(`\nReceived ${signal}, shutting down...`);
+		if (opts?.onShutdown) {
+			await opts.onShutdown();
+		}
+		process.exit(0);
+	};
+
+	process.on("SIGINT", () => shutdown("SIGINT"));
+	process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+	// Never resolves - daemon runs until signal
+	return new Promise(() => {});
+}

--- a/src/commands/fetch-attachment.ts
+++ b/src/commands/fetch-attachment.ts
@@ -6,6 +6,7 @@
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
 import { relayFetchAttachment } from "../relay/capabilities-client.js";
+import { requireRelay } from "./cli-guards.js";
 
 const logger = getChildLogger({ module: "cmd-fetch-attachment" });
 
@@ -32,12 +33,7 @@ export function registerFetchAttachmentCommand(program: Command): void {
 		.option("--user-id <id>", "User ID for rate limiting (optional)")
 		.action(async (opts: FetchAttachmentOptions) => {
 			try {
-				const useRelay = Boolean(process.env.TELCLAUDE_CAPABILITIES_URL);
-				if (!useRelay) {
-					console.error("Error: TELCLAUDE_CAPABILITIES_URL is not configured.");
-					console.error("This command requires the relay capabilities server.");
-					process.exit(1);
-				}
+				requireRelay();
 
 				const providerId = opts.provider?.trim() ?? "";
 				const attachmentId = opts.id?.trim() ?? "";

--- a/src/commands/git-proxy-init.ts
+++ b/src/commands/git-proxy-init.ts
@@ -252,7 +252,8 @@ export function registerGitProxyInitCommand(program: Command): void {
 				setInterval(() => void refresh(), refreshMs);
 
 				// Keep the process alive
-				await new Promise(() => {});
+				const { runDaemon } = await import("./cli-utils.js");
+				await runDaemon();
 			}
 		});
 }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { generateLinkCode, listIdentityLinks, removeIdentityLink } from "../security/linking.js";
+import { parseChatId } from "./cli-utils.js";
 
 export type LinkOptions = {
 	list?: boolean;
@@ -35,11 +36,7 @@ export function registerLinkCommand(program: Command): void {
 			}
 
 			if (opts.remove) {
-				const chatId = Number.parseInt(opts.remove, 10);
-				if (Number.isNaN(chatId)) {
-					console.error("Error: Invalid chat ID");
-					process.exit(1);
-				}
+				const chatId = parseChatId(opts.remove);
 
 				const removed = removeIdentityLink(chatId);
 				if (removed) {

--- a/src/commands/oauth.ts
+++ b/src/commands/oauth.ts
@@ -10,65 +10,16 @@
  * - telclaude oauth revoke <service> - Revoke + remove from vault
  */
 
-import { createInterface } from "node:readline";
 import type { Command } from "commander";
 
 import { getChildLogger } from "../logging.js";
 import { authorize, getCallbackUrl } from "../oauth/flow.js";
 import { getService, listServices } from "../oauth/registry.js";
 import { getVaultClient, isVaultAvailable } from "../vault-daemon/index.js";
+import { mask } from "./cli-mask.js";
+import { promptSecret } from "./cli-prompt.js";
 
 const logger = getChildLogger({ module: "cmd-oauth" });
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// Helpers
-// ═══════════════════════════════════════════════════════════════════════════════
-
-/**
- * Prompt for a secret without echoing to terminal.
- */
-async function promptSecret(prompt: string): Promise<string> {
-	return new Promise((resolve) => {
-		const rl = createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		if (process.stdin.isTTY) {
-			process.stdout.write(prompt);
-			process.stdin.setRawMode(true);
-
-			let secret = "";
-			process.stdin.resume();
-			process.stdin.on("data", function handler(char) {
-				const c = char.toString();
-				if (c === "\n" || c === "\r" || c === "\u0004") {
-					process.stdin.setRawMode(false);
-					process.stdin.removeListener("data", handler);
-					rl.close();
-					console.log();
-					resolve(secret);
-				} else if (c === "\u0003") {
-					process.exit(1);
-				} else if (c === "\u007F" || c === "\b") {
-					secret = secret.slice(0, -1);
-				} else {
-					secret += c;
-				}
-			});
-		} else {
-			rl.question(prompt, (answer) => {
-				rl.close();
-				resolve(answer);
-			});
-		}
-	});
-}
-
-function mask(value: string): string {
-	if (value.length <= 6) return "********";
-	return `${value.slice(0, 4)}..${value.slice(-3)}`;
-}
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Command Registration
@@ -143,7 +94,7 @@ export function registerOAuthCommand(program: Command): void {
 					const scopes = opts.scope?.split(" ") ?? service.defaultScopes;
 
 					// Collect credentials
-					const clientId = opts.clientId ?? (await promptSecret("Client ID: "));
+					const clientId = opts.clientId ?? (await promptSecret("Client ID: ")) ?? "";
 					if (!clientId) {
 						console.error("Client ID is required.");
 						process.exit(1);
@@ -151,7 +102,7 @@ export function registerOAuthCommand(program: Command): void {
 
 					let clientSecret = "";
 					if (service.confidentialClient) {
-						clientSecret = opts.clientSecret ?? (await promptSecret("Client Secret: "));
+						clientSecret = opts.clientSecret ?? (await promptSecret("Client Secret: ")) ?? "";
 						if (!clientSecret) {
 							console.error("Client Secret is required for confidential clients.");
 							process.exit(1);
@@ -165,7 +116,7 @@ export function registerOAuthCommand(program: Command): void {
 					console.log(`Callback URL (must be registered in Developer Console):`);
 					console.log(`  ${callbackUrl}`);
 					console.log();
-					console.log(`Client ID: ${mask(clientId)}`);
+					console.log(`Client ID: ${mask(clientId, { threshold: 6, suffix: 3 })}`);
 					if (service.confidentialClient) {
 						console.log(`Client Secret: ********`);
 					}

--- a/src/commands/provider-health.ts
+++ b/src/commands/provider-health.ts
@@ -126,12 +126,10 @@ export function registerProviderHealthCommand(program: Command): void {
 					return;
 				}
 
-				// Check all providers
-				const results: HealthCheckResult[] = [];
-				for (const provider of toCheck) {
-					const result = await checkProviderHealth(provider.id, provider.baseUrl);
-					results.push(result);
-				}
+				// Check all providers in parallel
+				const results = await Promise.all(
+					toCheck.map((provider) => checkProviderHealth(provider.id, provider.baseUrl)),
+				);
 
 				// Output results
 				console.log(formatHealthOutput(results, options.json ?? false));

--- a/src/commands/provider-query.ts
+++ b/src/commands/provider-query.ts
@@ -14,6 +14,7 @@
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
 import { relayProviderProxy } from "../relay/capabilities-client.js";
+import { requireRelay } from "./cli-guards.js";
 
 const logger = getChildLogger({ module: "cmd-provider-query" });
 
@@ -42,12 +43,7 @@ export function registerProviderQueryCommand(program: Command): void {
 		.option("--approval-token <token>", "Signed approval token for action-type requests")
 		.action(async (opts: ProviderQueryOptions) => {
 			try {
-				const useRelay = Boolean(process.env.TELCLAUDE_CAPABILITIES_URL);
-				if (!useRelay) {
-					console.error("Error: TELCLAUDE_CAPABILITIES_URL is not configured.");
-					console.error("This command requires the relay capabilities server.");
-					process.exit(1);
-				}
+				requireRelay();
 
 				const providerId = opts.provider?.trim();
 				const service = opts.service?.trim();

--- a/src/commands/quickstart.ts
+++ b/src/commands/quickstart.ts
@@ -1,27 +1,9 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import readline from "node:readline";
 import type { Command } from "commander";
 import { CONFIG_DIR } from "../utils.js";
-
-/**
- * Quickstart command - creates a minimal config for first-time users.
- *
- * Sets up:
- * - READ_ONLY tier (safe default)
- * - Simple security profile (no observer, no approvals)
- * - No TOTP requirement
- * - Minimal friction to get started
- */
-
-function prompt(rl: readline.Interface, question: string): Promise<string> {
-	return new Promise((resolve) => {
-		rl.question(question, (answer) => {
-			resolve(answer.trim());
-		});
-	});
-}
+import { promptLine } from "./cli-prompt.js";
 
 export interface QuickstartOptions {
 	token?: string;
@@ -40,11 +22,6 @@ export function registerQuickstartCommand(program: Command): void {
 			const configPath = path.join(CONFIG_DIR, "telclaude.json");
 			const configExists = fs.existsSync(configPath);
 
-			const rl = readline.createInterface({
-				input: process.stdin,
-				output: process.stdout,
-			});
-
 			try {
 				console.log("\n🚀 Telclaude Quickstart\n");
 				console.log("This will create a minimal config with:");
@@ -54,11 +31,10 @@ export function registerQuickstartCommand(program: Command): void {
 
 				// Check for existing config
 				if (configExists && !opts.force) {
-					const overwrite = await prompt(
-						rl,
+					const overwrite = await promptLine(
 						`Config already exists at ${configPath}. Overwrite? [y/N]: `,
 					);
-					if (overwrite.toLowerCase() !== "y" && overwrite.toLowerCase() !== "yes") {
+					if (overwrite?.toLowerCase() !== "y" && overwrite?.toLowerCase() !== "yes") {
 						console.log("\nAborted. Your existing config is unchanged.");
 						return;
 					}
@@ -69,7 +45,7 @@ export function registerQuickstartCommand(program: Command): void {
 				if (!token) {
 					console.log("Step 1: Get your bot token from @BotFather on Telegram");
 					console.log("        (Send /newbot to @BotFather to create one)\n");
-					token = await prompt(rl, "Bot token: ");
+					token = (await promptLine("Bot token: ")) ?? "";
 				}
 
 				if (!token || !token.includes(":")) {
@@ -84,7 +60,7 @@ export function registerQuickstartCommand(program: Command): void {
 					console.log("        Send a message to your bot, then visit:");
 					console.log(`        https://api.telegram.org/bot${token}/getUpdates`);
 					console.log('        Look for "chat":{"id": YOUR_CHAT_ID}\n');
-					chatId = await prompt(rl, "Your chat ID (numeric): ");
+					chatId = (await promptLine("Your chat ID (numeric): ")) ?? "";
 				}
 
 				const numericChatId = Number.parseInt(chatId, 10);
@@ -146,8 +122,9 @@ export function registerQuickstartCommand(program: Command): void {
 
 				console.log("Edit the config to change permissions:");
 				console.log(`  ${configPath}\n`);
-			} finally {
-				rl.close();
+			} catch (err) {
+				console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+				process.exit(1);
 			}
 		});
 }

--- a/src/commands/reset-auth.ts
+++ b/src/commands/reset-auth.ts
@@ -13,30 +13,12 @@
  * - Warning messages explain the risk
  */
 
-import crypto from "node:crypto";
-import * as readline from "node:readline";
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
 import { getDb } from "../storage/db.js";
+import { confirmDangerousReset } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-reset-auth" });
-
-/**
- * Prompt for user input with readline.
- */
-async function prompt(question: string): Promise<string> {
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-	});
-
-	return new Promise((resolve) => {
-		rl.question(question, (answer) => {
-			rl.close();
-			resolve(answer);
-		});
-	});
-}
 
 export function registerResetAuthCommand(program: Command): void {
 	program
@@ -60,29 +42,9 @@ export function registerResetAuthCommand(program: Command): void {
 				console.log("   An attacker with shell access could take over your bot.");
 				console.log("");
 
-				const isTty = Boolean(process.stdin.isTTY && process.stdout.isTTY);
-				if (options.force && isTty) {
-					console.log("--force ignored on TTY; interactive confirmations are required.");
-				}
-
-				if (!options.force || isTty) {
-					const answer = await prompt('Type "RESET" to confirm: ');
-					if (answer.trim() !== "RESET") {
-						console.log("");
-						console.log("Aborted. No changes made.");
-						return;
-					}
-				}
-
-				// Second confirmation with a random code when interactive
-				if (isTty) {
-					const confirmationCode = crypto.randomBytes(3).toString("hex").toUpperCase();
-					const codeAnswer = await prompt(`Enter confirmation code ${confirmationCode}: `);
-					if (codeAnswer.trim().toUpperCase() !== confirmationCode) {
-						console.log("");
-						console.log("Aborted. No changes made.");
-						return;
-					}
+				const confirmed = await confirmDangerousReset({ label: "RESET", force: options.force });
+				if (!confirmed) {
+					return;
 				}
 
 				const db = getDb();

--- a/src/commands/reset-db.ts
+++ b/src/commands/reset-db.ts
@@ -1,20 +1,9 @@
-import crypto from "node:crypto";
-import * as readline from "node:readline";
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
 import { resetDatabase } from "../storage/db.js";
+import { confirmDangerousReset } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-reset-db" });
-
-async function prompt(question: string): Promise<string> {
-	const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-	return new Promise((resolve) => {
-		rl.question(question, (answer) => {
-			rl.close();
-			resolve(answer);
-		});
-	});
-}
 
 export function registerResetDbCommand(program: Command): void {
 	program
@@ -36,27 +25,9 @@ export function registerResetDbCommand(program: Command): void {
 				console.log("   Audit logs and media files are NOT affected.");
 				console.log("");
 
-				const isTty = Boolean(process.stdin.isTTY && process.stdout.isTTY);
-
-				if (options.force && isTty) {
-					console.log("--force ignored on TTY; interactive confirmations are required.");
-				}
-
-				if (!options.force || isTty) {
-					const answer = await prompt('Type "RESET DB" to confirm: ');
-					if (answer.trim().toUpperCase() !== "RESET DB") {
-						console.log("Aborted. No changes made.");
-						return;
-					}
-				}
-
-				if (isTty) {
-					const confirmationCode = crypto.randomBytes(3).toString("hex").toUpperCase();
-					const codeAnswer = await prompt(`Enter confirmation code ${confirmationCode}: `);
-					if (codeAnswer.trim().toUpperCase() !== confirmationCode) {
-						console.log("Aborted. No changes made.");
-						return;
-					}
+				const confirmed = await confirmDangerousReset({ label: "RESET DB", force: options.force });
+				if (!confirmed) {
+					return;
 				}
 
 				resetDatabase();

--- a/src/commands/send-attachment.ts
+++ b/src/commands/send-attachment.ts
@@ -13,6 +13,7 @@ import fs from "node:fs";
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
 import { relayValidateAttachment } from "../relay/capabilities-client.js";
+import { requireRelay } from "./cli-guards.js";
 
 const logger = getChildLogger({ module: "cmd-send-attachment" });
 
@@ -29,12 +30,7 @@ export function registerSendAttachmentCommand(program: Command): void {
 		.option("--user-id <id>", "User ID for validation (optional)")
 		.action(async (opts: SendAttachmentOptions) => {
 			try {
-				const useRelay = Boolean(process.env.TELCLAUDE_CAPABILITIES_URL);
-				if (!useRelay) {
-					console.error("Error: TELCLAUDE_CAPABILITIES_URL is not configured.");
-					console.error("This command requires the relay capabilities server.");
-					process.exit(1);
-				}
+				requireRelay();
 
 				const ref = opts.ref?.trim();
 				if (!ref) {

--- a/src/commands/send-local-file.ts
+++ b/src/commands/send-local-file.ts
@@ -9,6 +9,7 @@
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
 import { relayDeliverLocalFile } from "../relay/capabilities-client.js";
+import { requireRelay } from "./cli-guards.js";
 
 const logger = getChildLogger({ module: "cmd-send-local-file" });
 
@@ -27,12 +28,7 @@ export function registerSendLocalFileCommand(program: Command): void {
 		.option("--user-id <id>", "User ID for logging (optional)")
 		.action(async (opts: SendLocalFileOptions) => {
 			try {
-				const useRelay = Boolean(process.env.TELCLAUDE_CAPABILITIES_URL);
-				if (!useRelay) {
-					console.error("Error: TELCLAUDE_CAPABILITIES_URL is not configured.");
-					console.error("This command requires the relay capabilities server.");
-					process.exit(1);
-				}
+				requireRelay();
 
 				const sourcePath = opts.path?.trim();
 				if (!sourcePath) {

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../config/config.js";
 import { readEnv } from "../env.js";
 import { getChildLogger } from "../logging.js";
 import { sendTelegramMessage } from "../telegram/outbound.js";
+import { parseChatId } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-send" });
 
@@ -28,11 +29,7 @@ export function registerSendCommand(program: Command): void {
 				const cfg = loadConfig();
 				const token = env.telegramBotToken;
 
-				const numericChatId = Number.parseInt(chatId, 10);
-				if (Number.isNaN(numericChatId)) {
-					console.error("Error: chatId must be a numeric value");
-					process.exit(1);
-				}
+				const numericChatId = parseChatId(chatId);
 
 				if (!message && !opts.media) {
 					console.error("Error: Either message or --media must be provided");

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { getAllSessions, type SessionEntry } from "../config/sessions.js";
+import { formatDuration } from "./cli-utils.js";
 
 export type SessionListRow = {
 	key: string;
@@ -35,23 +36,6 @@ function toRows(store: Record<string, SessionEntry>): SessionListRow[] {
 			systemSent: entry.systemSent === true,
 		}))
 		.sort((a, b) => b.updatedAt - a.updatedAt);
-}
-
-function formatAge(ageMs: number): string {
-	const seconds = Math.floor(ageMs / 1000);
-	if (seconds < 60) {
-		return `${seconds}s`;
-	}
-	const minutes = Math.floor(seconds / 60);
-	if (minutes < 60) {
-		return `${minutes}m`;
-	}
-	const hours = Math.floor(minutes / 60);
-	if (hours < 24) {
-		return `${hours}h`;
-	}
-	const days = Math.floor(hours / 24);
-	return `${days}d`;
 }
 
 function pad(value: string, width: number): string {
@@ -149,7 +133,7 @@ export function registerSessionsCommand(program: Command): void {
 						[
 							pad(row.kind, 7),
 							pad(truncate(row.key, 20), 20),
-							pad(formatAge(row.ageMs), 8),
+							pad(formatDuration(row.ageMs), 8),
 							pad(truncate(row.sessionId, 14), 14),
 							flags,
 						]

--- a/src/commands/setup-git.ts
+++ b/src/commands/setup-git.ts
@@ -6,8 +6,6 @@
  * on behalf of a bot user account.
  */
 
-import * as readline from "node:readline";
-
 import type { Command } from "commander";
 
 import { getChildLogger } from "../logging.js";
@@ -17,7 +15,6 @@ import {
 	getSecret,
 	getStorageProviderName,
 	hasSecret,
-	isSecretsStorageAvailable,
 	SECRET_KEYS,
 	storeSecret,
 } from "../secrets/index.js";
@@ -27,6 +24,9 @@ import {
 	isGitConfigured,
 	testGitConnectivity,
 } from "../services/git-credentials.js";
+import { requireSecretsStorage } from "./cli-guards.js";
+import { mask } from "./cli-mask.js";
+import { promptLine, promptSecret, promptYesNo } from "./cli-prompt.js";
 
 const logger = getChildLogger({ module: "cmd-setup-git" });
 
@@ -48,14 +48,7 @@ export function registerSetupGitCommand(program: Command): void {
 				test?: boolean;
 			}) => {
 				try {
-					// Check if storage is available
-					if (!(await isSecretsStorageAvailable())) {
-						console.error(
-							"Error: Secrets storage not available.\n" +
-								"On Linux, install libsecret-1-dev, or set SECRETS_ENCRYPTION_KEY for file storage.",
-						);
-						process.exit(1);
-					}
+					await requireSecretsStorage();
 
 					const providerName = await getStorageProviderName();
 
@@ -98,7 +91,7 @@ export function registerSetupGitCommand(program: Command): void {
 								console.log(`Git credentials (${providerName}):`);
 								console.log(`  Username: ${creds.username}`);
 								console.log(`  Email:    ${creds.email}`);
-								console.log(`  Token:    ${maskToken(creds.token)}`);
+								console.log(`  Token:    ${mask(creds.token, { threshold: 12, prefix: 8 })}`);
 							} catch {
 								console.log("Stored credentials are corrupted. Run setup-git again.");
 							}
@@ -109,7 +102,7 @@ export function registerSetupGitCommand(program: Command): void {
 								console.log("Git credentials (env vars):");
 								console.log(`  Username: ${process.env.GIT_USERNAME}`);
 								console.log(`  Email:    ${process.env.GIT_EMAIL}`);
-								console.log(`  Token:    ${maskToken(envToken)}`);
+								console.log(`  Token:    ${mask(envToken, { threshold: 12, prefix: 8 })}`);
 							} else {
 								console.log("No git credentials configured.");
 							}
@@ -190,7 +183,7 @@ async function runInteractiveSetup(providerName: string): Promise<void> {
 			console.log("Current credentials:");
 			console.log(`  Username: ${creds.username}`);
 			console.log(`  Email:    ${creds.email}`);
-			console.log(`  Token:    ${maskToken(creds.token)}`);
+			console.log(`  Token:    ${mask(creds.token, { threshold: 12, prefix: 8 })}`);
 			console.log("");
 			console.log("Enter new credentials to replace, or Ctrl+C to cancel.");
 			console.log("");
@@ -201,7 +194,7 @@ async function runInteractiveSetup(providerName: string): Promise<void> {
 	}
 
 	// Prompt for username
-	const username = await promptForInput("Git username (e.g., myproject-bot): ");
+	const username = await promptLine("Git username (e.g., myproject-bot): ");
 	if (!username) {
 		console.log("Cancelled.");
 		return;
@@ -210,11 +203,11 @@ async function runInteractiveSetup(providerName: string): Promise<void> {
 	// Prompt for email (with default)
 	const defaultEmail = `${username}@users.noreply.github.com`;
 	const emailPrompt = `Git email [${defaultEmail}]: `;
-	const emailInput = await promptForInput(emailPrompt);
+	const emailInput = await promptLine(emailPrompt);
 	const email = emailInput || defaultEmail;
 
 	// Prompt for token (hidden)
-	const token = await promptForSecret("GitHub PAT (fine-grained token): ");
+	const token = await promptSecret("GitHub PAT (fine-grained token): ");
 	if (!token) {
 		console.log("Cancelled.");
 		return;
@@ -276,112 +269,4 @@ async function runInteractiveSetup(providerName: string): Promise<void> {
 	console.log("  telclaude setup-git --apply  # Apply git identity");
 
 	logger.info({ username, email, provider: providerName }, "Git credentials stored");
-}
-
-/**
- * Mask a token for display.
- */
-function maskToken(token: string): string {
-	if (token.length <= 12) {
-		return "****";
-	}
-	return `${token.slice(0, 8)}...${token.slice(-4)}`;
-}
-
-/**
- * Prompt for visible input.
- */
-async function promptForInput(prompt: string): Promise<string | null> {
-	return new Promise((resolve) => {
-		const rl = readline.createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		rl.question(prompt, (answer) => {
-			rl.close();
-			resolve(answer.trim() || null);
-		});
-
-		// Handle Ctrl+C
-		rl.on("close", () => {
-			resolve(null);
-		});
-	});
-}
-
-/**
- * Prompt for secret input (hidden).
- */
-async function promptForSecret(prompt: string): Promise<string | null> {
-	return new Promise((resolve) => {
-		const rl = readline.createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		const stdin = process.stdin;
-		const wasRaw = stdin.isRaw;
-
-		process.stdout.write(prompt);
-
-		if (stdin.isTTY) {
-			stdin.setRawMode(true);
-		}
-
-		let input = "";
-
-		const onData = (char: Buffer) => {
-			const c = char.toString();
-
-			if (c === "\n" || c === "\r") {
-				if (stdin.isTTY) {
-					stdin.setRawMode(wasRaw ?? false);
-				}
-				stdin.removeListener("data", onData);
-				process.stdout.write("\n");
-				rl.close();
-				resolve(input.trim() || null);
-			} else if (c === "\u0003") {
-				// Ctrl+C
-				if (stdin.isTTY) {
-					stdin.setRawMode(wasRaw ?? false);
-				}
-				stdin.removeListener("data", onData);
-				process.stdout.write("\n");
-				rl.close();
-				resolve(null);
-			} else if (c === "\u007F" || c === "\b") {
-				// Backspace
-				if (input.length > 0) {
-					input = input.slice(0, -1);
-					process.stdout.write("\b \b");
-				}
-			} else if (c.charCodeAt(0) >= 32) {
-				// Printable character
-				input += c;
-				process.stdout.write("*");
-			}
-		};
-
-		stdin.on("data", onData);
-		stdin.resume();
-	});
-}
-
-/**
- * Prompt for yes/no confirmation.
- */
-async function promptYesNo(question: string): Promise<boolean> {
-	return new Promise((resolve) => {
-		const rl = readline.createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		rl.question(`${question} (y/N): `, (answer) => {
-			rl.close();
-			resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
-		});
-	});
 }

--- a/src/commands/setup-github-app.ts
+++ b/src/commands/setup-github-app.ts
@@ -8,7 +8,6 @@
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import * as readline from "node:readline";
 
 import type { Command } from "commander";
 
@@ -17,7 +16,6 @@ import {
 	deleteSecret,
 	getSecret,
 	getStorageProviderName,
-	isSecretsStorageAvailable,
 	SECRET_KEYS,
 	storeSecret,
 } from "../secrets/index.js";
@@ -30,6 +28,8 @@ import {
 	listAccessibleRepositories,
 	testGitHubAppConnectivity,
 } from "../services/github-app.js";
+import { requireSecretsStorage } from "./cli-guards.js";
+import { promptLine, promptYesNo } from "./cli-prompt.js";
 
 const logger = getChildLogger({ module: "cmd-setup-github-app" });
 
@@ -83,13 +83,7 @@ export function registerSetupGitHubAppCommand(program: Command): void {
 				privateKey?: string;
 			}) => {
 				try {
-					if (!(await isSecretsStorageAvailable())) {
-						console.error(
-							"Error: Secrets storage not available.\n" +
-								"On Linux, install libsecret-1-dev, or set SECRETS_ENCRYPTION_KEY for file storage.",
-						);
-						process.exit(1);
-					}
+					await requireSecretsStorage();
 
 					const providerName = await getStorageProviderName();
 
@@ -298,7 +292,7 @@ async function runInteractiveSetup(providerName: string): Promise<void> {
 	}
 
 	// Prompt for App ID
-	const appId = await promptForInput("GitHub App ID: ");
+	const appId = await promptLine("GitHub App ID: ");
 	if (!appId) {
 		console.log("Cancelled.");
 		return;
@@ -311,7 +305,7 @@ async function runInteractiveSetup(providerName: string): Promise<void> {
 	console.log("  2. Click 'Configure' on your app");
 	console.log("  3. The ID is in the URL: /installations/<INSTALLATION_ID>");
 	console.log("");
-	const installationId = await promptForInput("Installation ID: ");
+	const installationId = await promptLine("Installation ID: ");
 	if (!installationId) {
 		console.log("Cancelled.");
 		return;
@@ -319,7 +313,7 @@ async function runInteractiveSetup(providerName: string): Promise<void> {
 
 	// Prompt for private key path
 	console.log("");
-	const privateKeyPath = await promptForInput("Path to private key (.pem file): ");
+	const privateKeyPath = await promptLine("Path to private key (.pem file): ");
 	if (!privateKeyPath) {
 		console.log("Cancelled.");
 		return;
@@ -439,48 +433,4 @@ function maskPrivateKey(keyOrPath: string): string {
 	}
 	// It's inline content, mask it
 	return "-----BEGIN RSA PRIVATE KEY-----...-----END RSA PRIVATE KEY-----";
-}
-
-async function promptForInput(prompt: string): Promise<string | null> {
-	return new Promise((resolve) => {
-		let resolved = false;
-		const rl = readline.createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		rl.question(prompt, (answer) => {
-			resolved = true;
-			rl.close();
-			resolve(answer.trim() || null);
-		});
-
-		rl.on("close", () => {
-			if (!resolved) {
-				resolve(null);
-			}
-		});
-	});
-}
-
-async function promptYesNo(question: string): Promise<boolean> {
-	return new Promise((resolve) => {
-		let resolved = false;
-		const rl = readline.createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		rl.question(`${question} (y/N): `, (answer) => {
-			resolved = true;
-			rl.close();
-			resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
-		});
-
-		rl.on("close", () => {
-			if (!resolved) {
-				resolve(false); // Default to "no" if closed without answer
-			}
-		});
-	});
 }

--- a/src/commands/setup-google.ts
+++ b/src/commands/setup-google.ts
@@ -9,6 +9,8 @@ import { getChildLogger } from "../logging.js";
 import { authorize, getCallbackUrl } from "../oauth/flow.js";
 import { getService } from "../oauth/registry.js";
 import { getVaultClient, isVaultAvailable } from "../vault-daemon/index.js";
+import { mask } from "./cli-mask.js";
+import { promptSecret } from "./cli-prompt.js";
 
 const logger = getChildLogger({ module: "cmd-setup-google" });
 
@@ -46,49 +48,6 @@ const SCOPE_BUNDLES: Record<string, string[]> = {
 		"https://www.googleapis.com/auth/contacts.readonly",
 	],
 };
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// Helpers
-// ═══════════════════════════════════════════════════════════════════════════════
-
-function mask(value: string): string {
-	if (value.length <= 6) return "********";
-	return `${value.slice(0, 4)}..${value.slice(-3)}`;
-}
-
-async function promptSecret(prompt: string): Promise<string> {
-	const { createInterface } = await import("node:readline");
-	return new Promise((resolve) => {
-		const rl = createInterface({ input: process.stdin, output: process.stdout });
-		if (process.stdin.isTTY) {
-			process.stdout.write(prompt);
-			process.stdin.setRawMode(true);
-			let secret = "";
-			process.stdin.resume();
-			process.stdin.on("data", function handler(char) {
-				const c = char.toString();
-				if (c === "\n" || c === "\r" || c === "\u0004") {
-					process.stdin.setRawMode(false);
-					process.stdin.removeListener("data", handler);
-					rl.close();
-					console.log();
-					resolve(secret);
-				} else if (c === "\u0003") {
-					process.exit(1);
-				} else if (c === "\u007F" || c === "\b") {
-					secret = secret.slice(0, -1);
-				} else {
-					secret += c;
-				}
-			});
-		} else {
-			rl.question(prompt, (answer) => {
-				rl.close();
-				resolve(answer);
-			});
-		}
-	});
-}
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Command
@@ -171,7 +130,7 @@ export function registerSetupGoogleCommand(program: Command): void {
 							console.log(`  Target: ${service.vaultTarget}`);
 							console.log(`  Type: ${cred.type}`);
 							if (cred.type === "oauth2") {
-								console.log(`  Client ID: ${mask(cred.clientId)}`);
+								console.log(`  Client ID: ${mask(cred.clientId, { threshold: 6, suffix: 3 })}`);
 								console.log(`  Scope: ${cred.scope ?? "(default)"}`);
 							}
 							console.log(`  Created: ${entry.entry.createdAt}`);
@@ -208,13 +167,13 @@ export function registerSetupGoogleCommand(program: Command): void {
 					console.log(`Scope bundle: ${opts.scopes} (${scopes.length} scopes)`);
 					console.log();
 
-					const clientId = await promptSecret("Google Client ID: ");
+					const clientId = (await promptSecret("Google Client ID: ")) ?? "";
 					if (!clientId) {
 						console.error("Client ID is required.");
 						process.exit(1);
 					}
 
-					const clientSecret = await promptSecret("Google Client Secret: ");
+					const clientSecret = (await promptSecret("Google Client Secret: ")) ?? "";
 					if (!clientSecret) {
 						console.error("Client Secret is required.");
 						process.exit(1);

--- a/src/commands/setup-openai.ts
+++ b/src/commands/setup-openai.ts
@@ -3,8 +3,6 @@
  * Stores the key securely in OS keychain or encrypted file.
  */
 
-import * as readline from "node:readline";
-
 import type { Command } from "commander";
 
 import { getChildLogger } from "../logging.js";
@@ -13,11 +11,13 @@ import {
 	getSecret,
 	getStorageProviderName,
 	hasSecret,
-	isSecretsStorageAvailable,
 	SECRET_KEYS,
 	storeSecret,
 } from "../secrets/index.js";
 import { clearOpenAICache } from "../services/openai-client.js";
+import { requireSecretsStorage } from "./cli-guards.js";
+import { mask } from "./cli-mask.js";
+import { promptSecret, promptYesNo } from "./cli-prompt.js";
 
 const logger = getChildLogger({ module: "cmd-setup-openai" });
 
@@ -31,14 +31,7 @@ export function registerSetupOpenAICommand(program: Command): void {
 		.option("--check", "Check if an API key is configured")
 		.action(async (opts: { delete?: boolean; show?: boolean; check?: boolean }) => {
 			try {
-				// Check if storage is available
-				if (!(await isSecretsStorageAvailable())) {
-					console.error(
-						"Error: Secrets storage not available.\n" +
-							"On Linux, install libsecret-1-dev, or set SECRETS_ENCRYPTION_KEY for file storage.",
-					);
-					process.exit(1);
-				}
+				await requireSecretsStorage();
 
 				const providerName = await getStorageProviderName();
 
@@ -76,12 +69,12 @@ export function registerSetupOpenAICommand(program: Command): void {
 				if (opts.show) {
 					const key = await getSecret(SECRET_KEYS.OPENAI_API_KEY);
 					if (key) {
-						const masked = maskApiKey(key);
+						const masked = mask(key);
 						console.log(`OpenAI API key (${providerName}): ${masked}`);
 					} else {
 						const envKey = process.env.OPENAI_API_KEY;
 						if (envKey) {
-							const masked = maskApiKey(envKey);
+							const masked = mask(envKey);
 							console.log(`OpenAI API key (env var): ${masked}`);
 						} else {
 							console.log("No OpenAI API key configured.");
@@ -101,7 +94,7 @@ export function registerSetupOpenAICommand(program: Command): void {
 				if (existingKey) {
 					const current = await getSecret(SECRET_KEYS.OPENAI_API_KEY);
 					if (current) {
-						console.log(`Current key: ${maskApiKey(current)}`);
+						console.log(`Current key: ${mask(current)}`);
 					}
 					console.log(
 						"A key is already stored. Enter a new key to replace it, or Ctrl+C to cancel.",
@@ -110,7 +103,7 @@ export function registerSetupOpenAICommand(program: Command): void {
 				}
 
 				// Prompt for key
-				const apiKey = await promptForApiKey();
+				const apiKey = await promptSecret("Enter OpenAI API key: ");
 
 				if (!apiKey) {
 					console.log("Cancelled.");
@@ -145,92 +138,4 @@ export function registerSetupOpenAICommand(program: Command): void {
 		});
 
 	// Command alias is registered above.
-}
-
-/**
- * Mask an API key for display.
- */
-function maskApiKey(key: string): string {
-	if (key.length <= 8) {
-		return "****";
-	}
-	return `${key.slice(0, 4)}...${key.slice(-4)}`;
-}
-
-/**
- * Prompt for API key input (hidden).
- */
-async function promptForApiKey(): Promise<string | null> {
-	return new Promise((resolve) => {
-		const rl = readline.createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		// Hide input
-		const stdin = process.stdin;
-		const wasRaw = stdin.isRaw;
-
-		process.stdout.write("Enter OpenAI API key: ");
-
-		if (stdin.isTTY) {
-			stdin.setRawMode(true);
-		}
-
-		let input = "";
-
-		const onData = (char: Buffer) => {
-			const c = char.toString();
-
-			if (c === "\n" || c === "\r") {
-				// Enter pressed
-				if (stdin.isTTY) {
-					stdin.setRawMode(wasRaw ?? false);
-				}
-				stdin.removeListener("data", onData);
-				process.stdout.write("\n");
-				rl.close();
-				resolve(input.trim() || null);
-			} else if (c === "\u0003") {
-				// Ctrl+C
-				if (stdin.isTTY) {
-					stdin.setRawMode(wasRaw ?? false);
-				}
-				stdin.removeListener("data", onData);
-				process.stdout.write("\n");
-				rl.close();
-				resolve(null);
-			} else if (c === "\u007F" || c === "\b") {
-				// Backspace
-				if (input.length > 0) {
-					input = input.slice(0, -1);
-					process.stdout.write("\b \b");
-				}
-			} else if (c.charCodeAt(0) >= 32) {
-				// Printable character
-				input += c;
-				process.stdout.write("*");
-			}
-		};
-
-		stdin.on("data", onData);
-		stdin.resume();
-	});
-}
-
-/**
- * Prompt for yes/no confirmation.
- */
-async function promptYesNo(question: string): Promise<boolean> {
-	return new Promise((resolve) => {
-		const rl = readline.createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		rl.question(`${question} (y/N): `, (answer) => {
-			rl.close();
-			resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
-		});
-	});
 }

--- a/src/commands/skills-promote.ts
+++ b/src/commands/skills-promote.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
 import { scanSkill } from "../security/skill-scanner.js";
+import { copyDirRecursive } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-skills-promote" });
 
@@ -137,20 +138,6 @@ export function promoteSkill(
 
 	logger.info({ skillName }, "skill promoted from draft to active");
 	return { success: true, skillName };
-}
-
-function copyDirRecursive(source: string, target: string): void {
-	fs.mkdirSync(target, { recursive: true });
-	const entries = fs.readdirSync(source, { withFileTypes: true });
-	for (const entry of entries) {
-		const srcPath = path.join(source, entry.name);
-		const tgtPath = path.join(target, entry.name);
-		if (entry.isDirectory()) {
-			copyDirRecursive(srcPath, tgtPath);
-		} else if (entry.isFile()) {
-			fs.copyFileSync(srcPath, tgtPath);
-		}
-	}
 }
 
 /**

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,6 +7,7 @@ import { getCronStatusSummary } from "../cron/store.js";
 import { getChildLogger } from "../logging.js";
 import { createAuditLogger } from "../security/audit.js";
 import { buildRuntimeSnapshot } from "../system-metadata.js";
+import { formatDuration, formatUptime } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-status" });
 const STATUS_STARTED_AT = Date.now();
@@ -75,39 +76,6 @@ export type TelclaudeStatus = {
 		};
 	};
 };
-
-function formatUptime(seconds: number): string {
-	const minutes = Math.floor(seconds / 60);
-	const hours = Math.floor(minutes / 60);
-	const remainingMinutes = minutes % 60;
-	const remainingSeconds = seconds % 60;
-
-	if (hours > 0) {
-		return `${hours}h ${remainingMinutes}m ${remainingSeconds}s`;
-	}
-
-	if (minutes > 0) {
-		return `${minutes}m ${remainingSeconds}s`;
-	}
-
-	return `${remainingSeconds}s`;
-}
-
-function formatAgeShort(seconds: number): string {
-	if (seconds < 60) {
-		return `${seconds}s`;
-	}
-	const minutes = Math.floor(seconds / 60);
-	if (minutes < 60) {
-		return `${minutes}m`;
-	}
-	const hours = Math.floor(minutes / 60);
-	if (hours < 24) {
-		return `${hours}h`;
-	}
-	const days = Math.floor(hours / 24);
-	return `${days}d`;
-}
 
 export async function collectTelclaudeStatus(): Promise<TelclaudeStatus> {
 	const configPath = getConfigPath();
@@ -295,7 +263,7 @@ export function formatTelclaudeStatus(status: TelclaudeStatus, telegram = false)
 	);
 	if (status.operations.sessions.recent.length > 0) {
 		for (const recent of status.operations.sessions.recent) {
-			lines.push(`    ${recent.key} (${formatAgeShort(recent.ageSeconds)} ago)`);
+			lines.push(`    ${recent.key} (${formatDuration(recent.ageSeconds * 1000)} ago)`);
 		}
 	}
 	lines.push(

--- a/src/commands/totp-daemon.ts
+++ b/src/commands/totp-daemon.ts
@@ -10,6 +10,7 @@ import { setVerbose } from "../globals.js";
 import { getChildLogger } from "../logging.js";
 import { getDefaultSocketPath, startServer } from "../totp-daemon/index.js";
 import { getStorageProvider } from "../totp-daemon/storage-provider.js";
+import { runDaemon } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-totp-daemon" });
 
@@ -52,19 +53,10 @@ export function registerTOTPDaemonCommand(program: Command): void {
 				console.log(`Secrets stored in: ${storageDesc}`);
 				console.log("Press Ctrl+C to stop.");
 
-				// Set up graceful shutdown
-				const shutdown = async () => {
-					console.log("\nShutting down TOTP daemon...");
-					await handle.stop();
-					process.exit(0);
-				};
-
-				process.on("SIGINT", shutdown);
-				process.on("SIGTERM", shutdown);
-
-				// Keep the process running
-				await new Promise(() => {
-					// Never resolves - daemon runs until signal
+				await runDaemon({
+					onShutdown: async () => {
+						await handle.stop();
+					},
 				});
 			} catch (err) {
 				logger.error({ error: String(err) }, "totp-daemon command failed");

--- a/src/commands/totp-setup.ts
+++ b/src/commands/totp-setup.ts
@@ -1,7 +1,7 @@
-import * as readline from "node:readline";
 import type { Command } from "commander";
 import qrcode from "qrcode-terminal";
 import { getTOTPClient } from "../totp-client/client.js";
+import { promptLine } from "./cli-prompt.js";
 
 export type TOTPSetupOptions = {
 	user?: string;
@@ -14,23 +14,6 @@ function displayQRCode(uri: string): Promise<void> {
 	return new Promise((resolve) => {
 		qrcode.generate(uri, { small: true }, () => {
 			resolve();
-		});
-	});
-}
-
-/**
- * Read a line from stdin.
- */
-async function readLine(prompt: string): Promise<string> {
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-	});
-
-	return new Promise((resolve) => {
-		rl.question(prompt, (answer) => {
-			rl.close();
-			resolve(answer);
 		});
 	});
 }
@@ -55,8 +38,8 @@ export function registerTOTPSetupCommand(program: Command): void {
 			const checkResult = await client.check(userId);
 			if (checkResult.status === "enabled") {
 				console.log(`\n⚠️  TOTP is already enabled for user '${userId}'.`);
-				const answer = await readLine("Do you want to reset it? (yes/no): ");
-				if (answer.toLowerCase() !== "yes") {
+				const answer = await promptLine("Do you want to reset it? (yes/no): ");
+				if (answer?.toLowerCase() !== "yes") {
 					console.log("Aborted.");
 					process.exit(0);
 				}
@@ -102,7 +85,7 @@ export function registerTOTPSetupCommand(program: Command): void {
 
 			// Verify setup
 			console.log("Enter the 6-digit code from your authenticator to verify setup:");
-			const code = await readLine("> ");
+			const code = (await promptLine("> ")) ?? "";
 
 			if (!/^\d{6}$/.test(code)) {
 				console.error("\n❌ Invalid code format. Please enter a 6-digit number.");

--- a/src/commands/vault-daemon.ts
+++ b/src/commands/vault-daemon.ts
@@ -13,6 +13,7 @@ import type { Command } from "commander";
 
 import { getChildLogger } from "../logging.js";
 import { getDefaultSocketPath, startServer } from "../vault-daemon/index.js";
+import { runDaemon } from "./cli-utils.js";
 
 const logger = getChildLogger({ module: "cmd-vault-daemon" });
 
@@ -38,20 +39,10 @@ export function registerVaultDaemonCommand(program: Command): void {
 
 				console.log(`Vault daemon listening on ${handle.socketPath}`);
 
-				// Handle graceful shutdown
-				const shutdown = async (signal: string) => {
-					logger.info({ signal }, "received shutdown signal");
-					console.log(`\nReceived ${signal}, shutting down...`);
-					await handle.stop();
-					process.exit(0);
-				};
-
-				process.on("SIGINT", () => shutdown("SIGINT"));
-				process.on("SIGTERM", () => shutdown("SIGTERM"));
-
-				// Keep process running
-				await new Promise(() => {
-					// Never resolves - daemon runs until signaled
+				await runDaemon({
+					onShutdown: async () => {
+						await handle.stop();
+					},
 				});
 			} catch (err) {
 				logger.error({ error: String(err) }, "vault-daemon command failed");

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -14,7 +14,6 @@
 import { readFileSync, unlinkSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
-import { createInterface } from "node:readline";
 import type { Command } from "commander";
 
 import { getChildLogger } from "../logging.js";
@@ -26,57 +25,9 @@ import {
 	type Protocol,
 	ProtocolSchema,
 } from "../vault-daemon/index.js";
+import { promptSecret } from "./cli-prompt.js";
 
 const logger = getChildLogger({ module: "cmd-vault" });
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// Helpers
-// ═══════════════════════════════════════════════════════════════════════════════
-
-/**
- * Prompt for a password/secret without echoing to terminal.
- */
-async function promptSecret(prompt: string): Promise<string> {
-	return new Promise((resolve) => {
-		const rl = createInterface({
-			input: process.stdin,
-			output: process.stdout,
-		});
-
-		// Disable echo (best effort - may not work on all terminals)
-		if (process.stdin.isTTY) {
-			process.stdout.write(prompt);
-			process.stdin.setRawMode(true);
-
-			let secret = "";
-			process.stdin.resume();
-			process.stdin.on("data", function handler(char) {
-				const c = char.toString();
-				if (c === "\n" || c === "\r" || c === "\u0004") {
-					process.stdin.setRawMode(false);
-					process.stdin.removeListener("data", handler);
-					rl.close();
-					console.log(); // Newline after hidden input
-					resolve(secret);
-				} else if (c === "\u0003") {
-					// Ctrl+C
-					process.exit(1);
-				} else if (c === "\u007F" || c === "\b") {
-					// Backspace
-					secret = secret.slice(0, -1);
-				} else {
-					secret += c;
-				}
-			});
-		} else {
-			// Non-TTY fallback
-			rl.question(prompt, (answer) => {
-				rl.close();
-				resolve(answer);
-			});
-		}
-	});
-}
 
 /**
  * Validate protocol string.
@@ -233,7 +184,7 @@ export function registerVaultCommand(program: Command): void {
 
 						switch (type) {
 							case "bearer": {
-								const token = opts.token ?? (await promptSecret("Token: "));
+								const token = opts.token ?? (await promptSecret("Token: ")) ?? "";
 								if (!token) {
 									console.error("Token is required for bearer auth");
 									process.exit(1);
@@ -243,7 +194,7 @@ export function registerVaultCommand(program: Command): void {
 							}
 
 							case "api-key": {
-								const token = opts.token ?? (await promptSecret("API Key: "));
+								const token = opts.token ?? (await promptSecret("API Key: ")) ?? "";
 								const header = opts.header ?? "X-API-Key";
 								if (!token) {
 									console.error("Token is required for api-key auth");
@@ -259,13 +210,13 @@ export function registerVaultCommand(program: Command): void {
 									console.error("--username is required for basic auth");
 									process.exit(1);
 								}
-								const password = opts.token ?? (await promptSecret("Password: "));
+								const password = opts.token ?? (await promptSecret("Password: ")) ?? "";
 								credential = { type: "basic", username, password };
 								break;
 							}
 
 							case "query": {
-								const token = opts.token ?? (await promptSecret("Token: "));
+								const token = opts.token ?? (await promptSecret("Token: ")) ?? "";
 								const param = opts.param ?? "api_key";
 								if (!token) {
 									console.error("Token is required for query auth");
@@ -284,8 +235,10 @@ export function registerVaultCommand(program: Command): void {
 									console.error("--token-endpoint is required for oauth2");
 									process.exit(1);
 								}
-								const clientSecret = opts.clientSecret ?? (await promptSecret("Client Secret: "));
-								const refreshToken = opts.refreshToken ?? (await promptSecret("Refresh Token: "));
+								const clientSecret =
+									opts.clientSecret ?? (await promptSecret("Client Secret: ")) ?? "";
+								const refreshToken =
+									opts.refreshToken ?? (await promptSecret("Refresh Token: ")) ?? "";
 
 								if (!clientSecret || !refreshToken) {
 									console.error("Client secret and refresh token are required for oauth2");
@@ -314,7 +267,7 @@ export function registerVaultCommand(program: Command): void {
 							console.error("--username is required for database credentials");
 							process.exit(1);
 						}
-						const password = opts.token ?? (await promptSecret("Password: "));
+						const password = opts.token ?? (await promptSecret("Password: ")) ?? "";
 						credential = {
 							type: "db",
 							username,
@@ -337,7 +290,7 @@ export function registerVaultCommand(program: Command): void {
 							const fs = await import("node:fs");
 							const privateKey = fs.readFileSync(opts.key, "utf-8");
 							const passphrase =
-								opts.passphrase ?? (await promptSecret("Key passphrase (or empty): "));
+								opts.passphrase ?? (await promptSecret("Key passphrase (or empty): ")) ?? "";
 							credential = {
 								type: "ssh-key",
 								username,
@@ -345,7 +298,7 @@ export function registerVaultCommand(program: Command): void {
 								passphrase: passphrase || undefined,
 							};
 						} else if (type === "ssh-password") {
-							const password = opts.token ?? (await promptSecret("Password: "));
+							const password = opts.token ?? (await promptSecret("Password: ")) ?? "";
 							credential = { type: "ssh-password", username, password };
 						} else {
 							console.error(`Invalid SSH credential type: ${type}`);
@@ -353,7 +306,7 @@ export function registerVaultCommand(program: Command): void {
 							process.exit(1);
 						}
 					} else if (protocol === "secret") {
-						const value = opts.token ?? (await promptSecret("Secret value: "));
+						const value = opts.token ?? (await promptSecret("Secret value: ")) ?? "";
 						if (!value) {
 							console.error("Secret value is required");
 							process.exit(1);

--- a/src/security/approvals.ts
+++ b/src/security/approvals.ts
@@ -57,9 +57,114 @@ type ApprovalRow = {
 	observer_reason: string | null;
 };
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// GENERIC TABLE HELPERS — shared consume/deny logic for approvals + plan_approvals
+// ═══════════════════════════════════════════════════════════════════════════════
+
+type RowBase = {
+	nonce: string;
+	chat_id: number;
+	expires_at: number;
+	request_id: string;
+};
+
 /**
- * Convert database row to PendingApproval.
+ * Atomically consume a row from a table: SELECT → validate → DELETE.
+ * Shared by consumeApproval and consumePlanApproval.
  */
+function consumeFromTable<TRow extends RowBase, T>(
+	table: string,
+	label: string,
+	nonce: string,
+	chatId: number,
+	mapper: (row: TRow) => T,
+): Result<T> {
+	const db = getDb();
+
+	return db.transaction(() => {
+		const row = db.prepare(`SELECT * FROM ${table} WHERE nonce = ?`).get(nonce) as TRow | undefined;
+
+		if (!row) {
+			return { success: false as const, error: `No pending ${label} found for that code.` };
+		}
+
+		if (row.chat_id !== chatId) {
+			logger.warn(
+				{ nonce, expectedChatId: row.chat_id, actualChatId: chatId },
+				`${label} chat mismatch`,
+			);
+			return {
+				success: false as const,
+				error: "This approval code belongs to a different chat.",
+			};
+		}
+
+		if (Date.now() > row.expires_at) {
+			db.prepare(`DELETE FROM ${table} WHERE nonce = ?`).run(nonce);
+			logger.warn({ nonce, chatId }, `${label} expired`);
+			return {
+				success: false as const,
+				error: `This ${label} has expired. Please retry your request.`,
+			};
+		}
+
+		const deleteResult = db.prepare(`DELETE FROM ${table} WHERE nonce = ?`).run(nonce);
+		if (deleteResult.changes !== 1) {
+			logger.error(
+				{ nonce, chatId, changes: deleteResult.changes },
+				`SECURITY: ${label} deletion anomaly - possible race condition`,
+			);
+			return {
+				success: false as const,
+				error: `${label} consumption failed - please try again`,
+			};
+		}
+
+		logger.info({ nonce, requestId: row.request_id, chatId }, `${label} consumed`);
+
+		return { success: true as const, data: mapper(row) };
+	})();
+}
+
+/**
+ * Atomically deny/cancel a row from a table: SELECT → validate chat → DELETE.
+ * Shared by denyApproval and denyPlanApproval.
+ */
+function denyFromTable<TRow extends RowBase, T>(
+	table: string,
+	label: string,
+	nonce: string,
+	chatId: number,
+	mapper: (row: TRow) => T,
+): Result<T> {
+	const db = getDb();
+
+	return db.transaction(() => {
+		const row = db.prepare(`SELECT * FROM ${table} WHERE nonce = ?`).get(nonce) as TRow | undefined;
+
+		if (!row) {
+			return { success: false as const, error: `No pending ${label} found for that code.` };
+		}
+
+		if (row.chat_id !== chatId) {
+			return {
+				success: false as const,
+				error: "This approval code belongs to a different chat.",
+			};
+		}
+
+		db.prepare(`DELETE FROM ${table} WHERE nonce = ?`).run(nonce);
+
+		logger.info({ nonce, requestId: row.request_id, chatId }, `${label} denied`);
+
+		return { success: true as const, data: mapper(row) };
+	})();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// APPROVAL ROW MAPPING
+// ═══════════════════════════════════════════════════════════════════════════════
+
 function rowToApproval(row: ApprovalRow): PendingApproval {
 	return {
 		nonce: row.nonce,
@@ -178,85 +283,26 @@ export function createApproval(
  * requests could both consume the same approval.
  */
 export function consumeApproval(nonce: string, chatId: number): Result<PendingApproval> {
-	const db = getDb();
-
-	// Use a transaction for atomic get-and-delete
-	const result = db.transaction(() => {
-		const row = db.prepare("SELECT * FROM approvals WHERE nonce = ?").get(nonce) as
-			| ApprovalRow
-			| undefined;
-
-		if (!row) {
-			return { success: false as const, error: "No pending approval found for that code." };
-		}
-
-		// Verify chat ID matches
-		if (row.chat_id !== chatId) {
-			logger.warn(
-				{ nonce, expectedChatId: row.chat_id, actualChatId: chatId },
-				"approval chat mismatch",
-			);
-			return { success: false as const, error: "This approval code belongs to a different chat." };
-		}
-
-		// Check expiry
-		if (Date.now() > row.expires_at) {
-			// Delete expired entry
-			db.prepare("DELETE FROM approvals WHERE nonce = ?").run(nonce);
-			logger.warn({ nonce, chatId }, "approval expired");
-			return {
-				success: false as const,
-				error: "This approval has expired. Please retry your request.",
-			};
-		}
-
-		// SECURITY: Atomically consume the approval - verify it was actually deleted
-		// This prevents replay attacks if somehow the approval wasn't deleted
-		const deleteResult = db.prepare("DELETE FROM approvals WHERE nonce = ?").run(nonce);
-		if (deleteResult.changes !== 1) {
-			// This should never happen in normal operation, but if it does, fail safe
-			logger.error(
-				{ nonce, chatId, changes: deleteResult.changes },
-				"SECURITY: Approval deletion anomaly - possible race condition",
-			);
-			return { success: false as const, error: "Approval consumption failed - please try again" };
-		}
-
-		logger.info({ nonce, requestId: row.request_id, chatId }, "approval consumed");
-
-		return { success: true as const, data: rowToApproval(row) };
-	})();
-
-	return result;
+	return consumeFromTable<ApprovalRow, PendingApproval>(
+		"approvals",
+		"approval",
+		nonce,
+		chatId,
+		rowToApproval,
+	);
 }
 
 /**
  * Deny/cancel an approval.
  */
 export function denyApproval(nonce: string, chatId: number): Result<PendingApproval> {
-	const db = getDb();
-
-	const result = db.transaction(() => {
-		const row = db.prepare("SELECT * FROM approvals WHERE nonce = ?").get(nonce) as
-			| ApprovalRow
-			| undefined;
-
-		if (!row) {
-			return { success: false as const, error: "No pending approval found for that code." };
-		}
-
-		if (row.chat_id !== chatId) {
-			return { success: false as const, error: "This approval code belongs to a different chat." };
-		}
-
-		db.prepare("DELETE FROM approvals WHERE nonce = ?").run(nonce);
-
-		logger.info({ nonce, requestId: row.request_id, chatId }, "approval denied");
-
-		return { success: true as const, data: rowToApproval(row) };
-	})();
-
-	return result;
+	return denyFromTable<ApprovalRow, PendingApproval>(
+		"approvals",
+		"approval",
+		nonce,
+		chatId,
+		rowToApproval,
+	);
 }
 
 /**
@@ -492,87 +538,26 @@ export function createPlanApproval(
  * Atomic get-and-delete to prevent race conditions.
  */
 export function consumePlanApproval(nonce: string, chatId: number): Result<PlanApproval> {
-	const db = getDb();
-
-	const result = db.transaction(() => {
-		const row = db.prepare("SELECT * FROM plan_approvals WHERE nonce = ?").get(nonce) as
-			| PlanApprovalRow
-			| undefined;
-
-		if (!row) {
-			return { success: false as const, error: "No pending plan approval found for that code." };
-		}
-
-		if (row.chat_id !== chatId) {
-			logger.warn(
-				{ nonce, expectedChatId: row.chat_id, actualChatId: chatId },
-				"plan approval chat mismatch",
-			);
-			return {
-				success: false as const,
-				error: "This approval code belongs to a different chat.",
-			};
-		}
-
-		if (Date.now() > row.expires_at) {
-			db.prepare("DELETE FROM plan_approvals WHERE nonce = ?").run(nonce);
-			logger.warn({ nonce, chatId }, "plan approval expired");
-			return {
-				success: false as const,
-				error: "This plan approval has expired. Please retry your request.",
-			};
-		}
-
-		const deleteResult = db.prepare("DELETE FROM plan_approvals WHERE nonce = ?").run(nonce);
-		if (deleteResult.changes !== 1) {
-			logger.error(
-				{ nonce, chatId, changes: deleteResult.changes },
-				"SECURITY: Plan approval deletion anomaly",
-			);
-			return {
-				success: false as const,
-				error: "Plan approval consumption failed - please try again",
-			};
-		}
-
-		logger.info({ nonce, requestId: row.request_id, chatId }, "plan approval consumed");
-
-		return { success: true as const, data: rowToPlanApproval(row) };
-	})();
-
-	return result;
+	return consumeFromTable<PlanApprovalRow, PlanApproval>(
+		"plan_approvals",
+		"plan approval",
+		nonce,
+		chatId,
+		rowToPlanApproval,
+	);
 }
 
 /**
  * Deny/cancel a plan approval.
  */
 export function denyPlanApproval(nonce: string, chatId: number): Result<PlanApproval> {
-	const db = getDb();
-
-	const result = db.transaction(() => {
-		const row = db.prepare("SELECT * FROM plan_approvals WHERE nonce = ?").get(nonce) as
-			| PlanApprovalRow
-			| undefined;
-
-		if (!row) {
-			return { success: false as const, error: "No pending plan approval found for that code." };
-		}
-
-		if (row.chat_id !== chatId) {
-			return {
-				success: false as const,
-				error: "This approval code belongs to a different chat.",
-			};
-		}
-
-		db.prepare("DELETE FROM plan_approvals WHERE nonce = ?").run(nonce);
-
-		logger.info({ nonce, requestId: row.request_id, chatId }, "plan approval denied");
-
-		return { success: true as const, data: rowToPlanApproval(row) };
-	})();
-
-	return result;
+	return denyFromTable<PlanApprovalRow, PlanApproval>(
+		"plan_approvals",
+		"plan approval",
+		nonce,
+		chatId,
+		rowToPlanApproval,
+	);
 }
 
 /**

--- a/src/security/output-filter.ts
+++ b/src/security/output-filter.ts
@@ -186,6 +186,19 @@ export const CORE_SECRET_PATTERNS: SecretPattern[] = [
  */
 export const SECRET_PATTERNS: SecretPattern[] = CORE_SECRET_PATTERNS;
 
+/**
+ * Pre-compiled global regexes for SECRET_PATTERNS.
+ * Avoids re-creating RegExp objects on every scan/redact call.
+ * Each entry corresponds to the same index in SECRET_PATTERNS.
+ *
+ * SECURITY: Uses the same source/flags as the original patterns,
+ * with 'g' flag guaranteed for global matching.
+ */
+const COMPILED_GLOBAL_PATTERNS: RegExp[] = SECRET_PATTERNS.map(({ pattern }) => {
+	const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+	return new RegExp(pattern.source, flags);
+});
+
 export interface FilterMatch {
 	pattern: string;
 	severity: "critical" | "high";
@@ -223,10 +236,10 @@ function redact(secret: string): string {
 export function redactSecrets(text: string): string {
 	let result = text;
 
-	for (const { name, pattern } of SECRET_PATTERNS) {
-		// Create new regex instance, preserving original flags but ensuring global
-		const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
-		const regex = new RegExp(pattern.source, flags);
+	for (let i = 0; i < SECRET_PATTERNS.length; i++) {
+		const { name } = SECRET_PATTERNS[i];
+		const regex = COMPILED_GLOBAL_PATTERNS[i];
+		regex.lastIndex = 0;
 		if (name === "totp_seed") {
 			// Avoid redacting low-entropy base32-looking text (reduces false positives)
 			result = result.replace(regex, (m) =>
@@ -247,11 +260,10 @@ export function redactSecrets(text: string): string {
 function scanPlainText(text: string): FilterMatch[] {
 	const matches: FilterMatch[] = [];
 
-	for (const { name, pattern, severity, description } of SECRET_PATTERNS) {
-		// Create new regex instance, preserving original flags but ensuring global
-		// CRITICAL: Without 'g' flag, exec() never advances lastIndex → infinite loop
-		const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
-		const regex = new RegExp(pattern.source, flags);
+	for (let i = 0; i < SECRET_PATTERNS.length; i++) {
+		const { name, severity, description } = SECRET_PATTERNS[i];
+		const regex = COMPILED_GLOBAL_PATTERNS[i];
+		regex.lastIndex = 0;
 
 		for (let match = regex.exec(text); match !== null; match = regex.exec(text)) {
 			// Reduce false positives for base32-like TOTP seeds by checking entropy
@@ -385,6 +397,20 @@ function scanUrlEncoded(text: string): FilterMatch[] {
 }
 
 /**
+ * Deduplicate filter matches by pattern + redactedMatch.
+ * Preserves first occurrence of each unique match.
+ */
+function deduplicateMatches(matches: FilterMatch[]): FilterMatch[] {
+	const seen = new Set<string>();
+	return matches.filter((m) => {
+		const key = `${m.pattern}:${m.redactedMatch}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}
+
+/**
  * Main filter function: scan text for secrets using all detection methods.
  *
  * @param text - The text to scan (Telegram message, URL, request body, etc.)
@@ -405,14 +431,7 @@ export function filterOutput(text: string): FilterResult {
 	// Layer 4: URL encoded
 	allMatches.push(...scanUrlEncoded(text));
 
-	// Deduplicate by pattern + redactedMatch
-	const seen = new Set<string>();
-	const uniqueMatches = allMatches.filter((m) => {
-		const key = `${m.pattern}:${m.redactedMatch}`;
-		if (seen.has(key)) return false;
-		seen.add(key);
-		return true;
-	});
+	const uniqueMatches = deduplicateMatches(allMatches);
 
 	return {
 		blocked: uniqueMatches.length > 0,
@@ -437,17 +456,9 @@ export function filterInfrastructureSecrets(text: string): FilterResult {
 /**
  * Rolling buffer for detecting secrets split across message chunks.
  *
- * Usage:
- * ```
- * const buffer = new ChunkBuffer();
- * for (const chunk of responseChunks) {
- *   buffer.add(chunk);
- *   const result = buffer.scan();
- *   if (result.blocked) {
- *     // Abort - secret detected
- *   }
- * }
- * ```
+ * @deprecated Use {@link StreamingRedactor} from `./streaming-redactor.js` instead.
+ * StreamingRedactor handles overlap detection, config-aware filtering, and stats.
+ * ChunkBuffer is retained only for backward compatibility with the public export.
  */
 export class ChunkBuffer {
 	private buffer = "";
@@ -594,14 +605,7 @@ export function filterOutputWithConfig(text: string, config?: SecretFilterConfig
 		}
 	}
 
-	// Deduplicate by pattern + redactedMatch
-	const seen = new Set<string>();
-	const uniqueMatches = allMatches.filter((m) => {
-		const key = `${m.pattern}:${m.redactedMatch}`;
-		if (seen.has(key)) return false;
-		seen.add(key);
-		return true;
-	});
+	const uniqueMatches = deduplicateMatches(allMatches);
 
 	return {
 		blocked: uniqueMatches.length > 0,


### PR DESCRIPTION
## Summary
- Create 4 shared modules (`cli-prompt`, `cli-mask`, `cli-guards`, `cli-utils`) consolidating duplicate patterns across 25 command files
- Remove ~615 lines of duplicated readline prompts, masking functions, precondition guards, daemon keepalive patterns, and formatting utilities
- Net change: 434 insertions, 721 deletions across 29 files

## Shared modules
| Module | Exports | Consumers |
|--------|---------|-----------|
| `cli-prompt` | `promptLine`, `promptSecret`, `promptYesNo` | setup-openai, setup-git, setup-github-app, setup-google, oauth, vault, totp-setup, quickstart, reset-auth, reset-db |
| `cli-mask` | `mask` (configurable threshold/prefix/suffix) | setup-openai, setup-git, setup-google, oauth |
| `cli-guards` | `requireRelay`, `requireVault`, `requireSecretsStorage` | provider-query, fetch-attachment, send-attachment, send-local-file, setup-openai, setup-git, setup-github-app |
| `cli-utils` | `parseChatId`, `copyDirRecursive`, `formatDuration`, `formatUptime`, `confirmDangerousReset`, `runDaemon` | access-control, send, link, sessions, status, skills-promote, reset-auth, reset-db, totp-daemon, vault-daemon, agent, git-proxy-init |

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (import ordering auto-fixed)
- [x] `pnpm test` passes (709/709 tests, 69 files)
- [ ] Verify CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)