### PR TITLE
fix(deps): add 7-day cooldown to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -28,3 +31,6 @@ updates:
     labels:
       - "ci"
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,6 @@
 # pnpm configuration
 # Disable link-workspace-packages to allow --frozen-lockfile in Docker builds
 link-workspace-packages=false
+
+# Require packages to be at least 7 days old before installing
+min-release-age=7


### PR DESCRIPTION
## Summary
- Add `cooldown` block (7-day default, 14-day semver-major) to both npm and github-actions ecosystem entries
- Add `min-release-age=7` to `.npmrc` for additional release maturity gating
- Security updates (known CVEs) bypass cooldowns automatically

## Test plan
- [ ] Verify dependabot.yml is valid YAML and GitHub parses it correctly
- [ ] Verify .npmrc change doesn't break `pnpm install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)