### PR TITLE
feat: add optional HTTP scheme override for vault credentials

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -231,3 +231,27 @@ id = "jwt-token"
 description = "JSON Web Token"
 regex = '''eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*'''
 tags = ["credentials", "jwt"]
+
+# ============================================================================
+# Infrastructure leak detection (private subnet IPs)
+# ============================================================================
+
+[[rules]]
+id = "private-subnet-ip"
+description = "Private/local subnet IP address (infrastructure leak)"
+regex = '''(?:^|[^0-9./])(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})(?::\d{1,5})?(?:[^0-9/]|$)'''
+tags = ["infrastructure", "private-ip"]
+[[rules.allowlists]]
+description = "CIDR constants, example IPs in comments/docs, and security code"
+paths = [
+  '''src/sandbox/''',
+  '''src/config/config\.ts$''',
+  '''src/commands/network\.ts$''',
+  '''docs/''',
+  '''tests/''',
+  '''\.gitleaks\.toml$''',
+  '''CLAUDE\.md$''',
+  '''README\.md$''',
+  '''docker/.*\.example$''',
+  '''docker/init-firewall\.sh$''',
+]

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -129,6 +129,7 @@ export function registerVaultCommand(program: Command): void {
 		.option("--header <header>", "Header name for api-key type (e.g., X-API-Key)")
 		.option("--username <username>", "Username for basic/db/ssh auth")
 		.option("--param <param>", "Query parameter name for query type")
+		.option("--scheme <scheme>", "Upstream URL scheme for HTTP targets (http or https)")
 		.option("--client-id <clientId>", "OAuth2 client ID")
 		.option("--client-secret <clientSecret>", "OAuth2 client secret (will prompt if not provided)")
 		.option("--refresh-token <refreshToken>", "OAuth2 refresh token (will prompt if not provided)")
@@ -150,6 +151,7 @@ export function registerVaultCommand(program: Command): void {
 					header?: string;
 					username?: string;
 					param?: string;
+					scheme?: string;
 					clientId?: string;
 					clientSecret?: string;
 					refreshToken?: string;
@@ -323,6 +325,16 @@ export function registerVaultCommand(program: Command): void {
 
 					// Parse allowed paths
 					const allowedPaths = opts.allowedPaths?.split(",").map((p) => p.trim());
+					const scheme =
+						opts.scheme === undefined
+							? undefined
+							: opts.scheme === "http" || opts.scheme === "https"
+								? opts.scheme
+								: null;
+					if (scheme === null) {
+						console.error("Invalid --scheme value. Valid values: http, https");
+						process.exit(1);
+					}
 
 					// Store the credential
 					const client = getVaultClient();
@@ -331,6 +343,7 @@ export function registerVaultCommand(program: Command): void {
 						target,
 						credential,
 						label: opts.label,
+						scheme: scheme ?? undefined,
 						allowedPaths,
 						rateLimitPerMinute: opts.rateLimit,
 					});

--- a/src/relay/http-credential-proxy.ts
+++ b/src/relay/http-credential-proxy.ts
@@ -8,7 +8,8 @@
  * - Agent calls: http://relay:8792/{host}/{path}
  * - Proxy looks up credential for {host} from vault
  * - Injects authentication (bearer, api-key, basic, oauth2)
- * - Forwards request to https://{host}/{path}
+ * - Forwards request to {scheme}://{host}/{path} (defaults to https unless the
+ *   stored credential overrides it)
  * - Streams response back to agent
  *
  * Examples:
@@ -253,7 +254,8 @@ async function proxyRequest(
 
 	// Build upstream URL
 	const finalQuery = credential.type === "query" ? queryAddition : parsed.query;
-	const upstreamUrl = `https://${parsed.host}${parsed.path}${finalQuery}`;
+	const upstreamScheme = entry.scheme ?? "https";
+	const upstreamUrl = `${upstreamScheme}://${parsed.host}${parsed.path}${finalQuery}`;
 
 	// Build headers for upstream request
 	const upstreamHeaders: Record<string, string> = {

--- a/src/vault-daemon/protocol.ts
+++ b/src/vault-daemon/protocol.ts
@@ -173,6 +173,7 @@ export const CredentialEntrySchema = z.object({
 	target: z.string().min(1), // host or host:port
 	label: z.string().optional(),
 	credential: CredentialSchema,
+	scheme: z.enum(["http", "https"]).optional(), // For HTTP: upstream scheme override
 	allowedPaths: z.array(z.string()).optional(), // For HTTP: path regex allowlist
 	rateLimitPerMinute: z.number().positive().optional(),
 	createdAt: z.string().datetime(),
@@ -212,6 +213,7 @@ export const StoreRequestSchema = z.object({
 	target: z.string().min(1),
 	label: z.string().optional(),
 	credential: CredentialSchema,
+	scheme: z.enum(["http", "https"]).optional(),
 	allowedPaths: z.array(z.string()).optional(),
 	rateLimitPerMinute: z.number().positive().optional(),
 	expiresAt: z.string().datetime().optional(),

--- a/src/vault-daemon/server.ts
+++ b/src/vault-daemon/server.ts
@@ -402,6 +402,7 @@ async function persistRotatedRefreshToken(
 			{ ...currentEntry.credential, refreshToken: newRefreshToken },
 			{
 				label: currentEntry.label,
+				scheme: currentEntry.scheme,
 				allowedPaths: currentEntry.allowedPaths,
 				rateLimitPerMinute: currentEntry.rateLimitPerMinute,
 				expiresAt: currentEntry.expiresAt,
@@ -475,6 +476,7 @@ async function handleRequest(request: VaultRequest, clientId: string): Promise<V
 		case "store": {
 			await store.store(request.protocol, request.target, request.credential, {
 				label: request.label,
+				scheme: request.scheme,
 				allowedPaths: request.allowedPaths,
 				rateLimitPerMinute: request.rateLimitPerMinute,
 				expiresAt: request.expiresAt,

--- a/src/vault-daemon/store.ts
+++ b/src/vault-daemon/store.ts
@@ -145,6 +145,7 @@ export class VaultStore {
 		credential: Credential,
 		options: {
 			label?: string;
+			scheme?: "http" | "https";
 			allowedPaths?: string[];
 			rateLimitPerMinute?: number;
 			expiresAt?: string;
@@ -155,6 +156,7 @@ export class VaultStore {
 			target,
 			credential,
 			label: options.label,
+			scheme: options.scheme,
 			allowedPaths: options.allowedPaths,
 			rateLimitPerMinute: options.rateLimitPerMinute,
 			createdAt: new Date().toISOString(),

--- a/tests/vault-daemon/store.test.ts
+++ b/tests/vault-daemon/store.test.ts
@@ -273,4 +273,21 @@ describe("VaultStore", () => {
 		expect(entry?.allowedPaths).toEqual(["^/v1/safe/.*", "^/v2/also-safe/.*"]);
 		expect(entry?.rateLimitPerMinute).toBe(60);
 	});
+
+	it("should round-trip the optional scheme override", async () => {
+		const store = new VaultStore({
+			filePath: TEST_FILE,
+			encryptionKey: TEST_KEY,
+		});
+
+		await store.store(
+			"http",
+			"local-service.lan:8080",
+			{ type: "query", param: "apikey", token: "test-token" },
+			{ scheme: "http" },
+		);
+
+		const entry = await store.get("http", "local-service.lan:8080");
+		expect(entry?.scheme).toBe("http");
+	});
 });


### PR DESCRIPTION
## Summary
- Adds an optional `scheme` field (`"http" | "https"`) to vault credential entries, defaulting to `"https"`. This allows the HTTP credential proxy to forward requests over plain HTTP for local services (e.g., LAN APIs that don't support TLS).
- Adds a gitleaks `private-subnet-ip` rule to catch accidental commits of RFC1918 infrastructure IPs in source files.

## Changes
- **`src/vault-daemon/protocol.ts`** — `scheme` field on `CredentialEntrySchema` and `StoreRequestSchema`
- **`src/vault-daemon/store.ts`** — pass `scheme` through store options
- **`src/vault-daemon/server.ts`** — preserve `scheme` on token rotation and store requests
- **`src/commands/vault.ts`** — `--scheme` CLI flag with validation
- **`src/relay/http-credential-proxy.ts`** — use `entry.scheme ?? "https"` for upstream URL + updated header comment
- **`tests/vault-daemon/store.test.ts`** — round-trip test for scheme override
- **`.gitleaks.toml`** — new `private-subnet-ip` rule with allowlisted paths

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 804/804 tests pass (includes new scheme round-trip test)
- [x] gitleaks rule verified: catches real infra IPs, allowlists are clean
- [x] Live-validated on NUC: proxy successfully forwards `http://` requests to local SABnzbd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Codex <noreply@openai.com>