### PR TITLE
fix(deps): remove inert min-release-age from pnpm .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,3 @@
 # pnpm configuration
 # Disable link-workspace-packages to allow --frozen-lockfile in Docker builds
 link-workspace-packages=false
-
-# Require packages to be at least 7 days old before installing
-min-release-age=7


### PR DESCRIPTION
pnpm doesn't support `min-release-age` (npm-only). Dependabot cooldown is the active protection.