### PR TITLE
fix(telegram): overhaul message length limits and streaming

### DIFF
--- a/src/social/handler.ts
+++ b/src/social/handler.ts
@@ -945,9 +945,10 @@ async function handleAutonomousActivity(
 	}
 
 	logger.info({ serviceId }, "autonomous activity completed");
-	// First line as summary — notification sanitizer enforces the final length limit
-	const summaryLine = trimmed.split("\n")[0];
-	return { acted: true, summary: summaryLine };
+	// Keep first paragraph (up to first double-newline) as summary.
+	// Notification sanitizer enforces the final length limit near send time.
+	const firstParagraph = trimmed.split(/\n\n/)[0];
+	return { acted: true, summary: firstParagraph };
 }
 
 /**

--- a/src/telegram/constants.ts
+++ b/src/telegram/constants.ts
@@ -19,29 +19,42 @@ export const TELEGRAM_API_CHAR_LIMIT = 4096;
 /**
  * Maximum characters per message chunk after splitting.
  *
- * Set to 3200 to leave ~900 chars headroom for MarkdownV2 escape expansion
- * (e.g., "test.com" becomes "test\.com"). Used by sanitizeAndSplitResponse().
+ * Telegram's 4096 limit applies to text after entities parsing, not the raw
+ * MarkdownV2 payload. We split at 3800 (not 4096) to leave modest headroom
+ * for edge cases. The sendWithMarkdownFallback path handles rare post-conversion
+ * overflows by retrying as plain text.
  */
-export const MAX_MESSAGE_CHUNK_LENGTH = 3200;
+export const MAX_MESSAGE_CHUNK_LENGTH = 3800;
 
 /**
- * Maximum total response size (bytes) before truncation.
+ * Maximum total response size (characters) before truncation.
  *
  * Prevents DoS from extremely long LLM responses that could block the
- * event loop during sanitisation and splitting. 500 KB is well above any
- * reasonable Telegram conversation response.
+ * event loop during sanitisation and splitting. ~500K characters is well
+ * above any reasonable Telegram conversation response.
+ *
+ * Note: compared against string length (UTF-16 code units), not byte count.
  */
-export const MAX_TOTAL_RESPONSE_SIZE = 500 * 1024; // 500KB
+export const MAX_TOTAL_RESPONSE_SIZE = 500 * 1024;
 
 /**
  * Maximum length for heartbeat / admin notification text.
  *
- * These are metadata-only summaries (counts, service IDs, action labels),
- * not raw LLM output, so a moderate limit is safe. 800 chars gives enough
- * room for multi-service heartbeat summaries while staying well under the
- * Telegram API limit.
+ * These are sanitised summaries (counts, service IDs, action labels),
+ * not raw LLM output. 2000 chars leaves headroom for MarkdownV2 escaping
+ * while fitting in a single Telegram message (4096 after entities parsing).
  */
