### PR TITLE
fix(proxy): accept v3 session tokens in HTTP credential proxy

### DIFF
--- a/src/relay/http-credential-proxy.ts
+++ b/src/relay/http-credential-proxy.ts
@@ -33,9 +33,10 @@ import {
 	type HttpCredential,
 	type OAuth2Credential,
 } from "../vault-daemon/index.js";
-import { type SessionTokenPayload, validateSessionToken } from "./git-proxy-auth.js";
+import { type SessionTokenPayload, validateSessionTokenV3 } from "./git-proxy-auth.js";
 import { forwardResponseHeaders } from "./proxy-headers.js";
 import { SlidingWindowRateLimiter } from "./shared-rate-limiter.js";
+import { getPublicKey } from "./token-manager.js";
 
 const logger = getChildLogger({ module: "http-credential-proxy" });
 
@@ -464,7 +465,7 @@ export function startHttpCredentialProxy(
 				return;
 			}
 
-			const validated = validateSessionToken(sessionHeader);
+			const validated = validateSessionTokenV3(sessionHeader, getPublicKey());
 			if (!validated) {
 				logger.warn({ url }, "http proxy request with invalid session token");
 				res.writeHead(401, { "Content-Type": "text/plain" });


### PR DESCRIPTION
## Summary

- The HTTP credential proxy was using legacy-only `validateSessionToken()` while agent subprocesses receive v3 Ed25519 tokens, causing 401s when agents tried to use the proxy
- Switch to `validateSessionTokenV3()` with `getPublicKey()`, matching the existing git proxy pattern (git-proxy.ts:289)
- Legacy HMAC fallback preserved — v3 tokens that fail validation do NOT fall through to HMAC (prevents downgrade attacks)

## Security review

- Codex review: approved, no findings
- Sentry security-review skill: PASS
- OpenAI threat-model skill: modeled full agent→proxy→SABnzbd chain, no blocking findings on this change

## Test plan

- [x] `tsc --noEmit` passes
- [x] Codex code review
- [x] Security review (Sentry skill)
- [x] Threat model (OpenAI skill)
- [ ] Deploy to NUC and verify agent can reach credential proxy with v3 token

🤖 Generated with [Claude Code](https://claude.com/claude-code)