### PR TITLE
Add Telegram command registry and natural-language system help

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -53,6 +53,8 @@ cb853d9b343174696ced01e3cab2198c15e26fe5:src/telegram/auto-reply.ts:credentials-
 
 # Auto-reply - session key template literal `tg:${msg.chatId}` (not a credential)
 3c63ce8f105e070543ffc7d050f9618ca2b08165:src/telegram/auto-reply.ts:credentials-javascript:1362
+ae5fb38e614163f7258498e48ae04604c03bbf5f:src/telegram/auto-reply.ts:credentials-javascript:379
+ae5fb38e614163f7258498e48ae04604c03bbf5f:src/telegram/auto-reply.ts:credentials-javascript:654
 
 # Doctor security audit - fake GitHub PAT used as redaction self-test example
 3c63ce8f105e070543ffc7d050f9618ca2b08165:src/commands/doctor.ts:github-pat:305

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ docker compose exec telclaude pnpm start relay --profile strict
 - In the same chat, run `/setup-2fa` to bind TOTP for periodic identity verification (daemon must be running). `/skip-totp` is allowed but not recommended.
 - Optional hardening: set `TELCLAUDE_ADMIN_SECRET` and start with `/claim <secret>` to prevent scanner bots claiming admin first (see `SECURITY.md`).
 
+## Telegram command surface
+- Telegram syncs a native command menu on connect for the safe discovery and read-only commands: `/help`, `/commands`, `/system`, `/status`, `/sessions`, `/cron`, `/whoami`, `/new`.
+- `/help <command or topic>` answers natural-language operator questions such as `/help approvals`, `/help 2fa`, or `/help reset session`.
+- `/system <question>` routes natural-language system questions to the safe read-only views. Example: `/system what's the current status?` or `/system when is the next heartbeat?`.
+- Mutating commands remain explicit and narrow. Telclaude still does not expose a broad control UI or generic remote execution surface through Telegram.
+
 ## Configuration
 - Default path: `~/.telclaude/telclaude.json` (override with `TELCLAUDE_CONFIG` or `--config`).
 - Profiles:

--- a/src/commands/cron.ts
+++ b/src/commands/cron.ts
@@ -13,7 +13,14 @@ import {
 	removeCronJob,
 	setCronJobEnabled,
 } from "../cron/store.js";
-import type { CronAction, CronAddInput, CronJob, CronSchedule } from "../cron/types.js";
+import type {
+	CronAction,
+	CronAddInput,
+	CronCoverage,
+	CronJob,
+	CronSchedule,
+	CronStatusSummary,
+} from "../cron/types.js";
 import { getChildLogger } from "../logging.js";
 
 const logger = getChildLogger({ module: "cmd-cron" });
@@ -93,6 +100,56 @@ function formatAction(action: CronAction): string {
 	return "social heartbeat (all enabled)";
 }
 