-export const MAX_NOTIFICATION_LENGTH = 800;
+export const MAX_NOTIFICATION_LENGTH = 2000;
+
+/**
+ * Telegram Bot API hard character limit for media captions.
+ *
+ * Media captions (photos, videos, documents, etc.) are limited to 1024
+ * characters after entities parsing — much smaller than the 4096 text limit.
+ *
+ * @see https://core.telegram.org/bots/api#sendphoto
+ */
+export const TELEGRAM_CAPTION_CHAR_LIMIT = 1024;
 
 /**
  * Maximum display length for in-flight streaming updates.

--- a/src/telegram/heartbeat.ts
+++ b/src/telegram/heartbeat.ts
@@ -106,7 +106,8 @@ export async function handlePrivateHeartbeat(
 			return { acted: false, summary: "" };
 		}
 
-		const summaryLine = trimmed.split("\n")[0].slice(0, 100);
+		// Keep first paragraph — notification sanitizer enforces the final length limit.
+		const summaryLine = trimmed.split(/\n\n/)[0];
 		logger.info({ summary: summaryLine }, "private heartbeat completed with activity");
 
 		// Send notification if configured

--- a/src/telegram/inbound.ts
+++ b/src/telegram/inbound.ts
@@ -348,6 +348,9 @@ export async function monitorTelegramInbox(
 			}
 		}
 
+		// Extract forum topic thread ID (present in supergroup forum messages)
+		const messageThreadId = message.message_thread_id;
+
 		const inboundMsg: TelegramInboundMessage = {
 			id: String(message.message_id),
 			chatId: chat.id,
@@ -363,6 +366,7 @@ export async function monitorTelegramInbox(
 			isEdited,
 			editedTimestamp: isEdited && message.edit_date ? message.edit_date * 1000 : undefined,
 			replyToMessageId: message.reply_to_message?.message_id,
+			messageThreadId,
 			mediaPath,
 			mediaType,
 			mediaFilePath,
@@ -373,7 +377,9 @@ export async function monitorTelegramInbox(
 					logger.debug({ chatId: chat.id }, "dry-run: would send typing action");
 					return;
 				}
-				await bot.api.sendChatAction(chat.id, "typing");
+				await bot.api.sendChatAction(chat.id, "typing", {
+					message_thread_id: messageThreadId,
+				});
 			},
 			reply: async (text: string, options?: { useMarkdown?: boolean }) => {
 				// SECURITY: Filter for secret exfiltration BEFORE any processing
@@ -397,7 +403,9 @@ export async function monitorTelegramInbox(
 						return;
 					}
 					// Send blocked notification instead of the secret-containing message
-					await bot.api.sendMessage(chat.id, SECRET_BLOCKED_MESSAGE);
+					await bot.api.sendMessage(chat.id, SECRET_BLOCKED_MESSAGE, {
+						message_thread_id: messageThreadId,
+					});
 					return;
 				}
 
@@ -422,12 +430,16 @@ export async function monitorTelegramInbox(
 					const chunk = chunks[i];
 					if (options?.useMarkdown) {
 						// Legacy Markdown for system messages that are pre-formatted
-						await bot.api.sendMessage(chat.id, chunk, { parse_mode: "Markdown" });
+						await bot.api.sendMessage(chat.id, chunk, {
+							parse_mode: "Markdown",
+							message_thread_id: messageThreadId,
+						});
 					} else {
 						// Convert Claude's markdown to Telegram MarkdownV2
 						await convertAndSendMessage(bot.api, chat.id, chunk, {
 							replyToMessageId: i === 0 ? message.message_id : undefined,
 							secretFilterConfig,
+							messageThreadId,
 						});
 					}
 				}
@@ -444,7 +456,9 @@ export async function monitorTelegramInbox(
 					);
 					return;
 				}
-				await sendMediaToChat(bot.api, chat.id, payload, undefined, secretFilterConfig);
+				await sendMediaToChat(bot.api, chat.id, payload, undefined, secretFilterConfig, {
+					messageThreadId,
+				});
 			},
 			startStreaming: async (streamingConfig) => {
 				if (dryRun) {
@@ -455,6 +469,7 @@ export async function monitorTelegramInbox(
 				const streamer = createStreamingResponse(bot.api, chat.id, {
 					...(streamingConfig ?? {}),
 					secretFilterConfig,
+					messageThreadId,
 				});
 				await streamer.start();
 				return streamer;

--- a/src/telegram/outbound.ts
+++ b/src/telegram/outbound.ts
@@ -16,6 +16,7 @@ import {
 } from "../security/output-filter.js";
 import { recordBotMessage } from "../storage/reactions.js";
 import { stringToChatId } from "../utils.js";
+import { TELEGRAM_CAPTION_CHAR_LIMIT } from "./constants.js";
 import { sanitizeAndSplitResponse } from "./sanitize.js";
 import type { TelegramMediaPayload } from "./types.js";
 
@@ -79,6 +80,7 @@ export type SendMessageOptions = {
 	mediaPath?: string;
 	parseMode?: "Markdown" | "HTML" | "MarkdownV2";
 	replyToMessageId?: number;
+	messageThreadId?: number;
 	secretFilterConfig?: SecretFilterConfig;
 };
 
@@ -103,11 +105,13 @@ async function sendWithMarkdownFallback(
 	rawText: string,
 	parseMode: "Markdown" | "HTML" | "MarkdownV2",
 	replyToMessageId?: number,
+	messageThreadId?: number,
 ): Promise<Message> {
 	try {
 		return await api.sendMessage(chatId, formattedText, {
 			parse_mode: parseMode,
 			reply_to_message_id: replyToMessageId,
+			message_thread_id: messageThreadId,
 		});
 	} catch (err) {
 		const errStr = String(err);
@@ -115,6 +119,7 @@ async function sendWithMarkdownFallback(
 			logger.warn({ chatId, error: errStr }, "MarkdownV2 parse failed, falling back to plain text");
 			return api.sendMessage(chatId, rawText, {
 				reply_to_message_id: replyToMessageId,
+				message_thread_id: messageThreadId,
 			});
 		}
 		throw err;
@@ -135,13 +140,17 @@ export async function sendMessageTelegram(
 ): Promise<SendResult> {
 	const chatId = typeof to === "number" ? to : stringToChatId(to);
 
+	const threadId = options.messageThreadId;
+
 	// SECURITY: Filter output for secrets
 	try {
 		filterBeforeSend(body, options.secretFilterConfig);
 	} catch (err) {
 		if (err instanceof SecretExfiltrationBlockedError) {
 			// Send blocked notification instead
-			const result = await bot.api.sendMessage(chatId, SECRET_BLOCKED_MESSAGE);
+			const result = await bot.api.sendMessage(chatId, SECRET_BLOCKED_MESSAGE, {
+				message_thread_id: threadId,
+			});
 			logger.warn(
 				{ chatId, messageId: result.message_id },
 				"sent blocked notification (secrets detected)",
@@ -153,7 +162,7 @@ export async function sendMessageTelegram(
 
 	// Send typing indicator
 	try {
-		await bot.api.sendChatAction(chatId, "typing");
+		await bot.api.sendChatAction(chatId, "typing", { message_thread_id: threadId });
 	} catch {
 		// Non-fatal
 	}
@@ -170,10 +179,16 @@ export async function sendMessageTelegram(
 		? rawChunks.map((chunk) => convertToTelegramMarkdown(chunk))
 		: rawChunks;
 
-	// Handle media
+	// Handle media — captions are limited to 1024 chars (vs 4096 for text)
 	const mediaSource = options.mediaPath;
 	if (mediaSource) {
-		const payload = inferMediaPayload(mediaSource, formattedChunks[0]); // Use first chunk as caption
+		// If caption exceeds Telegram's caption limit, send media without caption
+		// and follow up with the full text as separate messages.
+		const captionTooLong =
+			formattedChunks[0] && formattedChunks[0].length > TELEGRAM_CAPTION_CHAR_LIMIT;
+		const caption = captionTooLong ? undefined : formattedChunks[0];
+		const payload = inferMediaPayload(mediaSource, caption);
+
 		// Note: sendMediaToChat already calls recordBotMessage internally
 		const result = await sendMediaToChat(
 			bot.api,
@@ -181,15 +196,21 @@ export async function sendMessageTelegram(
 			payload,
 			effectiveParseMode,
 			options.secretFilterConfig,
+			{ messageThreadId: threadId },
 		);
-		// Send remaining chunks as follow-up messages
-		for (let i = 1; i < formattedChunks.length; i++) {
+
+		// Send text chunks as follow-up messages.
+		// If caption was too long, start from chunk 0; otherwise from chunk 1.
+		const startChunk = captionTooLong ? 0 : 1;
+		for (let i = startChunk; i < formattedChunks.length; i++) {
 			const followUp = await sendWithMarkdownFallback(
 				bot.api,
 				chatId,
 				formattedChunks[i],
 				rawChunks[i],
 				effectiveParseMode,
+				undefined,
+				threadId,
 			);
 			recordBotMessage(chatId, followUp.message_id);
 		}
@@ -207,6 +228,7 @@ export async function sendMessageTelegram(
 			rawChunks[i],
 			effectiveParseMode,
 			i === 0 ? options.replyToMessageId : undefined,
+			threadId,
 		);
 		// Track for reaction context
 		recordBotMessage(chatId, lastResult.message_id);
@@ -238,6 +260,7 @@ export async function convertAndSendMessage(
 	options?: {
 		parseMode?: "Markdown" | "HTML" | "MarkdownV2";
 		replyToMessageId?: number;
+		messageThreadId?: number;
 		secretFilterConfig?: SecretFilterConfig;
 	},
 ): Promise<Message> {
@@ -252,6 +275,7 @@ export async function convertAndSendMessage(
 			);
 			return api.sendMessage(chatId, SECRET_BLOCKED_MESSAGE, {
 				reply_to_message_id: options?.replyToMessageId,
+				message_thread_id: options?.messageThreadId,
 			});
 		}
 		throw err;
@@ -269,6 +293,7 @@ export async function convertAndSendMessage(
 		text,
 		parseMode,
 		options?.replyToMessageId,
+		options?.messageThreadId,
 	);
 	// Track for reaction context
 	recordBotMessage(chatId, result.message_id);
@@ -467,7 +492,10 @@ export async function sendMediaToChat(
 	payload: TelegramMediaPayload,
 	parseMode?: "Markdown" | "MarkdownV2" | "HTML",
 	secretFilterConfig?: SecretFilterConfig,
+	extra?: { messageThreadId?: number },
 ): Promise<Message> {
+	const threadId = extra?.messageThreadId;
+
 	// SECURITY: Scan file content for secrets before sending (async to avoid blocking)
 	const fileScan = await scanFileForSecrets(payload.source, secretFilterConfig);
 	if (!fileScan.safe) {
@@ -482,6 +510,7 @@ export async function sendMediaToChat(
 				(fileScan.reason ??
 					"The file appears to contain sensitive credentials (API keys, tokens, or private keys). " +
 						"This is a security measure to prevent accidental exposure of secrets."),
+			{ message_thread_id: threadId },
 		);
 	}
 
@@ -511,19 +540,32 @@ export async function sendMediaToChat(
 	let result: Message;
 	switch (payload.type) {
 		case "photo":
-			result = await api.sendPhoto(chatId, source, { caption: safeCaption, parse_mode: parseMode });
+			result = await api.sendPhoto(chatId, source, {
+				caption: safeCaption,
+				parse_mode: parseMode,
+				message_thread_id: threadId,
+			});
 			break;
 		case "document":
 			result = await api.sendDocument(chatId, source, {
 				caption: safeCaption,
 				parse_mode: parseMode,
+				message_thread_id: threadId,
 			});
 			break;
 		case "voice":
-			result = await api.sendVoice(chatId, source, { caption: safeCaption, parse_mode: parseMode });
+			result = await api.sendVoice(chatId, source, {
+				caption: safeCaption,
+				parse_mode: parseMode,
+				message_thread_id: threadId,
+			});
 			break;
 		case "video":
-			result = await api.sendVideo(chatId, source, { caption: safeCaption, parse_mode: parseMode });
+			result = await api.sendVideo(chatId, source, {
+				caption: safeCaption,
+				parse_mode: parseMode,
+				message_thread_id: threadId,
+			});
 			break;
 		case "audio":
 			result = await api.sendAudio(chatId, source, {
@@ -531,15 +573,19 @@ export async function sendMediaToChat(
 				parse_mode: parseMode,
 				title: payload.title,
 				performer: payload.performer,
+				message_thread_id: threadId,
 			});
 			break;
 		case "sticker":
-			result = await api.sendSticker(chatId, source);
+			result = await api.sendSticker(chatId, source, {
+				message_thread_id: threadId,
+			});
 			break;
 		case "animation":
 			result = await api.sendAnimation(chatId, source, {
 				caption: safeCaption,
 				parse_mode: parseMode,
+				message_thread_id: threadId,
 			});
 			break;
 		default:
@@ -624,7 +670,12 @@ export async function sendTelegramMessage(
 		}
 
 		if (options.mediaPath) {
-			const payload = inferMediaPayload(options.mediaPath, options.caption ?? options.text);
+			const captionText = options.caption ?? options.text;
+			const captionTooLong = captionText && captionText.length > TELEGRAM_CAPTION_CHAR_LIMIT;
+			const payload = inferMediaPayload(
+				options.mediaPath,
+				captionTooLong ? undefined : captionText,
+			);
 			const result = await sendMediaToChat(
 				bot.api,
 				options.chatId,
@@ -632,6 +683,16 @@ export async function sendTelegramMessage(
 				undefined,
 				options.secretFilterConfig,
 			);
+			// If caption was too long, send the text as follow-up messages
+			if (captionTooLong && captionText) {
+				const chunks = sanitizeAndSplitResponse(captionText);
+				const convertedChunks = chunks.map((chunk) => convertToTelegramMarkdown(chunk));
+				for (const chunk of convertedChunks) {
+					await bot.api.sendMessage(options.chatId, chunk, {
+						parse_mode: "MarkdownV2",
+					});
+				}
+			}
 			return { success: true, messageId: result.message_id };
 		}
 

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -84,9 +84,15 @@ export interface StreamingConfig {
 	 * Default: true
 	 */
 	showTypingIndicator?: boolean;
