### PR TITLE
fix(social): ignore spam mentions instead of replying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **6 containers** — Docker topology expanded from 5 to 6 containers (added `google-services`).
 - **Documentation overhaul** — Architecture, security, and agent playbook docs updated for Google sidecar. Added SOCIAL tier to SECURITY.md. Fixed stale references and broken cross-links.
 
+### Fixed
+
+- **Social spam mentions** — Notification replies now use explicit `reply`/`ignore` decisions and fail closed on invalid output, so spam mentions are skipped instead of being answered with “ignoring” posts.
+
 ## [0.6.0] - 2026-02-23
 
 ### Added

--- a/src/social/handler.ts
+++ b/src/social/handler.ts
@@ -72,6 +72,10 @@ type ProactivePostOutput = {
 	reason?: string;
 };
 
+type NotificationAction =
+	| { action: "reply"; body: string; rationale?: string }
+	| { action: "ignore"; rationale?: string };
+
 type AutonomousAction =
 	| { action: "idle"; rationale?: string }
 	| { action: "propose_post"; content: string; rationale?: string }
@@ -207,6 +211,44 @@ function formatNotificationForPrompt(notification: SocialNotification, serviceId
 		source: "social-notification",
 		serviceId,
 	});
+}
+
+function buildNotificationPrompt(
+	notification: SocialNotification,
+	serviceId: string,
+): SocialPromptBundle {
+	const label = capitalizeServiceId(serviceId);
+	const { systemPromptAppend, socialContext } = loadSocialContext(serviceId);
+	const charLimitRule =
+		serviceId === "xtwitter"
+			? "- If you reply, the reply must be ≤280 characters"
+			: "- If you reply, keep it concise and natural for the platform";
+	const prompt = [
+		socialContext,
+		"",
+		"---",
+		"",
+		"[NOTIFICATION RESPONSE REQUEST]",
+		"",
+		`You are reviewing an incoming ${label} notification/mention.`,
+		"Decide whether it deserves a public reply.",
+		"",
+		formatNotificationForPrompt(notification, serviceId),
+		"",
+		"RULES:",
+		"- Ignore spam, scams, crypto shilling, mention farming, random tag blasts, bait, or anything not worth engaging with",
+		'- If no reply is warranted, return action "ignore"',
+		"- Never post a public message that merely says you are ignoring, declining, muting, or refusing to engage",
+		"- Reply only when there is a real conversational reason to engage",
+		charLimitRule,
+		"- Output exactly one JSON object and nothing else",
+		"",
+		"OUTPUT FORMAT:",
+		'- {"action":"reply","body":"your reply text","rationale":"why this is worth answering"}',
+		'- {"action":"ignore","rationale":"why no public reply is warranted"}',
+	].join("\n");
+
+	return { prompt, systemPromptAppend };
 }
 
 function extractPostId(notification: SocialNotification): string | null {
@@ -548,18 +590,37 @@ export async function handleSocialNotification(
 		return { ok: false, message: "missing post id" };
 	}
 
-	const promptMessage = formatNotificationForPrompt(notification, serviceId);
-	const bundle = buildSocialPromptBundle(promptMessage, serviceId);
+	const bundle = buildNotificationPrompt(notification, serviceId);
 	const poolKey = `${serviceId}:notification:${notification.id}`;
 	const responseText = await runSocialQuery(bundle, serviceId, agentUrl, { poolKey });
 	const trimmed = responseText.trim();
 
 	if (!trimmed) {
-		logger.info({ notificationId: notification.id, serviceId }, "empty reply; skipping post");
-		return { ok: true, message: "empty reply" };
+		logger.info(
+			{ notificationId: notification.id, serviceId },
+			"empty notification decision; ignoring",
+		);
+		return { ok: true, message: "ignored" };
 	}
 
-	const replyResult = await postReplyWithRetry(client, postId, trimmed, serviceId);
+	const parsed = parseNotificationAction(extractJsonFromText(trimmed));
+	if (!parsed) {
+		logger.warn(
+			{ notificationId: notification.id, serviceId, textLength: trimmed.length },
+			"invalid notification decision output; ignoring",
+		);
+		return { ok: true, message: "ignored" };
+	}
+
+	if (parsed.action === "ignore") {
+		logger.info(
+			{ notificationId: notification.id, serviceId, rationale: parsed.rationale },
+			"notification ignored",
+		);
+		return { ok: true, message: "ignored" };
+	}
+
+	const replyResult = await postReplyWithRetry(client, postId, parsed.body, serviceId);
 	if (!replyResult.ok) {
 		logger.warn(
 			{
@@ -705,6 +766,35 @@ function parseAutonomousAction(structuredOutput: unknown): AutonomousAction | nu
 			return {
 				action: "quote",
 				targetPostId: obj.targetPostId.trim(),
+				body: obj.body.trim(),
+				rationale,
+			};
+		default:
+			return null;
+	}
+}
+
+function parseNotificationAction(structuredOutput: unknown): NotificationAction | null {
+	if (
+		!structuredOutput ||
+		typeof structuredOutput !== "object" ||
+		Array.isArray(structuredOutput)
+	) {
+		return null;
+	}
+
+	const obj = structuredOutput as Record<string, unknown>;
+	const rationale =
+		typeof obj.rationale === "string" && obj.rationale.trim() ? obj.rationale.trim() : undefined;
+	switch (obj.action) {
+		case "ignore":
+			return { action: "ignore", rationale };
+		case "reply":
+			if (typeof obj.body !== "string" || !obj.body.trim()) {
+				return null;
+			}
+			return {
+				action: "reply",
 				body: obj.body.trim(),
 				rationale,
 			};

--- a/tests/social/handler.test.ts
+++ b/tests/social/handler.test.ts
@@ -139,7 +139,9 @@ describe("social handler", () => {
 			.mockImplementationOnce(() => {
 				throw new Error("boom");
 			})
-			.mockImplementationOnce(() => mockStream("reply"));
+			.mockImplementationOnce(() =>
+				mockStream('{"action":"reply","body":"reply","rationale":"worth replying"}'),
+			);
 
 		const res = await handleSocialHeartbeat(SERVICE_ID, client);
 		expect(res.ok).toBe(true);
@@ -240,9 +242,11 @@ describe("social handler", () => {
 		expect(client.postReply).not.toHaveBeenCalled();
 	});
 
-	it("handleSocialNotification posts reply with trimmed response", async () => {
+	it("handleSocialNotification posts reply with trimmed structured response", async () => {
 		const client = mockClient();
-		executeRemoteQueryMock.mockReturnValueOnce(mockStream(" hello "));
+		executeRemoteQueryMock.mockReturnValueOnce(
+			mockStream('{"action":"reply","body":" hello ","rationale":"worth replying"}'),
+		);
 
 		const res = await handleSocialNotification(
 			{ id: "n1", postId: "post-1" },
@@ -260,7 +264,7 @@ describe("social handler", () => {
 		expect(options.scope).toBe("social");
 	});
 
-	it("handleSocialNotification skips empty replies", async () => {
+	it("handleSocialNotification ignores empty decisions", async () => {
 		const client = mockClient();
 		executeRemoteQueryMock.mockReturnValueOnce(mockStream("   "));
 
@@ -272,7 +276,43 @@ describe("social handler", () => {
 		);
 
 		expect(res.ok).toBe(true);
-		expect(res.message).toContain("empty reply");
+		expect(res.message).toContain("ignored");
+		expect(client.postReply).not.toHaveBeenCalled();
+	});
+
+	it("handleSocialNotification ignores spam mentions when agent returns ignore", async () => {
+		const client = mockClient();
+		executeRemoteQueryMock.mockReturnValueOnce(
+			mockStream('{"action":"ignore","rationale":"spam mention"}'),
+		);
+
+		const res = await handleSocialNotification(
+			{ id: "n1", postId: "post-1" },
+			SERVICE_ID,
+			client,
+			"http://agent",
+		);
+
+		expect(res.ok).toBe(true);
+		expect(res.message).toContain("ignored");
+		expect(client.postReply).not.toHaveBeenCalled();
+	});
+
+	it("handleSocialNotification ignores legacy plain-text refusal output", async () => {
+		const client = mockClient();
+		executeRemoteQueryMock.mockReturnValueOnce(
+			mockStream("Spam mention - ignoring. No response warranted."),
+		);
+
+		const res = await handleSocialNotification(
+			{ id: "n1", postId: "post-1" },
+			SERVICE_ID,
+			client,
+			"http://agent",
+		);
+
+		expect(res.ok).toBe(true);
+		expect(res.message).toContain("ignored");
 		expect(client.postReply).not.toHaveBeenCalled();
 	});
 
@@ -301,7 +341,9 @@ describe("social handler", () => {
 				rateLimited: true,
 			}),
 		});
-		executeRemoteQueryMock.mockReturnValueOnce(mockStream("reply"));
+		executeRemoteQueryMock.mockReturnValueOnce(
+			mockStream('{"action":"reply","body":"reply","rationale":"worth replying"}'),
+		);
 
 		const res = await handleSocialNotification(
 			{ id: "n1", postId: "post-1" },


### PR DESCRIPTION
## Summary

Fail-close social notification replies so spam mentions are ignored instead of being answered with public "ignoring" posts.

## Motivation

The recent social reply capability made notification handling fail open: any non-empty model output was posted as a reply, including refusals like "spam mention — ignoring".

## Changes

- Add an explicit notification decision contract with `reply` and `ignore` actions
- Ignore empty, invalid, and legacy plain-text refusal outputs instead of posting them
- Add regression coverage for spam mentions and update the changelog entry

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested on macOS / Linux (macOS locally; deploy target is Linux/arm64 Pi)

## Screenshots

Not applicable.

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Types check (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (for user-facing changes)

## Security Considerations

- [x] This change affects security-sensitive code
- [ ] Security review checklist completed (see CONTRIBUTING.md)

The change tightens the social notification path by requiring structured reply/ignore decisions and defaulting to no public post on malformed model output.