+export type CronOverview = {
+	enabled: boolean;
+	pollIntervalSeconds: number;
+	timeoutSeconds: number;
+	summary: CronStatusSummary;
+	coverage: CronCoverage;
+	jobs: CronJob[];
+};
+
+export function collectCronOverview(options?: {
+	includeDisabled?: boolean;
+	limit?: number;
+}): CronOverview {
+	const cfg = loadConfig();
+	const jobs = listCronJobs({ includeDisabled: options?.includeDisabled });
+	return {
+		enabled: cfg.cron.enabled,
+		pollIntervalSeconds: cfg.cron.pollIntervalSeconds,
+		timeoutSeconds: cfg.cron.timeoutSeconds,
+		summary: getCronStatusSummary(),
+		coverage: getCronCoverage(),
+		jobs: typeof options?.limit === "number" ? jobs.slice(0, options.limit) : jobs,
+	};
+}
+
+export function formatCronOverview(overview: CronOverview): string {
+	const lines = [
+		"Cron scheduler",
+		`Enabled in config: ${overview.enabled ? "yes" : "no"}`,
+		`Poll interval: ${overview.pollIntervalSeconds}s`,
+		`Job timeout: ${overview.timeoutSeconds}s`,
+		`Jobs: ${overview.summary.enabledJobs}/${overview.summary.totalJobs} enabled`,
+		`Running now: ${overview.summary.runningJobs}`,
+		`Next run: ${formatTimestamp(overview.summary.nextRunAtMs)}`,
+		`Coverage: social(all=${overview.coverage.allSocial ? "yes" : "no"}, specific=${overview.coverage.socialServiceIds.length}), private=${overview.coverage.hasPrivateHeartbeat ? "yes" : "no"}`,
+	];
+
+	if (overview.jobs.length > 0) {
+		lines.push("", "Recent jobs:");
+		for (const job of overview.jobs) {
+			const status = job.lastStatus ? `, last=${job.lastStatus}` : "";
+			lines.push(
+				`- ${job.id}: ${job.name} (${job.enabled ? "enabled" : "disabled"}, next=${formatTimestamp(job.nextRunAtMs)}, action=${formatAction(job.action)}${status})`,
+			);
+		}
+	}
+
+	return lines.join("\n");
+}
+
 function printJobs(jobs: CronJob[]): void {
 	if (jobs.length === 0) {
 		console.log("No cron jobs.");
@@ -122,30 +179,12 @@ export function registerCronCommand(program: Command): void {
 		.description("Show scheduler status and cron coverage")
 		.option("--json", "Output as JSON")
 		.action((opts: { json?: boolean }) => {
-			const cfg = loadConfig();
-			const summary = getCronStatusSummary();
-			const coverage = getCronCoverage();
-			const payload = {
-				enabled: cfg.cron.enabled,
-				pollIntervalSeconds: cfg.cron.pollIntervalSeconds,
-				timeoutSeconds: cfg.cron.timeoutSeconds,
-				summary,
-				coverage,
-			};
+			const payload = collectCronOverview();
 			if (opts.json) {
 				console.log(JSON.stringify(payload, null, 2));
 				return;
 			}
-			console.log("Cron scheduler:");
-			console.log(`  Enabled in config: ${cfg.cron.enabled ? "yes" : "no"}`);
-			console.log(`  Poll interval: ${cfg.cron.pollIntervalSeconds}s`);
-			console.log(`  Job timeout: ${cfg.cron.timeoutSeconds}s`);
-			console.log(`  Jobs: ${summary.totalJobs} total, ${summary.enabledJobs} enabled`);
-			console.log(`  Running now: ${summary.runningJobs}`);
-			console.log(`  Next run: ${formatTimestamp(summary.nextRunAtMs)}`);
-			console.log(
-				`  Coverage: social(all=${coverage.allSocial ? "yes" : "no"}, specific=${coverage.socialServiceIds.length}), private=${coverage.hasPrivateHeartbeat ? "yes" : "no"}`,
-			);
+			console.log(formatCronOverview(payload));
 		});
 
 	cron

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -82,6 +82,35 @@ export function collectSessionRows(options?: {
 	return rows.slice(0, limit);
 }
 
+export function formatSessionRows(
+	rows: SessionListRow[],
+	options?: {
+		activeMinutes?: number;
+		limit?: number;
+	},
+): string {
+	const lines = [`Sessions: ${rows.length}`];
+	if (options?.activeMinutes) {
+		lines.push(`Filtered to the last ${options.activeMinutes} minute(s).`);
+	}
+	if (options?.limit) {
+		lines.push(`Showing up to ${options.limit} most recent session(s).`);
+	}
+	if (rows.length === 0) {
+		lines.push("No sessions found.");
+		return lines.join("\n");
+	}
+
+	lines.push("");
+	for (const row of rows) {
+		const flags = [row.systemSent ? "system prompt sent" : null].filter(Boolean).join(", ");
+		const suffix = flags ? ` (${flags})` : "";
+		lines.push(`- ${row.kind} ${row.key} updated ${formatDuration(row.ageMs)} ago${suffix}`);
+	}
+
+	return lines.join("\n");
+}
+
 export function registerSessionsCommand(program: Command): void {
 	program
 		.command("sessions")

--- a/src/telegram/auto-reply.ts
+++ b/src/telegram/auto-reply.ts
@@ -2,6 +2,8 @@ import crypto from "node:crypto";
 import { run } from "@grammyjs/runner";
 import type { Bot } from "grammy";
 import { executeRemoteQuery } from "../agent/client.js";
+import { collectCronOverview, formatCronOverview } from "../commands/cron.js";
+import { collectSessionRows, formatSessionRows } from "../commands/sessions.js";
 import { listDraftSkills, promoteSkill } from "../commands/skills-promote.js";
 import { collectTelclaudeStatus, formatTelclaudeStatus } from "../commands/status.js";
 import { loadConfig, type PermissionTier, type TelclaudeConfig } from "../config/config.js";
@@ -59,7 +61,15 @@ import { clearOpenAICache, initializeOpenAIKey } from "../services/openai-client
 import { parseSocialQuoteProposalMetadata } from "../social/proposal-metadata.js";
 import { cleanupExpired, getDb } from "../storage/db.js";
 import { formatReactionContext, getRecentReactions } from "../storage/reactions.js";
-import { createTelegramBot } from "./client.js";
+import { createTelegramBot, syncTelegramCommandMenu } from "./client.js";
+import {
+	formatTelegramCommandCatalog,
+	formatTelegramHelp,
+	isTelegramAuthExemptCommand,
+	matchTelegramControlCommand,
+	resolveTelegramSystemIntent,
+	type TelegramCommandMatch,
+} from "./control-commands.js";
 import { monitorTelegramInbox, normalizeInboundBody } from "./inbound.js";
 import { extractGeneratedMediaPaths, isMediaOnlyResponse } from "./media-detection.js";
 import { buildMultimodalPrompt, processMultimodalContext } from "./multimodal.js";
@@ -292,6 +302,517 @@ function resolveCommandBody(msg: TelegramInboundMessage): string {
 
 function resolveProcessingBody(msg: TelegramInboundMessage): string {
 	return msg.normalizedBody ?? msg.body;
+}
+
+type TelegramControlCommandContext = {
+	msg: TelegramInboundMessage;
+	cfg: TelclaudeConfig;
+	auditLogger: AuditLogger;
+	recentlySent: Set<string>;
+	requestId: string;
+};
+
+async function handleHelpCommand(
+	msg: TelegramInboundMessage,
+	query: string | undefined,
+): Promise<void> {
+	await msg.reply(formatTelegramHelp(query));
+}
+
+async function handleCommandsCommand(msg: TelegramInboundMessage): Promise<void> {
+	await msg.reply(formatTelegramCommandCatalog());
+}
+
+async function handleStatusCommand(msg: TelegramInboundMessage): Promise<void> {
+	if (!isAdmin(msg.chatId)) {
+		await msg.reply("Only admin can query status.");
+		return;
+	}
+	await msg.sendComposing();
+	try {
+		const status = await collectTelclaudeStatus();
+		await msg.reply(formatTelclaudeStatus(status, true));
+	} catch (err) {
+		logger.warn({ error: String(err), chatId: msg.chatId }, "status command failed");
+		await msg.reply("Failed to collect status. Check logs.");
+	}
+}
+
+async function handleSessionsCommand(msg: TelegramInboundMessage): Promise<void> {
+	if (!isAdmin(msg.chatId)) {
+		await msg.reply("Only admin can inspect sessions.");
+		return;
+	}
+
+	const limit = 8;
+	const rows = collectSessionRows({ limit });
+	await msg.reply(formatSessionRows(rows, { limit }));
+}
+
+async function handleCronCommand(msg: TelegramInboundMessage): Promise<void> {
+	if (!isAdmin(msg.chatId)) {
+		await msg.reply("Only admin can inspect cron.");
+		return;
+	}
+
+	const overview = collectCronOverview({ includeDisabled: true, limit: 8 });
+	await msg.reply(formatCronOverview(overview));
+}
+
+async function handleWhoAmICommand(msg: TelegramInboundMessage): Promise<void> {
+	const link = getIdentityLink(msg.chatId);
+	if (link) {
+		await msg.reply(
+			`This chat is linked to local user: *${link.localUserId}*\n` +
+				`Linked: ${new Date(link.linkedAt).toLocaleString()}`,
+		);
+		return;
+	}
+
+	await msg.reply(
+		"This chat is not linked to any local user.\n" +
+			"Use `telclaude link <user-id>` on your machine to generate a link code.",
+	);
+}
+
+async function handleSessionResetCommand(msg: TelegramInboundMessage): Promise<void> {
+	const sessionKey = `tg:${msg.chatId}`;
+	deleteSession(sessionKey);
+	getSessionManager().clearSession(sessionKey);
+
+	logger.info({ chatId: msg.chatId, sessionKey }, "session reset via control command");
+	await msg.reply("Session reset. Starting fresh conversation.");
+}
+
+async function handleSystemCommand(
+	msg: TelegramInboundMessage,
+	query: string | undefined,
+): Promise<void> {
+	const trimmedQuery = query?.trim();
+	if (!trimmedQuery) {
+		await msg.reply(
+			[
+				"Usage: /system <question>",
+				"",
+				"Examples:",
+				"- /system what's the current status?",
+				"- /system any active sessions?",
+				"- /system when is the next heartbeat?",
+				"- /system who am i linked as?",
+			].join("\n"),
+		);
+		return;
+	}
+
+	const intent = resolveTelegramSystemIntent(trimmedQuery);
+	switch (intent.kind) {
+		case "command":
+			switch (intent.commandId) {
+				case "status":
+					await handleStatusCommand(msg);
+					return;
+				case "sessions":
+					await handleSessionsCommand(msg);
+					return;
+				case "cron":
+					await handleCronCommand(msg);
+					return;
+				case "whoami":
+					await handleWhoAmICommand(msg);
+					return;
+				default: {
+					const exhaustiveCheck: never = intent.commandId;
+					throw new Error(`Unhandled system command: ${String(exhaustiveCheck)}`);
+				}
+			}
+		case "help":
+			await handleHelpCommand(msg, intent.query);
+			return;
+		case "unknown":
+			await msg.reply(
+				`I couldn't map "${trimmedQuery}" to a safe system view.\n\nTry /status, /sessions, /cron, /whoami, or /help <topic>.`,
+			);
+			return;
+		default: {
+			const exhaustiveCheck: never = intent;
+			throw new Error(`Unhandled system intent: ${String(exhaustiveCheck)}`);
+		}
+	}
+}
+
+async function dispatchTelegramControlCommand(
+	match: TelegramCommandMatch,
+	context: TelegramControlCommandContext,
+): Promise<boolean> {
+	const { msg, cfg, auditLogger, recentlySent, requestId } = context;
+
+	switch (match.command.id) {
+		case "help":
+			await handleHelpCommand(msg, match.rawArgs);
+			return true;
+		case "commands":
+			await handleCommandsCommand(msg);
+			return true;
+		case "system":
+			await handleSystemCommand(msg, match.rawArgs);
+			return true;
+		case "link": {
+			await handleLinkCommand(msg, match.args[0]?.trim(), auditLogger);
+			return true;
+		}
+		case "approve": {
+			await handleApproveCommand(msg, match.args[0]?.trim(), cfg, auditLogger, recentlySent);
+			return true;
+		}
+		case "deny": {
+			if (match.args.length === 0) {
+				await handleDenyMostRecent(msg, auditLogger);
+				return true;
+			}
+			await handleDenyCommand(msg, match.args[0]?.trim(), auditLogger);
+			return true;
+		}
+		case "otp": {
+			const service = match.args[0]?.trim();
+			const maybeChallengeId = match.args[1]?.trim();
+			const maybeCode = match.args[2]?.trim();
+
+			if (!service) {
+				await msg.reply("Usage: /otp <service> <code> OR /otp <service> <challengeId> <code>");
+				return true;
+			}
+
+			let challengeId: string | undefined;
+			let code: string | undefined;
+			if (maybeCode) {
+				challengeId = maybeChallengeId;
+				code = maybeCode;
+			} else {
+				code = maybeChallengeId;
+			}
+
+			if (!code) {
+				await msg.reply("Usage: /otp <service> <code> OR /otp <service> <challengeId> <code>");
+				return true;
+			}
+
+			const link = getIdentityLink(msg.chatId);
+			if (!link) {
+				await msg.reply(
+					"This chat is not linked to a local user. Use `telclaude link <user-id>` first.",
+				);
+				return true;
+			}
+
+			try {
+				const response = await sendProviderOtp({
+					service,
+					code,
+					challengeId,
+					actorUserId: link.localUserId,
+					requestId,
+				});
+
+				if (response.status && response.status !== "ok") {
+					await msg.reply(
+						`OTP rejected: ${response.message ?? response.detail ?? response.status}`,
+					);
+					return true;
+				}
+
+				await msg.reply("OTP accepted. Continuing authentication.");
+			} catch (err) {
+				logger.warn({ error: String(err), service }, "provider OTP failed");
+				await msg.reply(
+					`OTP failed for service '${service}'. Check provider status and try again.`,
+				);
+			}
+			return true;
+		}
+		case "promote": {
+			const entryId = match.args[0]?.trim();
+			if (!entryId) {
+				await msg.reply("Usage: `/promote <entry-id>`");
+				return true;
+			}
+			if (!isAdmin(msg.chatId)) {
+				await msg.reply("Only admin can promote entries.");
+				return true;
+			}
+			const telegramEntries = getEntries({
+				categories: ["posts"],
+				trust: ["quarantined"],
+				sources: ["telegram"],
+				chatId: String(msg.chatId),
+			});
+			const socialEntries = getEntries({
+				categories: ["posts"],
+				trust: ["untrusted"],
+				sources: ["social"],
+			});
+			const allPromotable = [...telegramEntries, ...socialEntries];
+			if (!allPromotable.some((entry) => entry.id === entryId)) {
+				await msg.reply("Entry not found. Use /pending to list promotable posts.");
+				return true;
+			}
+			const result = promoteEntryTrust(entryId, String(msg.chatId));
+			if (!result.ok) {
+				await msg.reply(`Promote failed: ${result.reason}`);
+				return true;
+			}
+			await msg.reply(
+				`Promoted \`${entryId}\`. Send /heartbeat to publish now, or wait for the next scheduled one.`,
+			);
+			return true;
+		}
+		case "pending": {
+			if (!isAdmin(msg.chatId)) {
+				await msg.reply("Only admin can view pending entries.");
+				return true;
+			}
+			const telegramPending = getEntries({
+				categories: ["posts"],
+				trust: ["quarantined"],
+				sources: ["telegram"],
+				chatId: String(msg.chatId),
+				limit: 20,
+				order: "desc",
+			});
+			const socialPending = getEntries({
+				categories: ["posts"],
+				trust: ["untrusted"],
+				sources: ["social"],
+				limit: 20,
+				order: "desc",
+			});
+			const pending = [...telegramPending, ...socialPending]
+				.sort((a, b) => b._provenance.createdAt - a._provenance.createdAt)
+				.slice(0, 20);
+			if (pending.length === 0) {
+				await msg.reply("No pending posts.");
+				return true;
+			}
+			const lines = pending.map((entry) => {
+				const age = Math.round((Date.now() - entry._provenance.createdAt) / 60000);
+				const ageStr = age < 60 ? `${age}m ago` : `${Math.round(age / 60)}h ago`;
+				const preview =
+					entry.content.length > 60 ? `${entry.content.slice(0, 60)}...` : entry.content;
+				const quoteMetadata = parseSocialQuoteProposalMetadata(entry.metadata);
+				const contextLine = quoteMetadata
+					? `\n  quote ${quoteMetadata.targetPostId}${
+							quoteMetadata.targetAuthor ? ` (${quoteMetadata.targetAuthor})` : ""
+						}${
+							quoteMetadata.targetExcerpt
+								? `: "${quoteMetadata.targetExcerpt.slice(0, 60)}${
+										quoteMetadata.targetExcerpt.length > 60 ? "..." : ""
+									}"`
+								: ""
+						}`
+					: "";
+				return `\`${entry.id}\` "${preview}" — ${ageStr}${contextLine}\n  /promote ${entry.id}`;
+			});
+			await msg.reply(`${pending.length} pending post(s):\n\n${lines.join("\n\n")}`);
+			return true;
+		}
+		case "promote-skill": {
+			const skillName = match.args[0]?.trim();
+			if (!skillName) {
+				await msg.reply("Usage: `/promote-skill <name>`");
+				return true;
+			}
+			if (!isAdmin(msg.chatId)) {
+				await msg.reply("Only admin can promote skills.");
+				return true;
+			}
+			const result = promoteSkill(skillName);
+			if (result.success) {
+				await msg.reply(`Skill "${skillName}" promoted. Available next session.`);
+			} else {
+				await msg.reply(`Promote failed: ${result.error}`);
+			}
+			return true;
+		}
+		case "list-drafts": {
+			if (!isAdmin(msg.chatId)) {
+				await msg.reply("Only admin can list drafts.");
+				return true;
+			}
+			const drafts = listDraftSkills();
+			if (drafts.length === 0) {
+				await msg.reply("No draft skills awaiting promotion.");
+				return true;
+			}
+			const lines = drafts.map((name) => `  /promote-skill ${name}`);
+			await msg.reply(`${drafts.length} draft skill(s):\n${lines.join("\n")}`);
+			return true;
+		}
+		case "reload-skills": {
+			if (!isAdmin(msg.chatId)) {
+				await msg.reply("Only admin can reload skills.");
+				return true;
+			}
+			const sessionKey = `tg:${msg.chatId}`;
+			deleteSession(sessionKey);
+			getSessionManager().clearSession(sessionKey);
+			await msg.reply(
+				"Skills reloaded. Next message will start a fresh session with updated skills.",
+			);
+			return true;
+		}
+		case "status":
+			await handleStatusCommand(msg);
+			return true;
+		case "sessions":
+			await handleSessionsCommand(msg);
+			return true;
+		case "cron":
+			await handleCronCommand(msg);
+			return true;
+		case "heartbeat": {
+			if (!isAdmin(msg.chatId)) {
+				await msg.reply("Only admin can trigger heartbeats.");
+				return true;
+			}
+			const serviceIdArg = match.args[0]?.trim() || undefined;
+			const enabledServices = cfg.socialServices?.filter((service) => service.enabled) ?? [];
+			if (enabledServices.length === 0) {
+				await msg.reply("No social services are enabled.");
+				return true;
+			}
+			const targets = serviceIdArg
+				? enabledServices.filter((service) => service.id === serviceIdArg)
+				: enabledServices;
+			if (targets.length === 0) {
+				const ids = enabledServices.map((service) => service.id).join(", ");
+				await msg.reply(`Unknown service. Available: ${ids}`);
+				return true;
+			}
+			const { createSocialClient, handleSocialHeartbeat } = await import("../social/index.js");
+			const label = targets.map((service) => service.id).join(", ");
+			await msg.reply(`Running heartbeat: ${label}...`);
+			await msg.sendComposing();
+			const results = await Promise.allSettled(
+				targets.map(async (service) => {
+					const client = await createSocialClient(service);
+					if (!client) {
+						return { serviceId: service.id, ok: false, message: "client not configured" };
+					}
+					const result = await handleSocialHeartbeat(service.id, client, service);
+					return { serviceId: service.id, ...result };
+				}),
+			);
+			const lines = results.map((result, index) => {
+				const serviceId = targets[index].id;
+				if (result.status === "rejected") {
+					return `${serviceId}: failed — ${String(result.reason).slice(0, 80)}`;
+				}
+				const { ok, message } = result.value;
+				return `${serviceId}: ${ok ? message || "done" : `failed — ${message}`}`;
+			});
+			await msg.reply(lines.join("\n"));
+			return true;
+		}
+		case "public-log": {
+			if (!isAdmin(msg.chatId)) {
+				await msg.reply("Only admin can view public activity.");
+				return true;
+			}
+			const serviceIdArg = match.args[0]?.trim() || undefined;
+			const hoursArg = match.args[1] ? Number.parseInt(match.args[1], 10) : 4;
+			const hours = Number.isNaN(hoursArg) ? 4 : hoursArg;
+			const { formatActivityLog, getActivitySummary } = await import("../social/activity-log.js");
+			const summary = getActivitySummary(serviceIdArg, hours);
+			await msg.reply(formatActivityLog(summary, hours));
+			return true;
+		}
+		case "ask-public": {
+			if (!isAdmin(msg.chatId)) {
+				await msg.reply("Only admin can query the public persona.");
+				return true;
+			}
+			const payload = match.rawArgs.trim();
+			if (!payload) {
+				await msg.reply("Usage: `/ask-public [serviceId] <question>`");
+				return true;
+			}
+			const enabledServices = cfg.socialServices?.filter((service) => service.enabled) ?? [];
+			if (enabledServices.length === 0) {
+				await msg.reply("No social services are enabled.");
+				return true;
+			}
+			const parts = payload.split(/\s+/);
+			const maybeService = enabledServices.find((service) => service.id === parts[0]);
+			const service = maybeService ?? enabledServices[0];
+			const question = maybeService ? payload.slice(parts[0].length + 1).trim() : payload;
+			if (!question) {
+				const serviceIds = enabledServices.map((enabledService) => enabledService.id).join(", ");
+				await msg.reply(
+					`Usage: \`/ask-public [serviceId] <question>\`\nAvailable services: ${serviceIds}`,
+				);
+				return true;
+			}
+			await msg.sendComposing();
+			const typingTimer = setInterval(() => {
+				msg.sendComposing().catch(() => {});
+			}, 4000);
+			try {
+				const { queryPublicPersona } = await import("../social/handler.js");
+				const response = await queryPublicPersona(question, service.id, service);
+				await msg.reply(response || "No response from public persona.");
+			} catch (err) {
+				logger.warn({ error: String(err), serviceId: service.id }, "/ask-public query failed");
+				await msg.reply("Failed to reach public persona. Check logs.");
+			} finally {
+				clearInterval(typingTimer);
+			}
+			return true;
+		}
+		case "unlink": {
+			const { removeIdentityLink } = await import("../security/linking.js");
+			const removed = removeIdentityLink(msg.chatId);
+			if (removed) {
+				await msg.reply("Identity link removed for this chat.");
+			} else {
+				await msg.reply("No identity link found for this chat.");
+			}
+			return true;
+		}
+		case "whoami":
+			await handleWhoAmICommand(msg);
+			return true;
+		case "setup-2fa":
+			await handleSetup2FA(msg);
+			return true;
+		case "verify-2fa":
+			await handleVerify2FA(msg, match.args[0]?.trim());
+			return true;
+		case "disable-2fa":
+			await handleDisable2FA(msg);
+			return true;
+		case "2fa-logout":
+			await handleLogout2FA(msg);
+			return true;
+		case "force-reauth":
+			await handleForceReauth(msg, match.args[0]?.trim());
+			return true;
+		case "skip-totp": {
+			const link = getIdentityLink(msg.chatId);
+			const setupCmd = link
+				? `telclaude totp-setup ${link.localUserId}`
+				: "telclaude totp-setup <user-id>";
+			await msg.reply(
+				`⚠️ *TOTP setup skipped*\n\nYou can set up two-factor authentication later by running:\n\`${setupCmd}\`\n\n${link ? "Tip: you can confirm your user-id with /whoami.\n\n" : ""}Note: Without 2FA, anyone with access to your Telegram account can use this bot.`,
+			);
+			return true;
+		}
+		case "new":
+			await handleSessionResetCommand(msg);
+			return true;
+		default: {
+			const exhaustiveCheck: never = match.command.id;
+			throw new Error(`Unhandled Telegram control command: ${String(exhaustiveCheck)}`);
+		}
+	}
 }
 
 /**
@@ -931,6 +1452,7 @@ export async function monitorTelegramProvider(
 
 			console.log("Connecting to Telegram...");
 			const { bot, botInfo } = await createTelegramBot({ token, verbose });
+			await syncTelegramCommandMenu(bot);
 			console.log(`Connected as @${botInfo.username}`);
 
 			logger.info({ botId: botInfo.id, username: botInfo.username }, "connected to Telegram");
@@ -1110,12 +1632,10 @@ async function handleInboundMessage(
 	// ══════════════════════════════════════════════════════════════════════════
 
 	const trimmedBody = resolveCommandBody(msg).trim();
+	const controlCommandMatch = matchTelegramControlCommand(trimmedBody);
 
 	// Commands exempt from auth gate (needed for TOTP setup)
-	const isAuthExemptCommand =
-		trimmedBody === "/setup-2fa" ||
-		trimmedBody === "/verify-2fa" ||
-		trimmedBody.startsWith("/verify-2fa ");
+	const isAuthExemptCommand = isTelegramAuthExemptCommand(trimmedBody);
 
 	if (!isAuthExemptCommand) {
 		const authGateResult = await checkTOTPAuthGate(msg.chatId, msg.body, {
@@ -1188,465 +1708,20 @@ async function handleInboundMessage(
 	// ══════════════════════════════════════════════════════════════════════════
 
 	// Rate limit control commands to prevent brute-force attacks
-	const isControlCommand =
-		trimmedBody.startsWith("/link ") ||
-		trimmedBody.startsWith("/approve ") ||
-		trimmedBody.startsWith("/deny ") ||
-		trimmedBody === "/otp" ||
-		trimmedBody.startsWith("/otp ") ||
-		trimmedBody.startsWith("/promote ") ||
-		trimmedBody.startsWith("/promote-skill ") ||
-		trimmedBody === "/list-drafts" ||
-		trimmedBody === "/reload-skills" ||
-		trimmedBody === "/pending" ||
-		trimmedBody === "/heartbeat" ||
-		trimmedBody.startsWith("/heartbeat ") ||
-		trimmedBody === "/status" ||
-		trimmedBody.startsWith("/status ") ||
-		trimmedBody === "/public-log" ||
-		trimmedBody.startsWith("/public-log ") ||
-		trimmedBody.startsWith("/ask-public ");
-
-	if (isControlCommand && !checkControlCommandRateLimit(userId)) {
+	if (controlCommandMatch?.command.rateLimited && !checkControlCommandRateLimit(userId)) {
 		logger.warn({ userId }, "control command rate limited");
 		await msg.reply("Too many attempts. Please wait a minute before trying again.");
 		return;
 	}
 
-	if (trimmedBody.startsWith("/link ")) {
-		const code = trimmedBody.split(/\s+/)[1]?.trim();
-		await handleLinkCommand(msg, code, auditLogger);
-		return;
-	}
-
-	if (trimmedBody.startsWith("/approve ")) {
-		const nonce = trimmedBody.split(/\s+/)[1]?.trim();
-		await handleApproveCommand(msg, nonce, cfg, auditLogger, recentlySent);
-		return;
-	}
-
-	if (trimmedBody.startsWith("/deny ")) {
-		const nonce = trimmedBody.split(/\s+/)[1]?.trim();
-		await handleDenyCommand(msg, nonce, auditLogger);
-		return;
-	}
-
-	if (trimmedBody === "/otp" || trimmedBody.startsWith("/otp ")) {
-		const parts = trimmedBody.split(/\s+/).filter(Boolean);
-		const service = parts[1]?.trim();
-		const maybeChallengeId = parts[2]?.trim();
-		const maybeCode = parts[3]?.trim();
-
-		if (!service) {
-			await msg.reply("Usage: /otp <service> <code> OR /otp <service> <challengeId> <code>");
-			return;
-		}
-
-		let challengeId: string | undefined;
-		let code: string | undefined;
-		if (maybeCode) {
-			challengeId = maybeChallengeId;
-			code = maybeCode;
-		} else {
-			code = maybeChallengeId;
-		}
-
-		if (!code) {
-			await msg.reply("Usage: /otp <service> <code> OR /otp <service> <challengeId> <code>");
-			return;
-		}
-
-		const link = getIdentityLink(msg.chatId);
-		if (!link) {
-			await msg.reply(
-				"This chat is not linked to a local user. Use `telclaude link <user-id>` first.",
-			);
-			return;
-		}
-
-		try {
-			const response = await sendProviderOtp({
-				service,
-				code,
-				challengeId,
-				actorUserId: link.localUserId,
-				requestId,
-			});
-
-			if (response.status && response.status !== "ok") {
-				await msg.reply(`OTP rejected: ${response.message ?? response.detail ?? response.status}`);
-				return;
-			}
-
-			await msg.reply("OTP accepted. Continuing authentication.");
-		} catch (err) {
-			logger.warn({ error: String(err), service }, "provider OTP failed");
-			await msg.reply(`OTP failed for service '${service}'. Check provider status and try again.`);
-		}
-		return;
-	}
-
-	if (trimmedBody.startsWith("/promote ")) {
-		const entryId = trimmedBody.split(/\s+/)[1]?.trim();
-		if (!entryId) {
-			await msg.reply("Usage: `/promote <entry-id>`");
-			return;
-		}
-		// Only admin can promote
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can promote entries.");
-			return;
-		}
-		// Verify entry is promotable: telegram quarantined (same chat) OR social untrusted
-		const telegramEntries = getEntries({
-			categories: ["posts"],
-			trust: ["quarantined"],
-			sources: ["telegram"],
-			chatId: String(msg.chatId),
+	if (controlCommandMatch) {
+		await dispatchTelegramControlCommand(controlCommandMatch, {
+			msg,
+			cfg,
+			auditLogger,
+			recentlySent,
+			requestId,
 		});
-		const socialEntries = getEntries({
-			categories: ["posts"],
-			trust: ["untrusted"],
-			sources: ["social"],
-		});
-		const allPromotable = [...telegramEntries, ...socialEntries];
-		if (!allPromotable.some((e) => e.id === entryId)) {
-			await msg.reply("Entry not found. Use /pending to list promotable posts.");
-			return;
-		}
-		const result = promoteEntryTrust(entryId, String(msg.chatId));
-		if (!result.ok) {
-			await msg.reply(`Promote failed: ${result.reason}`);
-			return;
-		}
-		await msg.reply(
-			`Promoted \`${entryId}\`. Send /heartbeat to publish now, or wait for the next scheduled one.`,
-		);
-		return;
-	}
-
-	if (trimmedBody === "/pending") {
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can view pending entries.");
-			return;
-		}
-		// Union: telegram quarantined (same chat) + social untrusted (post ideas)
-		const telegramPending = getEntries({
-			categories: ["posts"],
-			trust: ["quarantined"],
-			sources: ["telegram"],
-			chatId: String(msg.chatId),
-			limit: 20,
-			order: "desc",
-		});
-		const socialPending = getEntries({
-			categories: ["posts"],
-			trust: ["untrusted"],
-			sources: ["social"],
-			limit: 20,
-			order: "desc",
-		});
-		const pending = [...telegramPending, ...socialPending]
-			.sort((a, b) => b._provenance.createdAt - a._provenance.createdAt)
-			.slice(0, 20);
-		if (pending.length === 0) {
-			await msg.reply("No pending posts.");
-			return;
-		}
-		const lines = pending.map((entry) => {
-			const age = Math.round((Date.now() - entry._provenance.createdAt) / 60000);
-			const ageStr = age < 60 ? `${age}m ago` : `${Math.round(age / 60)}h ago`;
-			const preview =
-				entry.content.length > 60 ? `${entry.content.slice(0, 60)}...` : entry.content;
-			const quoteMetadata = parseSocialQuoteProposalMetadata(entry.metadata);
-			const contextLine = quoteMetadata
-				? `\n  quote ${quoteMetadata.targetPostId}${
-						quoteMetadata.targetAuthor ? ` (${quoteMetadata.targetAuthor})` : ""
-					}${
-						quoteMetadata.targetExcerpt
-							? `: "${quoteMetadata.targetExcerpt.slice(0, 60)}${
-									quoteMetadata.targetExcerpt.length > 60 ? "..." : ""
-								}"`
-							: ""
-					}`
-				: "";
-			return `\`${entry.id}\` "${preview}" — ${ageStr}${contextLine}\n  /promote ${entry.id}`;
-		});
-		await msg.reply(`${pending.length} pending post(s):\n\n${lines.join("\n\n")}`);
-		return;
-	}
-
-	// ── Skill Draft Management ─────────────────────────────────────────
-	if (trimmedBody.startsWith("/promote-skill ")) {
-		const skillName = trimmedBody.split(/\s+/)[1]?.trim();
-		if (!skillName) {
-			await msg.reply("Usage: `/promote-skill <name>`");
-			return;
-		}
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can promote skills.");
-			return;
-		}
-		const result = promoteSkill(skillName);
-		if (result.success) {
-			await msg.reply(`Skill "${skillName}" promoted. Available next session.`);
-		} else {
-			await msg.reply(`Promote failed: ${result.error}`);
-		}
-		return;
-	}
-
-	if (trimmedBody === "/list-drafts") {
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can list drafts.");
-			return;
-		}
-		const drafts = listDraftSkills();
-		if (drafts.length === 0) {
-			await msg.reply("No draft skills awaiting promotion.");
-			return;
-		}
-		const lines = drafts.map((name) => `  /promote-skill ${name}`);
-		await msg.reply(`${drafts.length} draft skill(s):\n${lines.join("\n")}`);
-		return;
-	}
-
-	if (trimmedBody === "/reload-skills") {
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can reload skills.");
-			return;
-		}
-		// Skills are re-scanned on each session start via enableSkills + settingSources.
-		// Force a session reset to pick up new skills.
-		const sessionKey = `tg:${msg.chatId}`;
-		deleteSession(sessionKey);
-		getSessionManager().clearSession(sessionKey);
-		await msg.reply(
-			"Skills reloaded. Next message will start a fresh session with updated skills.",
-		);
-		return;
-	}
-
-	if (trimmedBody === "/status" || trimmedBody.startsWith("/status ")) {
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can query status.");
-			return;
-		}
-		await msg.sendComposing();
-		try {
-			const status = await collectTelclaudeStatus();
-			await msg.reply(formatTelclaudeStatus(status, true));
-		} catch (err) {
-			logger.warn({ error: String(err), chatId: msg.chatId }, "status command failed");
-			await msg.reply("Failed to collect status. Check logs.");
-		}
-		return;
-	}
-
-	if (trimmedBody === "/heartbeat" || trimmedBody.startsWith("/heartbeat ")) {
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can trigger heartbeats.");
-			return;
-		}
-		const parts = trimmedBody.split(/\s+/);
-		const serviceIdArg = parts[1]?.trim() || undefined;
-		const enabledServices = cfg.socialServices?.filter((s) => s.enabled) ?? [];
-		if (enabledServices.length === 0) {
-			await msg.reply("No social services are enabled.");
-			return;
-		}
-		// Specific service or all enabled services (parallel)
-		const targets = serviceIdArg
-			? enabledServices.filter((s) => s.id === serviceIdArg)
-			: enabledServices;
-		if (targets.length === 0) {
-			const ids = enabledServices.map((s) => s.id).join(", ");
-			await msg.reply(`Unknown service. Available: ${ids}`);
-			return;
-		}
-		const { createSocialClient, handleSocialHeartbeat } = await import("../social/index.js");
-		const label = targets.map((s) => s.id).join(", ");
-		await msg.reply(`Running heartbeat: ${label}...`);
-		await msg.sendComposing();
-		const results = await Promise.allSettled(
-			targets.map(async (svc) => {
-				const client = await createSocialClient(svc);
-				if (!client) return { serviceId: svc.id, ok: false, message: "client not configured" };
-				const result = await handleSocialHeartbeat(svc.id, client, svc);
-				return { serviceId: svc.id, ...result };
-			}),
-		);
-		const lines = results.map((r, i) => {
-			const svcId = targets[i].id;
-			if (r.status === "rejected") return `${svcId}: failed — ${String(r.reason).slice(0, 80)}`;
-			const { ok, message } = r.value;
-			return `${svcId}: ${ok ? message || "done" : `failed — ${message}`}`;
-		});
-		await msg.reply(lines.join("\n"));
-		return;
-	}
-
-	// ══════════════════════════════════════════════════════════════════════════
-	// CROSS-PERSONA QUERIES — Safe bridge between private and public personas
-	// ══════════════════════════════════════════════════════════════════════════
-
-	if (trimmedBody === "/public-log" || trimmedBody.startsWith("/public-log ")) {
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can view public activity.");
-			return;
-		}
-		const parts = trimmedBody.split(/\s+/);
-		const serviceIdArg = parts[1]?.trim() || undefined;
-		const hoursArg = parts[2] ? Number.parseInt(parts[2], 10) : 4;
-		const hours = Number.isNaN(hoursArg) ? 4 : hoursArg;
-		const { formatActivityLog, getActivitySummary } = await import("../social/activity-log.js");
-		const summary = getActivitySummary(serviceIdArg, hours);
-		await msg.reply(formatActivityLog(summary, hours));
-		return;
-	}
-
-	if (trimmedBody.startsWith("/ask-public ")) {
-		if (!isAdmin(msg.chatId)) {
-			await msg.reply("Only admin can query the public persona.");
-			return;
-		}
-		const payload = trimmedBody.slice("/ask-public ".length).trim();
-		if (!payload) {
-			await msg.reply("Usage: `/ask-public [serviceId] <question>`");
-			return;
-		}
-		// Route to social agent — private LLM never sees the response
-		const enabledServices = cfg.socialServices?.filter((s) => s.enabled) ?? [];
-		if (enabledServices.length === 0) {
-			await msg.reply("No social services are enabled.");
-			return;
-		}
-		const parts = payload.split(/\s+/);
-		const maybeService = enabledServices.find((s) => s.id === parts[0]);
-		const svc = maybeService ?? enabledServices[0];
-		const question = maybeService ? payload.slice(parts[0].length + 1).trim() : payload;
-		if (!question) {
-			const serviceIds = enabledServices.map((s) => s.id).join(", ");
-			await msg.reply(
-				`Usage: \`/ask-public [serviceId] <question>\`\nAvailable services: ${serviceIds}`,
-			);
-			return;
-		}
-		// Show typing indicator — query can take minutes on Pi4 with browser automation
-		await msg.sendComposing();
-		const typingTimer = setInterval(() => {
-			msg.sendComposing().catch(() => {});
-		}, 4000);
-		try {
-			const { queryPublicPersona } = await import("../social/handler.js");
-			const response = await queryPublicPersona(question, svc.id, svc);
-			// Pipe social agent response directly to Telegram (relay handles routing)
-			await msg.reply(response || "No response from public persona.");
-		} catch (err) {
-			logger.warn({ error: String(err), serviceId: svc.id }, "/ask-public query failed");
-			await msg.reply("Failed to reach public persona. Check logs.");
-		} finally {
-			clearInterval(typingTimer);
-		}
-		return;
-	}
-
-	if (trimmedBody === "/unlink") {
-		const { removeIdentityLink } = await import("../security/linking.js");
-		const removed = removeIdentityLink(msg.chatId);
-		if (removed) {
-			await msg.reply("Identity link removed for this chat.");
-		} else {
-			await msg.reply("No identity link found for this chat.");
-		}
-		return;
-	}
-
-	if (trimmedBody === "/whoami") {
-		const link = getIdentityLink(msg.chatId);
-		if (link) {
-			await msg.reply(
-				`This chat is linked to local user: *${link.localUserId}*\n` +
-					`Linked: ${new Date(link.linkedAt).toLocaleString()}`,
-			);
-		} else {
-			await msg.reply(
-				"This chat is not linked to any local user.\n" +
-					"Use `telclaude link <user-id>` on your machine to generate a link code.",
-			);
-		}
-		return;
-	}
-
-	// ══════════════════════════════════════════════════════════════════════════
-	// 2FA COMMANDS
-	// ══════════════════════════════════════════════════════════════════════════
-
-	if (trimmedBody === "/setup-2fa") {
-		await handleSetup2FA(msg);
-		return;
-	}
-
-	if (trimmedBody === "/verify-2fa" || trimmedBody.startsWith("/verify-2fa ")) {
-		const code = trimmedBody.split(/\s+/)[1]?.trim();
-		await handleVerify2FA(msg, code);
-		return;
-	}
-
-	if (trimmedBody === "/disable-2fa") {
-		await handleDisable2FA(msg);
-		return;
-	}
-
-	if (trimmedBody === "/2fa-logout") {
-		await handleLogout2FA(msg);
-		return;
-	}
-
-	// Admin-only command to force re-authentication for a specific chat
-	if (trimmedBody === "/force-reauth" || trimmedBody.startsWith("/force-reauth ")) {
-		const targetChatIdStr = trimmedBody.split(/\s+/)[1]?.trim();
-		await handleForceReauth(msg, targetChatIdStr);
-		return;
-	}
-
-	if (trimmedBody === "/skip-totp") {
-		const link = getIdentityLink(msg.chatId);
-		const setupCmd = link
-			? `telclaude totp-setup ${link.localUserId}`
-			: "telclaude totp-setup <user-id>";
-		await msg.reply(
-			`⚠️ *TOTP setup skipped*\n\nYou can set up two-factor authentication later by running:\n\`${setupCmd}\`\n\n${link ? "Tip: you can confirm your user-id with /whoami.\n\n" : ""}Note: Without 2FA, anyone with access to your Telegram account can use this bot.`,
-		);
-		return;
-	}
-
-	if (trimmedBody === "/deny") {
-		// Deny without nonce - deny the most recent pending approval
-		await handleDenyMostRecent(msg, auditLogger);
-		return;
-	}
-
-	// NOTE: 6-digit TOTP codes for approvals are no longer needed here.
-	// Identity verification is now handled by the TOTP auth gate earlier in the flow.
-	// Approvals use nonce-based confirmation only.
-
-	// ══════════════════════════════════════════════════════════════════════════
-	// SESSION RESET COMMANDS
-	// ══════════════════════════════════════════════════════════════════════════
-
-	if (trimmedBody === "/new" || trimmedBody === "/reset") {
-		// Session key is tg:{chatId} for per-sender scope
-		const sessionKey = `tg:${msg.chatId}`;
-
-		// Clear the session from config/sessions (SQLite)
-		deleteSession(sessionKey);
-
-		// Clear the session from SDK session manager (in-memory)
-		getSessionManager().clearSession(sessionKey);
-
-		logger.info({ chatId: msg.chatId, sessionKey }, "session reset via control command");
-		await msg.reply("Session reset. Starting fresh conversation.");
 		return;
 	}
 

--- a/src/telegram/auto-reply.ts
+++ b/src/telegram/auto-reply.ts
@@ -376,7 +376,7 @@ async function handleWhoAmICommand(msg: TelegramInboundMessage): Promise<void> {
 }
 
 async function handleSessionResetCommand(msg: TelegramInboundMessage): Promise<void> {
-	const sessionKey = `tg:${msg.chatId}`;
+	const sessionKey = msg.from;
 	deleteSession(sessionKey);
 	getSessionManager().clearSession(sessionKey);
 
@@ -651,7 +651,7 @@ async function dispatchTelegramControlCommand(
 				await msg.reply("Only admin can reload skills.");
 				return true;
 			}
-			const sessionKey = `tg:${msg.chatId}`;
+			const sessionKey = msg.from;
 			deleteSession(sessionKey);
 			getSessionManager().clearSession(sessionKey);
 			await msg.reply(

--- a/src/telegram/client.ts
+++ b/src/telegram/client.ts
@@ -1,6 +1,7 @@
 import { autoRetry } from "@grammyjs/auto-retry";
 import { Bot, GrammyError, HttpError } from "grammy";
 import { getChildLogger } from "../logging.js";
+import { getTelegramMenuCommands } from "./control-commands.js";
 import type { BotInfo } from "./types.js";
 
 export type TelegramBotOptions = {
@@ -68,6 +69,18 @@ export async function createTelegramBot(options: TelegramBotOptions): Promise<Te
 	logger.info({ botId: me.id, username: me.username }, "bot authenticated");
 
 	return { bot, botInfo: me };
+}
+
+export async function syncTelegramCommandMenu(bot: Bot): Promise<void> {
+	const logger = getChildLogger({ module: "telegram-client" });
+
+	try {
+		const commands = getTelegramMenuCommands();
+		await bot.api.setMyCommands(commands);
+		logger.info({ commandCount: commands.length }, "telegram command menu synced");
+	} catch (err) {
+		logger.warn({ error: String(err) }, "failed to sync telegram command menu");
+	}
 }
 
 /**

--- a/src/telegram/control-commands.ts
+++ b/src/telegram/control-commands.ts
@@ -1,0 +1,788 @@
+type TelegramCommandCategory =
+	| "Discover"
+	| "System"
+	| "Identity"
+	| "Session"
+	| "Approvals"
+	| "Security"
+	| "Social"
+	| "Skills";
+
+export type TelegramCommandId =
+	| "help"
+	| "commands"
+	| "system"
+	| "link"
+	| "unlink"
+	| "whoami"
+	| "approve"
+	| "deny"
+	| "otp"
+	| "setup-2fa"
+	| "verify-2fa"
+	| "disable-2fa"
+	| "2fa-logout"
+	| "force-reauth"
+	| "skip-totp"
+	| "status"
+	| "sessions"
+	| "cron"
+	| "heartbeat"
+	| "pending"
+	| "promote"
+	| "public-log"
+	| "ask-public"
+	| "list-drafts"
+	| "promote-skill"
+	| "reload-skills"
+	| "new";
+
+type TelegramControlCommandDefinition = {
+	id: TelegramCommandId;
+	name: string;
+	aliases?: string[];
+	category: TelegramCommandCategory;
+	description: string;
+	usage: string;
+	examples?: string[];
+	keywords?: string[];
+	readOnly?: boolean;
+	authExempt?: boolean;
+	rateLimited?: boolean;
+	menuDescription?: string;
+	hideFromCatalog?: boolean;
+};
+
+export type TelegramCommandMatch = {
+	command: TelegramControlCommandDefinition;
+	commandToken: string;
+	aliasUsed?: string;
+	raw: string;
+	rawArgs: string;
+	args: string[];
+};
+
+type TelegramHelpTopic = {
+	id: string;
+	title: string;
+	summary: string;
+	keywords: string[];
+	commands: TelegramCommandId[];
+};
+
+export type TelegramHelpMatch =
+	| {
+			kind: "command";
+			command: TelegramControlCommandDefinition;
+	  }
+	| {
+			kind: "topic";
+			topic: TelegramHelpTopic;
+	  };
+
+export type TelegramSystemIntent =
+	| {
+			kind: "command";
+			commandId: "status" | "sessions" | "cron" | "whoami";
+	  }
+	| {
+			kind: "help";
+			query: string;
+	  }
+	| {
+			kind: "unknown";
+	  };
+
+const TELEGRAM_CONTROL_COMMANDS: TelegramControlCommandDefinition[] = [
+	{
+		id: "help",
+		name: "help",
+		category: "Discover",
+		description: "Explain commands, topics, or operator workflows.",
+		usage: "/help [command or topic]",
+		examples: ["/help approvals", "/help reset session", "/help cron"],
+		keywords: ["help", "docs", "what can i do", "how do i", "explain"],
+		readOnly: true,
+		menuDescription: "Explain commands and topics",
+	},
+	{
+		id: "commands",
+		name: "commands",
+		category: "Discover",
+		description: "List the Telegram command catalog.",
+		usage: "/commands",
+		examples: ["/commands"],
+		keywords: ["commands", "command list", "menu", "available commands"],
+		readOnly: true,
+		menuDescription: "List available commands",
+	},
+	{
+		id: "system",
+		name: "system",
+		category: "System",
+		description: "Answer a natural-language question about status, sessions, cron, or identity.",
+		usage: "/system <question>",
+		examples: [
+			"/system what's the current status?",
+			"/system any cron jobs running?",
+			"/system who am i linked as?",
+		],
+		keywords: ["system", "status question", "natural language", "what is running"],
+		readOnly: true,
+		rateLimited: true,
+		menuDescription: "Ask about system state",
+	},
+	{
+		id: "status",
+		name: "status",
+		category: "System",
+		description: "Show runtime, security, service, and configuration status.",
+		usage: "/status",
+		examples: ["/status"],
+		keywords: ["status", "health", "runtime", "security", "audit", "config", "environment"],
+		readOnly: true,
+		rateLimited: true,
+		menuDescription: "Show runtime status",
+	},
+	{
+		id: "sessions",
+		name: "sessions",
+		category: "System",
+		description: "Show recent session state for active chats.",
+		usage: "/sessions",
+		examples: ["/sessions"],
+		keywords: ["sessions", "session state", "active sessions", "context"],
+		readOnly: true,
+		rateLimited: true,
+		menuDescription: "Inspect chat sessions",
+	},
+	{
+		id: "cron",
+		name: "cron",
+		category: "System",
+		description: "Show cron scheduler state and recent jobs.",
+		usage: "/cron",
+		examples: ["/cron", "/system when is the next heartbeat"],
+		keywords: ["cron", "schedule", "scheduled jobs", "heartbeat schedule", "next run"],
+		readOnly: true,
+		rateLimited: true,
+		menuDescription: "Inspect cron jobs",
+	},
+	{
+		id: "link",
+		name: "link",
+		category: "Identity",
+		description: "Link this private chat to a local user with a one-time code.",
+		usage: "/link <code>",
+		examples: ["/link ABCD-1234"],
+		keywords: ["link", "pair", "identity link", "bind chat", "claim user"],
+		rateLimited: true,
+	},
+	{
+		id: "unlink",
+		name: "unlink",
+		category: "Identity",
+		description: "Remove the identity link for this chat.",
+		usage: "/unlink",
+		examples: ["/unlink"],
+		keywords: ["unlink", "remove link", "disconnect identity"],
+	},
+	{
+		id: "whoami",
+		name: "whoami",
+		category: "Identity",
+		description: "Show which local user this chat is linked to.",
+		usage: "/whoami",
+		examples: ["/whoami"],
+		keywords: ["whoami", "who am i", "identity", "linked user", "which user"],
+		readOnly: true,
+		menuDescription: "Show linked identity",
+	},
+	{
+		id: "approve",
+		name: "approve",
+		category: "Approvals",
+		description: "Approve a pending request, plan, provider action, or admin claim.",
+		usage: "/approve <code>",
+		examples: ["/approve 123456"],
+		keywords: ["approve", "approval", "allow pending request", "confirm"],
+		rateLimited: true,
+	},
+	{
+		id: "deny",
+		name: "deny",
+		category: "Approvals",
+		description: "Deny a pending request. Without a code, denies the newest pending approval.",
+		usage: "/deny [code]",
+		examples: ["/deny", "/deny 123456"],
+		keywords: ["deny", "reject", "cancel approval", "block pending request"],
+		rateLimited: true,
+	},
+	{
+		id: "otp",
+		name: "otp",
+		category: "Security",
+		description: "Submit a provider OTP challenge code.",
+		usage: "/otp <service> <code> OR /otp <service> <challengeId> <code>",
+		examples: ["/otp github 123456"],
+		keywords: ["otp", "one time password", "provider auth", "challenge"],
+		rateLimited: true,
+	},
+	{
+		id: "setup-2fa",
+		name: "setup-2fa",
+		category: "Security",
+		description: "Start the local TOTP setup flow.",
+		usage: "/setup-2fa",
+		examples: ["/setup-2fa"],
+		keywords: ["2fa", "setup totp", "enable two factor", "totp setup"],
+		authExempt: true,
+	},
+	{
+		id: "verify-2fa",
+		name: "verify-2fa",
+		category: "Security",
+		description: "Verify the current TOTP code and start a 2FA-backed session.",
+		usage: "/verify-2fa <6-digit-code>",
+		examples: ["/verify-2fa 123456"],
+		keywords: ["verify 2fa", "totp code", "authenticate"],
+		authExempt: true,
+	},
+	{
+		id: "disable-2fa",
+		name: "disable-2fa",
+		category: "Security",
+		description: "Disable TOTP for this chat.",
+		usage: "/disable-2fa",
+		examples: ["/disable-2fa"],
+		keywords: ["disable 2fa", "turn off totp"],
+	},
+	{
+		id: "2fa-logout",
+		name: "2fa-logout",
+		category: "Security",
+		description: "Invalidate the current TOTP-backed session.",
+		usage: "/2fa-logout",
+		examples: ["/2fa-logout"],
+		keywords: ["2fa logout", "logout", "end auth session", "reauth"],
+	},
+	{
+		id: "force-reauth",
+		name: "force-reauth",
+		category: "Security",
+		description: "Invalidate your own 2FA session, or an admin can target another chat.",
+		usage: "/force-reauth [chatId]",
+		examples: ["/force-reauth", "/force-reauth 123456789"],
+		keywords: ["force reauth", "invalidate totp", "end session"],
+	},
+	{
+		id: "skip-totp",
+		name: "skip-totp",
+		category: "Security",
+		description: "Acknowledge that TOTP setup is being skipped for now.",
+		usage: "/skip-totp",
+		examples: ["/skip-totp"],
+		keywords: ["skip totp", "skip 2fa"],
+	},
+	{
+		id: "new",
+		name: "new",
+		aliases: ["reset"],
+		category: "Session",
+		description: "Reset the current conversation session and start fresh.",
+		usage: "/new",
+		examples: ["/new", "/reset"],
+		keywords: ["new conversation", "reset session", "start fresh", "clear context"],
+		readOnly: true,
+		menuDescription: "Start a fresh session",
+	},
+	{
+		id: "heartbeat",
+		name: "heartbeat",
+		category: "Social",
+		description: "Run a social heartbeat now for one service or all enabled services.",
+		usage: "/heartbeat [serviceId]",
+		examples: ["/heartbeat", "/heartbeat xtwitter"],
+		keywords: ["heartbeat", "social run", "post now", "trigger scheduler"],
+		rateLimited: true,
+	},
+	{
+		id: "pending",
+		name: "pending",
+		category: "Social",
+		description: "List pending promotable post ideas.",
+		usage: "/pending",
+		examples: ["/pending"],
+		keywords: ["pending posts", "quarantine", "draft posts"],
+		rateLimited: true,
+	},
+	{
+		id: "promote",
+		name: "promote",
+		category: "Social",
+		description: "Promote a pending post idea so it can be published.",
+		usage: "/promote <entry-id>",
+		examples: ["/promote post_123"],
+		keywords: ["promote", "approve post", "publish idea"],
+		rateLimited: true,
+	},
+	{
+		id: "public-log",
+		name: "public-log",
+		category: "Social",
+		description: "Summarize recent public persona activity.",
+		usage: "/public-log [serviceId] [hours]",
+		examples: ["/public-log", "/public-log xtwitter 12"],
+		keywords: ["public log", "activity log", "social history"],
+		readOnly: true,
+		rateLimited: true,
+	},
+	{
+		id: "ask-public",
+		name: "ask-public",
+		category: "Social",
+		description:
+			"Ask the social persona a question without routing the reply through the private persona.",
+		usage: "/ask-public [serviceId] <question>",
+		examples: ["/ask-public what did you post today?", "/ask-public xtwitter draft a reply"],
+		keywords: ["ask public", "public persona", "social query"],
+		rateLimited: true,
+	},
+	{
+		id: "list-drafts",
+		name: "list-drafts",
+		category: "Skills",
+		description: "List draft skills awaiting promotion.",
+		usage: "/list-drafts",
+		examples: ["/list-drafts"],
+		keywords: ["draft skills", "list drafts", "skills queue"],
+		rateLimited: true,
+	},
+	{
+		id: "promote-skill",
+		name: "promote-skill",
+		category: "Skills",
+		description: "Promote a draft skill into the live skill set.",
+		usage: "/promote-skill <name>",
+		examples: ["/promote-skill my-skill"],
+		keywords: ["promote skill", "publish skill"],
+		rateLimited: true,
+	},
+	{
+		id: "reload-skills",
+		name: "reload-skills",
+		category: "Skills",
+		description: "Force the next session to start with the latest skills.",
+		usage: "/reload-skills",
+		examples: ["/reload-skills"],
+		keywords: ["reload skills", "refresh skills"],
+		rateLimited: true,
+	},
+];
+
+const TELEGRAM_HELP_TOPICS: TelegramHelpTopic[] = [
+	{
+		id: "approvals",
+		title: "Approvals",
+		summary:
+			"Approvals protect sensitive actions. Approve with /approve <code>, deny with /deny <code>, and /deny without a code rejects the newest pending request.",
+		keywords: ["approval", "approvals", "approve", "deny", "plan preview", "pending request"],
+		commands: ["approve", "deny"],
+	},
+	{
+		id: "identity",
+		title: "Identity",
+		summary:
+			"Identity linking binds a Telegram chat to a local user. Link in a private chat, inspect it with /whoami, and remove it with /unlink.",
+		keywords: ["identity", "link", "unlink", "who am i", "whoami", "pairing"],
+		commands: ["link", "whoami", "unlink"],
+	},
+	{
+		id: "2fa",
+		title: "Two-Factor Auth",
+		summary:
+			"2FA is set up locally. /setup-2fa explains the local flow, /verify-2fa activates it, /2fa-logout ends the current session, and /disable-2fa removes it.",
+		keywords: ["2fa", "totp", "two factor", "reauth", "force reauth", "auth"],
+		commands: ["setup-2fa", "verify-2fa", "2fa-logout", "disable-2fa", "force-reauth", "skip-totp"],
+	},
+	{
+		id: "system",
+		title: "System Introspection",
+		summary:
+			"Use /status for runtime and security state, /sessions for recent chat sessions, /cron for scheduled jobs, or /system <question> when you want the bot to route a natural-language system question for you.",
+		keywords: ["system", "status", "sessions", "cron", "health", "diagnostics"],
+		commands: ["status", "sessions", "cron", "system"],
+	},
+	{
+		id: "social",
+		title: "Social Persona",
+		summary:
+			"Social commands are still explicit and admin-gated. Use /pending and /promote for queued ideas, /heartbeat to run posting now, /public-log for metadata history, and /ask-public to query the social persona directly.",
+		keywords: ["social", "public persona", "heartbeat", "posts", "pending", "promote"],
+		commands: ["pending", "promote", "heartbeat", "public-log", "ask-public"],
+	},
+	{
+		id: "skills",
+		title: "Skills",
+		summary:
+			"Skills are promoted intentionally. /list-drafts shows candidates, /promote-skill activates one, and /reload-skills resets the next session so the refreshed set is loaded.",
+		keywords: ["skills", "draft skills", "promote skill", "reload skills"],
+		commands: ["list-drafts", "promote-skill", "reload-skills"],
+	},
+	{
+		id: "reset-session",
+		title: "Reset Session",
+		summary:
+			"Use /new to clear the current chat session and start fresh. /reset is an alias for the same action.",
+		keywords: ["reset session", "new session", "start fresh", "clear context"],
+		commands: ["new"],
+	},
+];
+
+const COMMAND_BY_ID = new Map(
+	TELEGRAM_CONTROL_COMMANDS.map((command) => [command.id, command] as const),
+);
+
+const COMMAND_BY_TRIGGER = new Map<string, TelegramControlCommandDefinition>();
+for (const command of TELEGRAM_CONTROL_COMMANDS) {
+	COMMAND_BY_TRIGGER.set(command.name, command);
+	for (const alias of command.aliases ?? []) {
+		COMMAND_BY_TRIGGER.set(alias, command);
+	}
+}
+
+const CATALOG_CATEGORY_ORDER: TelegramCommandCategory[] = [
+	"Discover",
+	"System",
+	"Identity",
+	"Session",
+	"Approvals",
+	"Security",
+	"Social",
+	"Skills",
+];
+
+function normalizeLookup(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/^\//, "")
+		.replace(/[_-]+/g, " ")
+		.replace(/[^a-z0-9\s]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function tokenize(value: string): string[] {
+	const normalized = normalizeLookup(value);
+	return normalized ? normalized.split(" ") : [];
+}
+
+function scoreLookup(query: string, terms: string[]): number {
+	if (!query) {
+		return 0;
+	}
+	const queryTokens = tokenize(query);
+	let best = 0;
+	for (const term of terms) {
+		const normalizedTerm = normalizeLookup(term);
+		if (!normalizedTerm) {
+			continue;
+		}
+		if (normalizedTerm === query) {
+			best = Math.max(best, 100);
+			continue;
+		}
+		if (normalizedTerm.includes(query) || query.includes(normalizedTerm)) {
+			best = Math.max(best, 60);
+			continue;
+		}
+		const termTokens = new Set(tokenize(normalizedTerm));
+		const overlap = queryTokens.filter((token) => termTokens.has(token)).length;
+		best = Math.max(best, overlap * 10);
+	}
+	return best;
+}
+
+function formatCommandTrigger(command: TelegramControlCommandDefinition): string {
+	const aliases = (command.aliases ?? []).map((alias) => `/${alias}`);
+	if (aliases.length === 0) {
+		return `/${command.name}`;
+	}
+	return `/${command.name} (aliases: ${aliases.join(", ")})`;
+}
+
+function formatCommandLine(command: TelegramControlCommandDefinition): string {
+	return `${formatCommandTrigger(command)} - ${command.description}`;
+}
+
+function formatCommandDetail(command: TelegramControlCommandDefinition): string {
+	const lines = [
+		formatCommandTrigger(command),
+		"",
+		command.description,
+		"",
+		`Usage: ${command.usage}`,
+	];
+	if (command.examples?.length) {
+		lines.push("", "Examples:");
+		for (const example of command.examples) {
+			lines.push(`- ${example}`);
+		}
+	}
+	return lines.join("\n");
+}
+
+function formatTopicDetail(topic: TelegramHelpTopic): string {
+	const lines = [topic.title, "", topic.summary];
+	if (topic.commands.length > 0) {
+		lines.push("", "Related commands:");
+		for (const commandId of topic.commands) {
+			const command = getTelegramControlCommand(commandId);
+			lines.push(`- ${formatCommandLine(command)}`);
+		}
+	}
+	return lines.join("\n");
+}
+
+export function listTelegramControlCommands(): TelegramControlCommandDefinition[] {
+	return [...TELEGRAM_CONTROL_COMMANDS];
+}
+
+export function getTelegramControlCommand(
+	commandId: TelegramCommandId,
+): TelegramControlCommandDefinition {
+	const command = COMMAND_BY_ID.get(commandId);
+	if (!command) {
+		throw new Error(`Unknown Telegram command: ${commandId}`);
+	}
+	return command;
+}
+
+export function matchTelegramControlCommand(
+	body: string,
+	options?: { botUsername?: string },
+): TelegramCommandMatch | null {
+	const trimmed = body.trim();
+	if (!trimmed.startsWith("/")) {
+		return null;
+	}
+
+	const spaceIndex = trimmed.indexOf(" ");
+	const rawToken = (spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex)).slice(1);
+	const rawArgs = spaceIndex === -1 ? "" : trimmed.slice(spaceIndex + 1).trim();
+
+	let commandToken = rawToken.toLowerCase();
+	const atIndex = commandToken.indexOf("@");
+	if (atIndex !== -1) {
+		const explicitTarget = commandToken.slice(atIndex + 1);
+		if (options?.botUsername && explicitTarget !== options.botUsername.toLowerCase()) {
+			return null;
+		}
+		commandToken = commandToken.slice(0, atIndex);
+	}
+
+	const command = COMMAND_BY_TRIGGER.get(commandToken);
+	if (!command) {
+		return null;
+	}
+
+	return {
+		command,
+		commandToken,
+		aliasUsed: commandToken !== command.name ? commandToken : undefined,
+		raw: trimmed,
+		rawArgs,
+		args: rawArgs ? rawArgs.split(/\s+/).filter(Boolean) : [],
+	};
+}
+
+export function hasTelegramControlCommand(
+	body: string,
+	options?: { botUsername?: string },
+): boolean {
+	return matchTelegramControlCommand(body, options) !== null;
+}
+
+export function isTelegramAuthExemptCommand(body: string): boolean {
+	const match = matchTelegramControlCommand(body);
+	return match?.command.authExempt === true;
+}
+
+export function formatTelegramHelpOverview(): string {
+	const lines = [
+		"Telclaude help",
+		"",
+		"Start with:",
+		"- /help approvals",
+		"- /help reset session",
+		"- /help 2fa",
+		"- /system what's the current status?",
+		"",
+		"Common commands:",
+		`- ${formatCommandLine(getTelegramControlCommand("help"))}`,
+		`- ${formatCommandLine(getTelegramControlCommand("status"))}`,
+		`- ${formatCommandLine(getTelegramControlCommand("whoami"))}`,
+		`- ${formatCommandLine(getTelegramControlCommand("new"))}`,
+		"",
+		"Use /commands for the full catalog.",
+	];
+
+	return lines.join("\n");
+}
+
+export function formatTelegramCommandCatalog(): string {
+	const visibleCommands = TELEGRAM_CONTROL_COMMANDS.filter(
+		(command) => command.hideFromCatalog !== true,
+	);
+	const sections = CATALOG_CATEGORY_ORDER.map((category) => {
+		const commands = visibleCommands.filter((command) => command.category === category);
+		if (commands.length === 0) {
+			return null;
+		}
+		return [category, ...commands.map((command) => `- ${formatCommandLine(command)}`)].join("\n");
+	}).filter(Boolean) as string[];
+
+	return [
+		"Telclaude command catalog",
+		"",
+		...sections,
+		"",
+		"Use /help <command or topic> for details.",
+	].join("\n");
+}
+
+export function resolveTelegramHelpQuery(query: string): TelegramHelpMatch | null {
+	const normalized = normalizeLookup(query);
+	if (!normalized) {
+		return null;
+	}
+
+	const exactCommand = COMMAND_BY_TRIGGER.get(normalized);
+	if (exactCommand) {
+		return { kind: "command", command: exactCommand };
+	}
+
+	const exactTopic = TELEGRAM_HELP_TOPICS.find((topic) =>
+		topic.keywords.some((keyword) => normalizeLookup(keyword) === normalized),
+	);
+	if (exactTopic) {
+		return { kind: "topic", topic: exactTopic };
+	}
+
+	const bestCommand = TELEGRAM_CONTROL_COMMANDS.map((command) => ({
+		command,
+		score: scoreLookup(normalized, [
+			command.name,
+			...(command.aliases ?? []),
+			command.description,
+			command.usage,
+			...(command.keywords ?? []),
+		]),
+	})).sort((a, b) => b.score - a.score)[0];
+
+	const bestTopic = TELEGRAM_HELP_TOPICS.map((topic) => ({
+		topic,
+		score: scoreLookup(normalized, [topic.title, topic.summary, ...topic.keywords]),
+	})).sort((a, b) => b.score - a.score)[0];
+
+	if (bestCommand && bestCommand.score >= Math.max(bestTopic?.score ?? 0, 20)) {
+		return { kind: "command", command: bestCommand.command };
+	}
+
+	if (bestTopic && bestTopic.score >= 20) {
+		return { kind: "topic", topic: bestTopic.topic };
+	}
+
+	return null;
+}
+
+export function formatTelegramHelp(query?: string): string {
+	const trimmedQuery = query?.trim();
+	if (!trimmedQuery) {
+		return formatTelegramHelpOverview();
+	}
+
+	const match = resolveTelegramHelpQuery(trimmedQuery);
+	if (!match) {
+		return [
+			`No help match for "${trimmedQuery}".`,
+			"",
+			"Try:",
+			"- /help approvals",
+			"- /help 2fa",
+			"- /help status",
+			"- /help reset session",
+			"",
+			"Use /commands to browse the full catalog.",
+		].join("\n");
+	}
+
+	return match.kind === "command"
+		? formatCommandDetail(match.command)
+		: formatTopicDetail(match.topic);
+}
+
+export function getTelegramMenuCommands(): Array<{ command: string; description: string }> {
+	return TELEGRAM_CONTROL_COMMANDS.filter((command) => Boolean(command.menuDescription)).map(
+		(command) => ({
+			command: command.name,
+			description: command.menuDescription ?? command.description,
+		}),
+	);
+}
+
+export function resolveTelegramSystemIntent(query: string): TelegramSystemIntent {
+	const normalized = normalizeLookup(query);
+	if (!normalized) {
+		return { kind: "unknown" };
+	}
+
+	const whoamiScore = scoreLookup(normalized, [
+		"whoami",
+		"who am i",
+		"identity",
+		"linked user",
+		"linked chat",
+		"who is this chat",
+	]);
+	const statusScore = scoreLookup(normalized, [
+		"status",
+		"health",
+		"runtime",
+		"security",
+		"audit",
+		"config",
+		"environment",
+		"version",
+		"running",
+	]);
+	const sessionsScore = scoreLookup(normalized, [
+		"sessions",
+		"session state",
+		"active sessions",
+		"conversation context",
+		"session age",
+	]);
+	const cronScore = scoreLookup(normalized, [
+		"cron",
+		"schedule",
+		"scheduled jobs",
+		"heartbeat schedule",
+		"next heartbeat",
+		"next run",
+		"jobs",
+	]);
+
+	const bestCommand = [
+		{ commandId: "whoami" as const, score: whoamiScore },
+		{ commandId: "status" as const, score: statusScore },
+		{ commandId: "sessions" as const, score: sessionsScore },
+		{ commandId: "cron" as const, score: cronScore },
+	].sort((a, b) => b.score - a.score)[0];
+
+	if (bestCommand && bestCommand.score >= 20) {
+		return { kind: "command", commandId: bestCommand.commandId };
+	}
+
+	return { kind: "help", query };
+}

--- a/src/telegram/control-commands.ts
+++ b/src/telegram/control-commands.ts
@@ -575,7 +575,10 @@ export function matchTelegramControlCommand(
 	const atIndex = commandToken.indexOf("@");
 	if (atIndex !== -1) {
 		const explicitTarget = commandToken.slice(atIndex + 1);
-		if (options?.botUsername && explicitTarget !== options.botUsername.toLowerCase()) {
+		if (!options?.botUsername) {
+			return null;
+		}
+		if (explicitTarget !== options.botUsername.toLowerCase()) {
 			return null;
 		}
 		commandToken = commandToken.slice(0, atIndex);

--- a/src/telegram/inbound.ts
+++ b/src/telegram/inbound.ts
@@ -9,6 +9,7 @@ import { filterOutputWithConfig, type SecretFilterConfig } from "../security/out
 import { isBotMessage, removeReaction, storeReaction } from "../storage/reactions.js";
 import { chatIdToString, normalizeTelegramId } from "../utils.js";
 import { resolveControlCommandGate } from "./command-gating.js";
+import { hasTelegramControlCommand } from "./control-commands.js";
 import { registerKeyboardHandlers } from "./keyboard-handlers.js";
 import { resolveMentionGatingWithBypass } from "./mention-gating.js";
 import { convertAndSendMessage, SECRET_BLOCKED_MESSAGE, sendMediaToChat } from "./outbound.js";
@@ -46,41 +47,6 @@ export type InboxMonitorHandle = {
 };
 
 const ZERO_WIDTH_CHARS_REGEX = /\u200B|\u200C|\u200D|\uFEFF/gu;
-const CONTROL_COMMAND_PREFIXES = [
-	"/link ",
-	"/approve ",
-	"/deny ",
-	"/otp ",
-	"/promote ",
-	"/promote-skill ",
-	"/heartbeat ",
-	"/status ",
-	"/public-log ",
-	"/ask-public ",
-	"/verify-2fa ",
-	"/force-reauth ",
-] as const;
-const CONTROL_COMMAND_EXACT = new Set([
-	"/otp",
-	"/list-drafts",
-	"/reload-skills",
-	"/pending",
-	"/heartbeat",
-	"/status",
-	"/public-log",
-	"/setup-2fa",
-	"/verify-2fa",
-	"/disable-2fa",
-	"/2fa-logout",
-	"/force-reauth",
-	"/skip-totp",
-	"/unlink",
-	"/whoami",
-	"/new",
-	"/reset",
-	"/deny",
-]);
-
 export type InboundBodyNormalization = {
 	normalized: string;
 	changed: boolean;
@@ -172,14 +138,7 @@ export async function monitorTelegramInbox(
 	};
 
 	const hasControlCommand = (body: string): boolean => {
-		const trimmed = body.trim();
-		if (!trimmed.startsWith("/")) {
-			return false;
-		}
-		if (CONTROL_COMMAND_EXACT.has(trimmed)) {
-			return true;
-		}
-		return CONTROL_COMMAND_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+		return hasTelegramControlCommand(body, { botUsername });
 	};
 
 	// Helper to check if chat is allowed

--- a/src/telegram/keyboard-handlers.ts
+++ b/src/telegram/keyboard-handlers.ts
@@ -9,6 +9,7 @@ import type { Bot, CallbackQueryContext, Context } from "grammy";
 import { deleteSession, deriveSessionKey } from "../config/sessions.js";
 import { getChildLogger } from "../logging.js";
 import { getSessionManager } from "../sdk/session-manager.js";
+import { formatTelegramHelpOverview } from "./control-commands.js";
 
 const logger = getChildLogger({ module: "keyboard-handlers" });
 
@@ -158,21 +159,6 @@ async function handleTTS(ctx: CallbackQueryContext<Context>, chatId: number): Pr
  * Handle "Help" button press.
  */
 async function handleHelp(ctx: CallbackQueryContext<Context>): Promise<void> {
-	const helpText = `*Quick Commands*
-
-🔄 /new \\- Start fresh conversation
-❓ /whoami \\- Show your identity
-
-*Media*
-📷 Send images for analysis
-🎤 Send voice for transcription
-
-*Buttons*
-🔄 Reset session
-🔊 Read aloud \\(TTS\\)
-
-_Long\\-press messages to copy_`;
-
 	await ctx.answerCallbackQuery();
-	await ctx.reply(helpText, { parse_mode: "MarkdownV2" });
+	await ctx.reply(formatTelegramHelpOverview());
 }

--- a/tests/commands/sessions.test.ts
+++ b/tests/commands/sessions.test.ts
@@ -6,7 +6,7 @@ vi.mock("../../src/config/sessions.js", () => ({
 	getAllSessions: (...args: unknown[]) => getAllSessionsImpl(...args),
 }));
 
-import { collectSessionRows } from "../../src/commands/sessions.js";
+import { collectSessionRows, formatSessionRows } from "../../src/commands/sessions.js";
 
 describe("collectSessionRows", () => {
 	it("sorts by most recently active and classifies session kinds", () => {
@@ -36,5 +36,24 @@ describe("collectSessionRows", () => {
 		const rows = collectSessionRows({ activeMinutes: 2, limit: 1 });
 		expect(rows).toHaveLength(1);
 		expect(rows[0].key).toBe("tg:1");
+	});
+
+	it("formats a Telegram-friendly session summary", () => {
+		const rows = [
+			{
+				key: "tg:123",
+				kind: "direct" as const,
+				sessionId: "abc",
+				updatedAt: Date.now() - 5_000,
+				ageMs: 5_000,
+				systemSent: true,
+			},
+		];
+
+		const output = formatSessionRows(rows, { limit: 5 });
+		expect(output).toContain("Sessions: 1");
+		expect(output).toContain("Showing up to 5 most recent session(s).");
+		expect(output).toContain("direct tg:123 updated");
+		expect(output).toContain("system prompt sent");
 	});
 });

--- a/tests/telegram/control-commands.test.ts
+++ b/tests/telegram/control-commands.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	formatTelegramHelp,
+	getTelegramMenuCommands,
+	hasTelegramControlCommand,
+	matchTelegramControlCommand,
+	resolveTelegramSystemIntent,
+} from "../../src/telegram/control-commands.js";
+
+describe("telegram control command registry", () => {
+	it("matches canonical commands and aliases", () => {
+		expect(matchTelegramControlCommand("/help")?.command.id).toBe("help");
+		expect(matchTelegramControlCommand("/reset")?.command.id).toBe("new");
+		expect(matchTelegramControlCommand("/reset")?.aliasUsed).toBe("reset");
+	});
+
+	it("supports explicit bot usernames for matching", () => {
+		expect(
+			matchTelegramControlCommand("/status@telclaude_bot", {
+				botUsername: "telclaude_bot",
+			})?.command.id,
+		).toBe("status");
+		expect(
+			matchTelegramControlCommand("/status@other_bot", {
+				botUsername: "telclaude_bot",
+			}),
+		).toBeNull();
+	});
+
+	it("detects known commands for inbound gating", () => {
+		expect(hasTelegramControlCommand("/commands")).toBe(true);
+		expect(hasTelegramControlCommand("/nope")).toBe(false);
+	});
+
+	it("formats topic help for natural-language queries", () => {
+		const help = formatTelegramHelp("reset session");
+
+		expect(help).toContain("Reset Session");
+		expect(help).toContain("/new");
+		expect(help).toContain("/reset");
+	});
+
+	it("maps natural-language system questions to safe handlers", () => {
+		expect(resolveTelegramSystemIntent("who am i linked as?")).toEqual({
+			kind: "command",
+			commandId: "whoami",
+		});
+		expect(resolveTelegramSystemIntent("when is the next heartbeat?")).toEqual({
+			kind: "command",
+			commandId: "cron",
+		});
+		expect(resolveTelegramSystemIntent("how do approvals work?")).toEqual({
+			kind: "help",
+			query: "how do approvals work?",
+		});
+	});
+
+	it("exposes only the safe command menu entries", () => {
+		expect(getTelegramMenuCommands()).toEqual([
+			{ command: "help", description: "Explain commands and topics" },
+			{ command: "commands", description: "List available commands" },
+			{ command: "system", description: "Ask about system state" },
+			{ command: "status", description: "Show runtime status" },
+			{ command: "sessions", description: "Inspect chat sessions" },
+			{ command: "cron", description: "Inspect cron jobs" },
+			{ command: "whoami", description: "Show linked identity" },
+			{ command: "new", description: "Start a fresh session" },
+		]);
+	});
+});

--- a/tests/telegram/control-commands.test.ts
+++ b/tests/telegram/control-commands.test.ts
@@ -26,6 +26,7 @@ describe("telegram control command registry", () => {
 				botUsername: "telclaude_bot",
 			}),
 		).toBeNull();
+		expect(matchTelegramControlCommand("/status@other_bot")).toBeNull();
 	});
 
 	it("detects known commands for inbound gating", () => {


### PR DESCRIPTION
## Summary
- add a shared Telegram command registry that drives dispatch, slash-help, command catalog output, keyboard help, and native Telegram command menu sync
- add read-only sessions, cron, and system-question routing for natural-language system introspection
- add reusable cron and session formatters plus docs and tests for the new command surface

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test -- tests/telegram/control-commands.test.ts tests/commands/sessions.test.ts tests/telegram/auto-reply.test.ts
- TELCLAUDE_DATA_DIR=/tmp/telclaude-test-data pnpm test -- tests/telegram/inbound-normalization.test.ts

## Notes
- Full pnpm test is blocked in this Codex sandbox by EPERM restrictions around the default log file path and localhost listeners; CI should cover the unrestricted run.