+
+	/**
+	 * Forum topic thread ID. When set, all messages and typing actions
+	 * are sent to this specific thread within a supergroup forum.
+	 */
+	messageThreadId?: number;
 }
 
-const DEFAULT_CONFIG: Required<Omit<StreamingConfig, "secretFilterConfig">> = {
+const DEFAULT_CONFIG: Required<Omit<StreamingConfig, "secretFilterConfig" | "messageThreadId">> = {
 	minUpdateIntervalMs: 1500,
 	maxUpdateIntervalMs: 5000,
 	minCharsForUpdate: 50,
@@ -129,9 +135,12 @@ export function createCompactKeyboard(): InlineKeyboard {
 export class StreamingResponse {
 	private readonly api: Api;
 	private readonly chatId: number;
-	private readonly config: Required<Omit<StreamingConfig, "secretFilterConfig">> & {
+	private readonly config: Required<
+		Omit<StreamingConfig, "secretFilterConfig" | "messageThreadId">
+	> & {
 		secretFilterConfig?: SecretFilterConfig;
 	};
+	private readonly messageThreadId?: number;
 
 	private messageId: number | null = null;
 	private content = "";
@@ -145,10 +154,17 @@ export class StreamingResponse {
 	private consecutiveErrors = 0;
 	private useMarkdown = true; // Fall back to plain text after parse errors
 
+	/** Offset into this.content where the current streaming message starts. */
+	private rolledContentOffset = 0;
+	/** Message IDs of finalized rollover messages (for tracking). */
+	private readonly finalizedMessageIds: number[] = [];
+
 	constructor(api: Api, chatId: number, config: StreamingConfig = {}) {
 		this.api = api;
 		this.chatId = chatId;
-		this.config = { ...DEFAULT_CONFIG, ...config };
+		const { messageThreadId, ...rest } = config;
+		this.messageThreadId = messageThreadId;
+		this.config = { ...DEFAULT_CONFIG, ...rest };
 		this.streamLoop = createDraftStreamLoop({
 			throttleMs: this.config.minUpdateIntervalMs,
 			isStopped: () => this.isFinished,
@@ -177,7 +193,9 @@ export class StreamingResponse {
 	 * Also starts a typing indicator interval if configured.
 	 */
 	async start(): Promise<Message> {
-		const message = await this.api.sendMessage(this.chatId, this.config.initialMessage);
+		const message = await this.api.sendMessage(this.chatId, this.config.initialMessage, {
+			message_thread_id: this.messageThreadId,
+		});
 		this.messageId = message.message_id;
 		this.lastUpdateTime = Date.now();
 
@@ -200,9 +218,13 @@ export class StreamingResponse {
 	private startTypingIndicator(): void {
 		this.typingInterval = setInterval(() => {
 			if (!this.isFinished) {
-				this.api.sendChatAction(this.chatId, "typing").catch(() => {
-					// Ignore typing indicator errors
-				});
+				this.api
+					.sendChatAction(this.chatId, "typing", {
+						message_thread_id: this.messageThreadId,
+					})
+					.catch(() => {
+						// Ignore typing indicator errors
+					});
 			}
 		}, 4000);
 	}
@@ -283,6 +305,9 @@ export class StreamingResponse {
 	/**
 	 * Perform the actual message edit.
 	 * Handles rate limits, parse errors, and "message not modified" gracefully.
+	 *
+	 * When content exceeds MAX_STREAMING_UPDATE_LENGTH, rolls over to a new
+	 * message instead of truncating the beginning.
 	 */
 	private async doUpdate(): Promise<void> {
 		if (!this.messageId || this.content === this.lastSentContent) {
@@ -299,15 +324,17 @@ export class StreamingResponse {
 			);
 		}
 
-		// Truncate for Telegram's 4096 char limit
-		// Keep the end of the content (most recent) if truncating
-		let displayContent = this.content;
-		if (displayContent.length > MAX_STREAMING_UPDATE_LENGTH) {
-			displayContent = `...\n${displayContent.slice(-(MAX_STREAMING_UPDATE_LENGTH - 50))}`;
+		// Content for the current streaming message (from rollover offset)
+		const currentContent = this.content.slice(this.rolledContentOffset);
+
+		// If current message content exceeds the limit, roll over to a new message
+		if (currentContent.length > MAX_STREAMING_UPDATE_LENGTH) {
+			await this.rollOverToNewMessage(currentContent);
+			return;
 		}
 
 		// Add streaming indicator
-		const streamingContent = `${displayContent}\n\n⏳ _generating..._`;
+		const streamingContent = `${currentContent}\n\n⏳ _generating..._`;
 
 		try {
 			// Convert to MarkdownV2 if we haven't fallen back to plain text
@@ -318,7 +345,7 @@ export class StreamingResponse {
 				textToSend = convertToTelegramMarkdown(streamingContent);
 				parseMode = "MarkdownV2";
 			} else {
-				textToSend = `${displayContent}\n\n⏳ generating...`;
+				textToSend = `${currentContent}\n\n⏳ generating...`;
 				parseMode = undefined;
 			}
 
@@ -340,7 +367,132 @@ export class StreamingResponse {
 				"streaming update sent",
 			);
 		} catch (err) {
-			await this.handleUpdateError(err, displayContent);
+			await this.handleUpdateError(err, currentContent);
+		}
+	}
+
+	/**
+	 * Finalize the current streaming message and start a new one for continuation.
+	 * This preserves the beginning of the response instead of truncating it.
+	 *
+	 * State transitions are atomic: offset and finalized list are only committed
+	 * after the continuation message is successfully created. On failure, the
+	 * current message ID remains valid for future edits (degraded tail-truncation).
+	 */
+	private async rollOverToNewMessage(currentContent: string): Promise<void> {
+		if (!this.messageId) return;
+
+		const finalizeContent = currentContent.slice(0, MAX_STREAMING_UPDATE_LENGTH);
+
+		// SECURITY: Filter the chunk BEFORE finalizing — once sent, it cannot be recalled.
+		const filterResult = filterWithOptionalConfig(finalizeContent, this.config.secretFilterConfig);
+		if (filterResult.blocked) {
+			logger.warn(
+				{ chatId: this.chatId, patterns: filterResult.matches.map((m) => m.pattern) },
+				"secrets detected in rollover chunk — aborting rollover",
+			);
+			// Replace the current message with a warning and stop streaming
+			try {
+				await this.api.editMessageText(
+					this.chatId,
+					this.messageId,
+					"⚠️ Response blocked by security filter.\n\n" +
+						"The response contained what appears to be sensitive credentials.",
+				);
+			} catch {
+				// Best effort
+			}
+			this.isFinished = true;
+			return;
+		}
+
+		// Finalize the current message (no "generating..." indicator).
+		// Successful finalization is a prerequisite for rollover — if both edits
+		// fail, abort and fall back to normal update-error handling.
+		let finalized = false;
+		let finalizeError: unknown;
+		try {
+			const finalizeText = this.useMarkdown
+				? convertToTelegramMarkdown(finalizeContent)
+				: finalizeContent;
+
+			await this.api.editMessageText(this.chatId, this.messageId, finalizeText, {
+				parse_mode: this.useMarkdown ? "MarkdownV2" : undefined,
+			});
+			finalized = true;
+		} catch {
+			// If MarkdownV2 fails, try plain text
+			try {
+				await this.api.editMessageText(this.chatId, this.messageId, finalizeContent);
+				finalized = true;
+			} catch (fallbackErr) {
+				finalizeError = fallbackErr;
+				logger.error({ error: String(fallbackErr) }, "rollover finalization failed");
+			}
+		}
+
+		if (!finalized) {
+			// Cannot finalize current message — abort rollover, degrade to tail-truncation.
+			// Pass the real error so handleUpdateError can detect 429/parse errors.
+			const cappedContent =
+				currentContent.length > MAX_STREAMING_UPDATE_LENGTH
+					? `...\n${currentContent.slice(-(MAX_STREAMING_UPDATE_LENGTH - 50))}`
+					: currentContent;
+			await this.handleUpdateError(finalizeError, cappedContent);
+			return;
+		}
+
+		// Save pre-rollover state so we can revert on continuation failure
+		const prevMessageId = this.messageId;
+		const prevOffset = this.rolledContentOffset;
+
+		// Tentatively advance state
+		this.finalizedMessageIds.push(this.messageId);
+		this.rolledContentOffset += finalizeContent.length;
+
+		// Send a new message for the continuation
+		const continuationContent = this.content.slice(this.rolledContentOffset);
+		const streamingContent = `${continuationContent}\n\n⏳ _generating..._`;
+		try {
+			const textToSend = this.useMarkdown
+				? convertToTelegramMarkdown(streamingContent)
+				: `${continuationContent}\n\n⏳ generating...`;
+
+			const newMessage = await this.api.sendMessage(this.chatId, textToSend, {
+				parse_mode: this.useMarkdown ? "MarkdownV2" : undefined,
+				message_thread_id: this.messageThreadId,
+			});
+
+			this.messageId = newMessage.message_id;
+			recordBotMessage(this.chatId, newMessage.message_id);
+
+			this.lastSentContent = this.content;
+			this.lastUpdateTime = Date.now();
+			this.consecutiveErrors = 0;
+			this.clearForceUpdateTimer();
+
+			logger.info(
+				{
+					chatId: this.chatId,
+					messageId: this.messageId,
+					rolledMessages: this.finalizedMessageIds.length,
+					contentLength: this.content.length,
+				},
+				"streaming rolled over to new message",
+			);
+		} catch (err) {
+			// Revert state — keep editing the current (finalized) message as fallback.
+			// Route through handleUpdateError for plain-text fallback and 429 backoff.
+			// Cap content to streaming limit so the plain-text retry fits in one message.
+			this.finalizedMessageIds.pop();
+			this.rolledContentOffset = prevOffset;
+			this.messageId = prevMessageId;
+			const fallbackContent = this.content.slice(this.rolledContentOffset);
+			const cappedContent =
+				fallbackContent.length > MAX_STREAMING_UPDATE_LENGTH
+					? `...\n${fallbackContent.slice(-(MAX_STREAMING_UPDATE_LENGTH - 50))}`
+					: fallbackContent;
+			await this.handleUpdateError(err, cappedContent);
 		}
 	}
 
@@ -459,26 +611,44 @@ export class StreamingResponse {
 			return null;
 		}
 
-		// Filter final content for secrets
+		// Filter final content for secrets — check the FULL content across all messages.
+		// Note: rollover chunks are pre-filtered in rollOverToNewMessage(), so this
+		// catches secrets that only appear when chunks are concatenated.
 		const filterResult = filterWithOptionalConfig(this.content, this.config.secretFilterConfig);
 
-		let finalContent = this.content;
 		if (filterResult.blocked) {
-			finalContent =
+			const blockedMsg =
 				"⚠️ Response blocked by security filter.\n\n" +
 				"The response contained what appears to be sensitive credentials.";
 			logger.warn(
 				{ chatId: this.chatId, patterns: filterResult.matches.map((m) => m.pattern) },
 				"secrets detected in final streaming content",
 			);
+			// Delete previously finalized rollover messages
+			for (const msgId of this.finalizedMessageIds) {
+				try {
+					await this.api.deleteMessage(this.chatId, msgId);
+				} catch {
+					// Best effort — message may already be gone
+				}
+			}
+			// Replace the current message with a warning
+			try {
+				await this.api.editMessageText(this.chatId, this.messageId, blockedMsg);
+			} catch {
+				// Best effort
+			}
+			return null;
 		}
 
-		// Handle empty content
-		if (!finalContent.trim()) {
-			finalContent = "_(No response generated)_";
-		}
+		// Only finalize the remaining content from the current message (after rollover offset).
+		// Previous rollover messages are already finalized.
+		const remainingContent = this.content.slice(this.rolledContentOffset);
 
-		// Split for Telegram's message limit
+		// Handle empty remaining content
+		const finalContent = remainingContent.trim() ? remainingContent : "_(No response generated)_";
+
+		// Split remaining content for Telegram's message limit
 		const chunks = sanitizeAndSplitResponse(finalContent);
 
 		// Determine keyboard to use
@@ -488,7 +658,7 @@ export class StreamingResponse {
 				: undefined;
 
 		try {
-			// First chunk replaces the streaming message
+			// First chunk replaces the current streaming message
 			const firstChunk = chunks[0];
 			let textToSend: string;
 			let parseMode: "MarkdownV2" | undefined;
@@ -517,6 +687,7 @@ export class StreamingResponse {
 				lastResult = await this.api.sendMessage(this.chatId, chunkText, {
 					parse_mode: this.useMarkdown ? "MarkdownV2" : undefined,
 					reply_markup: isLast ? keyboard : undefined,
+					message_thread_id: this.messageThreadId,
 				});
 				// Track for reaction context
 				recordBotMessage(this.chatId, lastResult.message_id);
@@ -526,8 +697,9 @@ export class StreamingResponse {
 				{
 					chatId: this.chatId,
 					messageId: this.messageId,
-					contentLength: finalContent.length,
+					contentLength: this.content.length,
 					chunks: chunks.length,
+					rolledMessages: this.finalizedMessageIds.length,
 					usedMarkdown: this.useMarkdown,
 				},
 				"streaming response finished",
@@ -568,6 +740,7 @@ export class StreamingResponse {
 						const isLast = i === chunks.length - 1;
 						lastResult = await this.api.sendMessage(this.chatId, chunks[i], {
 							reply_markup: isLast ? keyboard : undefined,
+							message_thread_id: this.messageThreadId,
 						});
 						// Track for reaction context
 						recordBotMessage(this.chatId, lastResult.message_id);

--- a/src/telegram/types.ts
+++ b/src/telegram/types.ts
@@ -42,6 +42,7 @@ export type TelegramInboundMessage = {
 	isEdited?: boolean;
 	editedTimestamp?: number;
 	replyToMessageId?: number;
+	messageThreadId?: number; // Forum topic thread ID
 
 	// Media info (if present)
 	mediaPath?: string;


### PR DESCRIPTION
## Summary
- Raise chunk size 3200→3800, notification limit 800→2000, add 1024 caption limit
- Replace first-line-only heartbeat summary with first-paragraph extraction
- Plumb `message_thread_id` through all send paths for forum topic support
- Replace streaming tail-truncation with message rollover (atomic state, per-chunk secret filter, proper error recovery)

## Test plan
- [ ] Verify long heartbeat notifications show full first paragraph
- [ ] Verify media with long captions sends media + follow-up text
- [ ] Verify streaming messages roll over instead of truncating
- [ ] Verify forum topic replies stay in the correct thread
- [ ] `pnpm typecheck` and `pnpm lint` pass clean

Reviewed-by: Codex (AMQ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)