### PR TITLE
[codex] retire native runtime support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 - **PreToolUse hooks**: PRIMARY enforcement; run unconditionally, even in acceptEdits mode.
 - **canUseTool**: FALLBACK only; runs only when a permission prompt would appear (so not for auto-approved calls in acceptEdits mode).
 - **Skill allowlisting**: SOCIAL tier requires explicit `allowedSkills` when `enableSkills` is true; omitting fail-closes (denies all Skill calls). Non-SOCIAL tiers are unaffected. Enforced by PreToolUse hook (primary) + canUseTool (fallback).
-- Network: PreToolUse hook blocks RFC1918/metadata (including CGNAT 100.64.0.0/10 for Tailscale); Bash uses SDK sandbox (native) or Docker firewall; WebSearch not filtered (server-side). `TELCLAUDE_NETWORK_MODE=open|permissive` broadens WebFetch egress.
+- Network: PreToolUse hook blocks RFC1918/metadata (including CGNAT 100.64.0.0/10 for Tailscale); supported runtime uses the Docker firewall as the network boundary; WebSearch not filtered (server-side). `TELCLAUDE_NETWORK_MODE=open|permissive` broadens WebFetch egress.
 - Profiles: simple (default, rate limits + audit), strict (+observer + approvals + tier enforcement), test (all disabled, requires `TELCLAUDE_ENABLE_TEST_PROFILE=1`).
 
 ## SDK References (authoritative)
@@ -36,7 +36,7 @@
   - Deprecated: `decision: "block"` (maps to `permissionDecision: "deny"`)
 - **Sandboxing**: https://www.anthropic.com/engineering/claude-code-sandboxing
   - "Effective sandboxing requires both filesystem and network isolation"
-  - ONE isolation boundary recommended (Docker container OR SDK sandbox, not both)
+  - ONE isolation boundary recommended. Telclaude's supported runtime uses Docker container isolation; native/non-Docker deployment is retired.
 
 ## Workflow
 1) Plan → propose files to touch.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Isolation-first Telegram ⇄ Claude Code relay with LLM pre-screening, approvals
 > **Alpha** — Security-first defaults; expect breaking changes until 1.0.
 
 ## Highlights
-- Mandatory isolation boundary: SDK sandbox (Seatbelt/bubblewrap) in native mode, relay+agent containers + firewall in Docker mode.
+- Mandatory isolation boundary: relay+agent containers + firewall in Docker mode.
 - Credential vault: sidecar daemon stores API keys and injects them into requests — agents never see raw credentials.
 - Hard defaults: secret redaction (CORE patterns + entropy), rate limits, audit log, and fail-closed chat allowlist.
 - Soft controls: Haiku observer, nonce-based approval workflow for FULL_ACCESS, and optional TOTP auth gate for periodic identity verification.
@@ -18,7 +18,7 @@ Isolation-first Telegram ⇄ Claude Code relay with LLM pre-screening, approvals
 - Generic social services integration (X/Twitter, Moltbook, Bluesky, etc.) via config-driven `SOCIAL` agent context with unified social persona.
 - External provider sidecars: Google Services (Gmail, Calendar, Drive, Contacts) with approval-gated actions; extensible pattern for adding new providers.
 - Private network allowlist for homelab services (Home Assistant, NAS, etc.) with port enforcement.
-- Runs locally on macOS/Linux or via the Docker Compose stack (Windows through WSL2).
+- Runs via the Docker Compose stack (Windows through WSL2).
 - No telemetry or analytics; only audit logs you enable in your own environment.
 
 ## Documentation map
@@ -37,7 +37,7 @@ Isolation-first Telegram ⇄ Claude Code relay with LLM pre-screening, approvals
 
 ## Support & cadence
 - Status: alpha — breaking changes possible until 1.0.
-- Platforms: native mode on macOS 14+ or Linux (bubblewrap+socat+rg); Docker/WSL recommended for prod.
+- Platforms: Docker Compose on Linux/macOS (Windows through WSL2). Native/non-Docker deployment is retired.
 - Issues/PR triage: weekly; security reports acknowledged within 48h.
 - Releases: ad-hoc during alpha; aim for monthly.
 - Security contact: project maintainer(s) via GitHub security advisory.
@@ -73,9 +73,8 @@ Isolation-first Telegram ⇄ Claude Code relay with LLM pre-screening, approvals
                                │
                                ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│            Isolation Boundary (mode-dependent)                   │
-│   Docker: relay+agent + firewall  │  Native: SDK sandbox         │
-│          (SDK sandbox off)        │  (Seatbelt/bwrap)            │
+│                Isolation Boundary                               │
+│     Docker: relay+agent + firewall (SDK sandbox off)           │
 └──────────────────────────────────────────────────────────────────┘
                                │
                                ▼
@@ -92,8 +91,7 @@ Isolation-first Telegram ⇄ Claude Code relay with LLM pre-screening, approvals
 - Node 20+, pnpm 9.x
 - Claude CLI (`brew install anthropic-ai/cli/claude`) — recommended. In Docker, telclaude routes Anthropic access through the relay proxy; if you use OAuth, run `claude login` in the relay container with `CLAUDE_CONFIG_DIR=/home/telclaude-auth` so tokens live in the dedicated auth profile.
 - Telegram bot token from @BotFather
-- Native mode: macOS 14+ or Linux with `bubblewrap`, `socat`, and `ripgrep` available on PATH
-- Docker/WSL: Docker + Compose (no host bubblewrap required)
+- Docker/WSL: Docker + Compose
 - Optional but recommended: TOTP daemon uses the OS keychain (keytar)
 
 ## Third-party terms
@@ -114,58 +112,7 @@ This starts 6 containers: `telclaude` (relay), `telclaude-agent` (private person
 
 Note: Docker uses a shared **skills** profile (`/home/telclaude-skills`) and a relay-only **auth** profile (`/home/telclaude-auth`). Agents access Anthropic through the relay proxy; credentials never mount in agent containers.
 
-## Quick start (local)
-1) Clone and install
-```bash
-git clone https://github.com/avivsinai/telclaude.git
-cd telclaude
-pnpm install
-```
-2) Create config (JSON5) at `~/.telclaude/telclaude.json` — allowlist is required or the bot will ignore all chats (fail-closed).
-```json
-{
-  "telegram": {
-    "botToken": "123456:ABC-DEF",
-    "allowedChats": [123456789]      // your Telegram numeric chat ID
-  },
-  "security": {
-    "profile": "strict",             // simple | strict | test
-    "permissions": {
-      "users": {
-        "tg:123456789": { "tier": "FULL_ACCESS" }
-      }
-    }
-  }
-}
-```
-Notes: `defaultTier=FULL_ACCESS` is intentionally rejected at runtime. Prefer putting `botToken` in the config for native installs; `TELEGRAM_BOT_TOKEN` is accepted (mainly for Docker).
-
-3) Authenticate Claude
-```bash
-claude login             # API key is not forwarded into sandboxed agent
-```
-
-4) (Recommended) Start TOTP daemon in another terminal
-```bash
-pnpm dev totp-daemon
-```
-
-5) Health check
-```bash
-pnpm dev doctor --network --secrets
-```
-
-6) Run the relay
-```bash
-# Development (native: SDK sandbox via @anthropic-ai/sandbox-runtime; if unavailable, use Docker below)
-pnpm dev relay --profile simple
-
-# Recommended / Production: Docker or WSL with container boundary + firewall
-docker compose up -d --build
-docker compose exec telclaude pnpm start relay --profile strict
-```
-
-7) First admin claim
+## First admin claim
 - DM your bot from the allowed chat; it replies with `/approve <code>`.
 - Send that command back to link the chat as admin (FULL_ACCESS with per-request approvals).
 - In the same chat, run `/auth setup` to bind TOTP for periodic identity verification (daemon must be running). `/auth skip` is allowed but not recommended.
@@ -192,11 +139,10 @@ docker compose exec telclaude pnpm start relay --profile strict
   - Set per-user under `security.permissions.users`; `defaultTier` stays `READ_ONLY`.
 - Optional group guardrail:
   - `telegram.groupChat.requireMention: true` to ignore group/supergroup messages unless they mention the bot or reply to it.
-- OpenAI/GitHub key exposure (tier-based):
-  - FULL_ACCESS tier automatically gets configured API keys (OpenAI, GitHub) exposed to sandbox.
-  - READ_ONLY and WRITE_LOCAL tiers never get keys.
-  - Configure keys via `telclaude setup-openai` / `telclaude setup-git` or env vars.
-  - **Security note:** keys are exposed to the model in FULL_ACCESS; use restricted keys if concerned.
+- OpenAI/GitHub access:
+  - Supported Docker deployments do not inject raw OpenAI or GitHub keys into the agent sandbox.
+  - FULL_ACCESS reaches external services through relay-managed proxies and session-scoped relay auth.
+  - Configure provider credentials on the relay side via `telclaude setup-openai` / `telclaude setup-git`, env vars, or the vault daemon.
 - Rate limits and audit logging are on by default; see `CLAUDE.md` for full schema and options.
 
 ## Credential vault
@@ -209,7 +155,7 @@ The vault daemon stores API credentials and injects them into HTTP requests tran
 3. Proxy looks up credentials by host, injects auth headers, forwards to upstream
 4. Agent receives response without ever seeing the API key
 
-**Note:** The HTTP credential proxy is only started when a remote agent is configured (`TELCLAUDE_AGENT_URL`). Native mode uses direct key exposure for FULL_ACCESS tier instead (see Configuration section).
+**Note:** The HTTP credential proxy is only started when a remote agent is configured (`TELCLAUDE_AGENT_URL`). Native/non-Docker deployment is unsupported.
 
 **Supported auth types:** `bearer`, `api-key`, `basic`, `query`, `oauth2` (with automatic token refresh)
 
@@ -352,18 +298,17 @@ Optional: `/v1/challenge/respond` (POST) for OTP/2FA completion.
 ## Usage example
 Run strict profile with approvals and TOTP:
 ```bash
-pnpm dev totp-daemon &
-pnpm dev relay --profile strict
+docker compose up -d --build
 # In Telegram (allowed chat):
 # 1) bot replies with /approve CODE for admin claim
 # 2) run /auth setup to bind TOTP
 ```
 
-Use `pnpm dev <command>` during development (tsx). For production: `pnpm build && pnpm start <command>` (runs from `dist/`).
+Use `docker compose exec telclaude pnpm start <command>` for runtime commands inside the supported deployment. Host-side `pnpm dev <command>` remains useful for lint/test/build tooling, not for running the service stack natively.
 
 ## Deployment
 - **Production (mandatory): Docker/WSL Compose stack** (`docker/README.md`). Relay+agent containers + firewall; SDK sandbox disabled in Docker mode. Use this on shared or multi-tenant hosts.
-- **Development:** Native macOS/Linux with SDK sandbox (Seatbelt/bubblewrap). SDK sandbox provides OS-level isolation for Bash; WebFetch/WebSearch are filtered by hooks/allowlists. Keep `~/.telclaude/telclaude.json` chmod 600.
+- **Development/runtime:** Docker/WSL Compose stack only. Native/non-Docker runtime is retired.
 
 ## Development
 - Lint/format: `pnpm lint`, `pnpm format`
@@ -375,7 +320,7 @@ Use `pnpm dev <command>` during development (tsx). For production: `pnpm build &
 
 ## Security & reporting
 - Default stance is fail-closed (empty `allowedChats` denies all; `defaultTier=FULL_ACCESS` is rejected).
-- Native mode requires the SDK sandbox; relay exits if Seatbelt/bubblewrap (or socat on Linux) is unavailable. Docker mode requires the firewall (containers enforce it).
+- Docker mode requires the firewall (containers enforce it). Native/non-Docker runtime is unsupported.
 - Vulnerabilities: please follow `SECURITY.md` for coordinated disclosure.
 - Security contact: project maintainer(s) via GitHub security advisory.
 
@@ -383,7 +328,7 @@ Use `pnpm dev <command>` during development (tsx). For production: `pnpm build &
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | Bot silent/denied | `allowedChats` empty or rate limit hit | Add your chat ID and rerun; check audit/doctor |
-| Sandbox unavailable (native) | seatbelt/bubblewrap/rg/socat missing | Install deps (see Requirements section above) |
+| Sandbox unavailable | Service started outside the supported Docker runtime | Run telclaude inside the Docker Compose stack |
 | TOTP fails | Daemon not running or clock drift | Start `pnpm dev totp-daemon`; sync device time |
 | SDK/observer errors | Claude CLI missing or not logged in | `brew install anthropic-ai/cli/claude && claude login` (Docker: `docker compose exec -e CLAUDE_CONFIG_DIR=/home/telclaude-auth telclaude claude login`) |
 | Vault not injecting | Daemon not running or host not configured | Start `telclaude vault-daemon`; check `vault list` |

--- a/docker/README.md
+++ b/docker/README.md
@@ -389,11 +389,11 @@ This bypass is logged to the audit log.
 
 ## Troubleshooting
 
-### "Sandbox unavailable" (native mode only)
+### "Sandbox unavailable"
 
-Docker mode disables the SDK sandbox, so this error should not appear inside the container.
-If you see it, you are likely running native mode outside Docker. On Linux, install
-`bubblewrap` and `socat` and retry.
+The supported runtime is Docker-only, and Docker mode disables the SDK sandbox.
+If you see this error, you are likely starting telclaude outside the Compose stack.
+Run it inside Docker instead of trying to repair a native setup.
 
 ### "Permission denied" on workspace
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ The relay is the security boundary — it holds all secrets, enforces tiers/rate
 
 The relay and agents are separate trust domains. The relay is the only component with access to secrets (API keys, Telegram token, OAuth credentials). Agents are treated as potentially compromised — they can only act through tiered tool access and relay-proxied API calls. This means a prompt injection that compromises the agent cannot exfiltrate secrets or escalate privileges beyond the user's tier.
 
-In Docker, this maps to separate containers on isolated networks. In native mode, the SDK sandbox provides equivalent isolation. Both modes enforce the same invariant: agents never see raw credentials.
+In the supported runtime, this maps to separate containers on isolated networks. Native/non-Docker deployment is retired. The invariant stays the same: agents never see raw credentials.
 
 ### Private ↔ Public Persona Split
 

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -4,10 +4,7 @@ import { withTimeout } from "../infra/timeout.js";
 import { buildInternalAuthHeaders, type InternalAuthScope } from "../internal-auth.js";
 import { getChildLogger } from "../logging.js";
 import { issueToken, isTokenManagerActive } from "../relay/token-manager.js";
-import { isDockerEnvironment } from "../sandbox/mode.js";
-import type { ExposedCredentials, PooledQueryOptions, StreamChunk } from "../sdk/client.js";
-import { getGitCredentials } from "../services/git-credentials.js";
-import { getOpenAIKey } from "../services/openai-client.js";
+import type { PooledQueryOptions, StreamChunk } from "../sdk/client.js";
 import { stripTrailingSlash } from "../utils.js";
 
 const logger = getChildLogger({ module: "agent-client" });
@@ -63,37 +60,6 @@ export async function* executeRemoteQuery(
 				// Best-effort; agent falls back to static auth if available
 			}
 		}
-		// Native/dev fallback only: Docker deployments must keep raw credentials inside
-		// the relay and route via the git proxy / HTTP credential proxy instead.
-		// Gate on scope to prevent credential leakage to social agents — the agent server
-		// downgrades non-telegram scopes to SOCIAL tier, but that happens AFTER this payload
-		// is serialized. Credentials must never enter a social agent container.
-		const effectiveScope = options.scope ?? "telegram";
-		let exposedCredentials: ExposedCredentials | undefined;
-		if (!isDockerEnvironment() && options.tier === "FULL_ACCESS" && effectiveScope === "telegram") {
-			const creds: ExposedCredentials = {};
-			try {
-				const gitCreds = await getGitCredentials();
-				if (gitCreds?.token) {
-					creds.githubToken = gitCreds.token;
-				}
-			} catch {
-				// Best-effort; agent falls back to env vars
-			}
-			try {
-				const openaiKey = await getOpenAIKey();
-				// Don't inject the credential-proxy sentinel — only real keys
-				if (openaiKey && openaiKey !== "credential-proxy") {
-					creds.openaiApiKey = openaiKey;
-				}
-			} catch {
-				// Best-effort; agent uses credential proxy for OpenAI
-			}
-			if (creds.githubToken || creds.openaiApiKey) {
-				exposedCredentials = creds;
-			}
-		}
-
 		const payload = JSON.stringify({
 			prompt,
 			cwd: options.cwd,
@@ -108,7 +74,6 @@ export async function* executeRemoteQuery(
 			systemPromptAppend: options.systemPromptAppend,
 			sessionToken,
 			outputFormat: options.outputFormat,
-			exposedCredentials,
 		});
 		const endpoint = `${stripTrailingSlash(agentUrl)}${path}`;
 		const scope = options.scope ?? "telegram";

--- a/src/agent/server.ts
+++ b/src/agent/server.ts
@@ -8,7 +8,6 @@ import { verifyInternalAuth } from "../internal-auth.js";
 import { getChildLogger } from "../logging.js";
 import { getCachedProviderSummary } from "../providers/provider-skill.js";
 import { getSandboxMode } from "../sandbox/index.js";
-import type { ExposedCredentials } from "../sdk/client.js";
 import { executePooledQuery, type StreamChunk } from "../sdk/client.js";
 import { loadSocialContractPrompt } from "../social-contract.js";
 import { loadSoul } from "../soul.js";
@@ -41,8 +40,6 @@ type QueryRequest = {
 	sessionToken?: string;
 	/** Structured output format (JSON Schema). Agent returns validated data instead of free-form text. */
 	outputFormat?: OutputFormat;
-	/** Relay-resolved credentials for tier-based key exposure (Docker mode). */
-	exposedCredentials?: ExposedCredentials;
 };
 
 type AgentServerOptions = {
@@ -170,7 +167,6 @@ async function streamQuery(
 			betas: req.betas,
 			systemPromptAppend: req.systemPromptAppend,
 			outputFormat: req.outputFormat,
-			exposedCredentials: req.exposedCredentials,
 		})) {
 			if (!firstChunkReceived) {
 				firstChunkReceived = true;
@@ -291,13 +287,6 @@ export function startAgentServer(options: AgentServerOptions = {}): http.Server 
 					effectiveTier = "SOCIAL";
 					if (!effectiveUserId?.startsWith(`${scope}:`)) {
 						effectiveUserId = `${scope}:${effectiveUserId ?? "agent"}`;
-					}
-					// Defense-in-depth: strip credentials from social scopes.
-					// The relay should never send them for non-telegram scopes, but
-					// if it does, drop them here before they reach buildSdkOptions().
-					if (parsed.exposedCredentials) {
-						logger.warn({ scope }, "stripping exposedCredentials from social scope request");
-						parsed.exposedCredentials = undefined;
 					}
 				}
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -10,7 +10,7 @@ import {
 	writeProviderSchemaFromRelay,
 } from "../providers/provider-skill.js";
 import { relayGetProviders } from "../relay/capabilities-client.js";
-import { getSandboxMode } from "../sandbox/index.js";
+import { assertDockerRuntime } from "../sandbox/index.js";
 import { buildRuntimeSnapshot } from "../system-metadata.js";
 import { runDaemon } from "./cli-utils.js";
 
@@ -24,6 +24,7 @@ export function registerAgentCommand(program: Command): void {
 		.option("--host <host>", "Host to bind the agent server")
 		.action(async (opts: { port?: string; host?: string }) => {
 			installUnhandledRejectionHandler("agent");
+			assertDockerRuntime("telclaude agent");
 
 			const port = opts.port ? Number.parseInt(opts.port, 10) : undefined;
 			const host = opts.host;
@@ -31,47 +32,43 @@ export function registerAgentCommand(program: Command): void {
 				process.env.SOCIAL_RPC_RELAY_PUBLIC_KEY || process.env.SOCIAL_RPC_AGENT_PRIVATE_KEY,
 			);
 
-			if (getSandboxMode() === "docker") {
-				if (process.env.TELCLAUDE_FIREWALL !== "1") {
-					if (isSocialAgent) {
-						console.error("\n❌ SECURITY ERROR: Social agent requires firewall.\n");
-						console.error("Social agents run untrusted inputs and must be isolated.");
-						console.error("Set TELCLAUDE_FIREWALL=1 and ensure init-firewall.sh succeeds.\n");
-						process.exit(1);
-					}
-					if (process.env.TELCLAUDE_ACCEPT_NO_FIREWALL === "1") {
-						logger.warn("TELCLAUDE_FIREWALL not enabled - agent tools have NO network isolation");
-					} else {
-						console.error("\n❌ SECURITY ERROR: Docker mode requires network firewall.\n");
-						console.error("The agent runs tools without the SDK sandbox in Docker mode.");
-						console.error("Without TELCLAUDE_FIREWALL=1, Bash can reach arbitrary endpoints.\n");
-						console.error("To fix:");
-						console.error("  - Set TELCLAUDE_FIREWALL=1 in your docker/.env file");
-						console.error("  - Ensure init-firewall.sh runs (requires NET_ADMIN capability)\n");
-						console.error("To bypass (TESTING ONLY - NOT FOR PRODUCTION):");
-						console.error("  - Set TELCLAUDE_ACCEPT_NO_FIREWALL=1\n");
-						process.exit(1);
-					}
-				} else {
-					const sentinelPath = "/run/telclaude/firewall-active";
-					if (!fsSync.existsSync(sentinelPath)) {
-						console.error("\n❌ SECURITY ERROR: Firewall enabled but not verified.\n");
-						console.error(
-							"TELCLAUDE_FIREWALL=1 is set, but the firewall sentinel file is missing.",
-						);
-						console.error(`Expected: ${sentinelPath}\n`);
-						console.error("This means init-firewall.sh failed or didn't run.");
-						console.error("Possible causes:");
-						console.error("  - Container missing --cap-add=NET_ADMIN capability");
-						console.error("  - iptables not available in container");
-						console.error("  - init-firewall.sh not executed at container start\n");
-						console.error("To fix:");
-						console.error("  - Ensure docker-compose.yml has cap_add: [NET_ADMIN]");
-						console.error("  - Check container logs for firewall setup errors\n");
-						process.exit(1);
-					}
-					logger.info("Firewall: verified (sentinel file present)");
+			if (process.env.TELCLAUDE_FIREWALL !== "1") {
+				if (isSocialAgent) {
+					console.error("\n❌ SECURITY ERROR: Social agent requires firewall.\n");
+					console.error("Social agents run untrusted inputs and must be isolated.");
+					console.error("Set TELCLAUDE_FIREWALL=1 and ensure init-firewall.sh succeeds.\n");
+					process.exit(1);
 				}
+				if (process.env.TELCLAUDE_ACCEPT_NO_FIREWALL === "1") {
+					logger.warn("TELCLAUDE_FIREWALL not enabled - agent tools have NO network isolation");
+				} else {
+					console.error("\n❌ SECURITY ERROR: Docker mode requires network firewall.\n");
+					console.error("The agent runs tools without the SDK sandbox in Docker mode.");
+					console.error("Without TELCLAUDE_FIREWALL=1, Bash can reach arbitrary endpoints.\n");
+					console.error("To fix:");
+					console.error("  - Set TELCLAUDE_FIREWALL=1 in your docker/.env file");
+					console.error("  - Ensure init-firewall.sh runs (requires NET_ADMIN capability)\n");
+					console.error("To bypass (TESTING ONLY - NOT FOR PRODUCTION):");
+					console.error("  - Set TELCLAUDE_ACCEPT_NO_FIREWALL=1\n");
+					process.exit(1);
+				}
+			} else {
+				const sentinelPath = "/run/telclaude/firewall-active";
+				if (!fsSync.existsSync(sentinelPath)) {
+					console.error("\n❌ SECURITY ERROR: Firewall enabled but not verified.\n");
+					console.error("TELCLAUDE_FIREWALL=1 is set, but the firewall sentinel file is missing.");
+					console.error(`Expected: ${sentinelPath}\n`);
+					console.error("This means init-firewall.sh failed or didn't run.");
+					console.error("Possible causes:");
+					console.error("  - Container missing --cap-add=NET_ADMIN capability");
+					console.error("  - iptables not available in container");
+					console.error("  - init-firewall.sh not executed at container start\n");
+					console.error("To fix:");
+					console.error("  - Ensure docker-compose.yml has cap_add: [NET_ADMIN]");
+					console.error("  - Check container logs for firewall setup errors\n");
+					process.exit(1);
+				}
+				logger.info("Firewall: verified (sentinel file present)");
 			}
 
 			startAgentServer({

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -9,11 +9,9 @@ import {
 	buildAllowedDomainNames,
 	buildAllowedDomains,
 	DEFAULT_NETWORK_CONFIG,
+	getDockerRuntimeRequirementMessage,
 	getNetworkIsolationSummary,
 	getSandboxMode,
-	getSandboxRuntimeVersion,
-	isSandboxRuntimeAtLeast,
-	MIN_SANDBOX_RUNTIME_VERSION,
 	runNetworkSelfTest,
 } from "../sandbox/index.js";
 import { CORE_SECRET_PATTERNS, filterOutput, redactSecrets } from "../security/index.js";
@@ -114,10 +112,6 @@ export function registerDoctorCommand(program: Command): void {
 					// TOTP daemon check
 					const totpDaemonAvailable = await isTOTPDaemonAvailable();
 
-					// Sandbox runtime version (CVE guardrail)
-					const sandboxRuntimeVersion = getSandboxRuntimeVersion();
-					const sandboxRuntimePatched = isSandboxRuntimeAtLeast();
-
 					// Load config for profile info
 					const cfg = loadConfig();
 					const profile = cfg.security?.profile ?? "simple";
@@ -160,7 +154,7 @@ export function registerDoctorCommand(program: Command): void {
 					const sandboxDesc =
 						sandboxMode === "docker"
 							? "Docker container (SDK sandbox disabled)"
-							: "SDK sandbox (bubblewrap/Seatbelt)";
+							: "unsupported non-Docker runtime";
 					console.log(`   1. Filesystem isolation: ✓ ${sandboxDesc}`);
 					console.log("   2. Environment isolation: ✓ minimal env vars passed to sandbox");
 
@@ -194,21 +188,11 @@ export function registerDoctorCommand(program: Command): void {
 
 					// Sandbox details
 					console.log("\n📦 Sandbox");
-					console.log(`   Mode: ${sandboxMode === "docker" ? "Docker" : "Native"}`);
+					console.log(`   Mode: ${sandboxMode === "docker" ? "Docker" : "Native (unsupported)"}`);
 					if (sandboxMode === "docker") {
 						console.log("   SDK sandbox: disabled (container provides isolation)");
 					} else {
-						console.log("   SDK sandbox: enabled (bubblewrap/Seatbelt)");
-						console.log(
-							`   Runtime: ${sandboxRuntimeVersion ?? "not found"}${
-								sandboxRuntimeVersion ? "" : " (install via package manager)"
-							}`,
-						);
-						if (sandboxRuntimeVersion && !sandboxRuntimePatched) {
-							console.log(
-								`   ⚠️  Upgrade @anthropic-ai/sandbox-runtime to >= ${MIN_SANDBOX_RUNTIME_VERSION} (fixes CVE-2025-66479)`,
-							);
-						}
+						console.log(`   ${getDockerRuntimeRequirementMessage("Telclaude")}`);
 					}
 
 					// TOTP details
@@ -223,9 +207,8 @@ export function registerDoctorCommand(program: Command): void {
 					const issues: string[] = [];
 					if (!loggedIn) issues.push("Claude not logged in");
 					if (!totpDaemonAvailable) issues.push("TOTP daemon not running");
-					// In native mode, missing sandbox runtime is a critical issue
-					if (sandboxMode === "native" && !sandboxRuntimeVersion) {
-						issues.push("SDK sandbox runtime not found (required for native mode)");
+					if (sandboxMode !== "docker") {
+						issues.push("Native/non-Docker runtime is unsupported");
 					}
 
 					if (issues.length === 0) {
@@ -240,8 +223,7 @@ export function registerDoctorCommand(program: Command): void {
 					if (!loggedIn) {
 						process.exitCode = 1;
 					}
-					// Missing sandbox runtime in native mode should also set exit code
-					if (sandboxMode === "native" && !sandboxRuntimeVersion) {
+					if (sandboxMode !== "docker") {
 						process.exitCode = 1;
 					}
 

--- a/src/commands/integration-test.ts
+++ b/src/commands/integration-test.ts
@@ -1,9 +1,10 @@
 /**
  * Integration test command for testing the full SDK path.
  *
- * This command runs queries through the actual Claude SDK, testing:
- * - SDK sandbox initialization (native mode)
- * - Network proxy setup by SDK
+ * This command runs queries through the actual Claude SDK inside the supported
+ * Docker runtime, testing:
+ * - Agent/relay SDK execution
+ * - Docker runtime wiring
  * - Skill execution (image-generator, etc.)
  *
  * This allows testing without Telegram/auth overhead.
@@ -17,6 +18,7 @@ import type { Command } from "commander";
 import { executeRemoteQuery } from "../agent/client.js";
 import type { PermissionTier } from "../config/config.js";
 import { getMediaOutboxDirSync } from "../media/store.js";
+import { assertDockerRuntime } from "../sandbox/index.js";
 import { executeQueryStream } from "../sdk/client.js";
 import { getOpenAIKey } from "../services/openai-client.js";
 
@@ -32,20 +34,25 @@ type IntegrationTestOptions = {
 	timeout?: string;
 };
 
+const LOCAL_INTEGRATION_CWD = "/tmp/telclaude-integration";
+let integrationQueryCounter = 0;
+
 export function registerIntegrationTestCommand(program: Command): void {
 	program
 		.command("integration-test")
-		.description("Test full SDK path (sandbox, network proxy, skills)")
+		.description("Test the supported Docker SDK path (agent, relay, and skills)")
 		.option("--image", "Test image generation through SDK")
 		.option("--echo", "Test simple echo command through SDK")
-		.option("--env", "Test environment variable passing through SDK")
-		.option("--network", "Test sandbox network proxy configuration")
+		.option("--env", "Test Docker runtime env contract through SDK")
+		.option("--network", "Test Docker runtime wiring through SDK")
 		.option("--voice", "Test voice message response (TTS skill)")
 		.option("--agents", "Test direct agent transport (real agent, no Telegram)")
 		.option("--all", "Run all integration tests")
 		.option("-v, --verbose", "Show detailed output")
 		.option("--timeout <ms>", "Query timeout in ms", "120000")
 		.action(async (opts: IntegrationTestOptions) => {
+			assertDockerRuntime("telclaude integration-test");
+
 			const verbose = program.opts().verbose || opts.verbose;
 			const timeoutMs = Number.parseInt(opts.timeout ?? "120000", 10);
 
@@ -61,9 +68,6 @@ export function registerIntegrationTestCommand(program: Command): void {
 
 			console.log(chalk.bold("\n🔬 Telclaude Integration Test\n"));
 			console.log("This tests the full SDK path (not just sandbox config).\n");
-
-			// SDK handles sandbox initialization internally when sandbox.enabled=true
-			// No need to pre-check - SDK will fail with clear error if unavailable
 
 			const results: { name: string; passed: boolean; message: string; duration?: number }[] = [];
 
@@ -83,7 +87,7 @@ export function registerIntegrationTestCommand(program: Command): void {
 			}
 
 			if (runNetwork) {
-				console.log(chalk.bold("── Network Proxy Test ──"));
+				console.log(chalk.bold("── Runtime Wiring Test ──"));
 				const result = await testNetworkProxy(verbose, timeoutMs);
 				results.push(result);
 				console.log();
@@ -93,23 +97,16 @@ export function registerIntegrationTestCommand(program: Command): void {
 				console.log(chalk.bold("── Image Generation Test ──"));
 				const hasKey = await getOpenAIKey();
 				if (!hasKey) {
-					console.log(chalk.yellow("  ○ Skipped (OPENAI_API_KEY not configured)"));
+					console.log(chalk.yellow("  ○ Skipped (OpenAI/image generation not configured)"));
 					results.push({
 						name: "Image generation",
 						passed: true,
-						message: "Skipped (no API key)",
+						message: "Skipped (image generation not configured)",
 					});
 				} else {
-					// Note: Image generation through SDK sandbox may fail locally because:
-					// - The telclaude CLI inside sandbox can't access ~/.telclaude (blocked)
-					// - However, OPENAI_API_KEY is injected via env var by buildSdkOptions() (FULL_ACCESS tier)
-					// - In Docker, this works because the key comes from env var, not keychain
 					if (verbose) {
-						console.log(chalk.gray("  Note: Testing image generation through SDK sandbox..."));
 						console.log(
-							chalk.gray(
-								"  The SDK should inject OPENAI_API_KEY into the environment (FULL_ACCESS).",
-							),
+							chalk.gray("  Note: Testing the supported telclaude image-generation path..."),
 						);
 					}
 					const result = await testImageGeneration(verbose, timeoutMs);
@@ -122,11 +119,11 @@ export function registerIntegrationTestCommand(program: Command): void {
 				console.log(chalk.bold("── Voice Message Response Test ──"));
 				const hasKey = await getOpenAIKey();
 				if (!hasKey) {
-					console.log(chalk.yellow("  ○ Skipped (OPENAI_API_KEY not configured)"));
+					console.log(chalk.yellow("  ○ Skipped (OpenAI/TTS not configured)"));
 					results.push({
 						name: "Voice message response",
 						passed: true,
-						message: "Skipped (no API key)",
+						message: "Skipped (TTS not configured)",
 					});
 				} else {
 					const result = await testVoiceMessageResponse(verbose, timeoutMs);
@@ -186,18 +183,33 @@ async function runSdkQuery(
 	let output = "";
 	let querySuccess = false;
 	let error: string | undefined;
+	const agentUrl = process.env.TELCLAUDE_AGENT_URL;
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), opts.timeoutMs);
 
 	try {
-		const stream = executeQueryStream(prompt, {
-			tier: opts.tier ?? "WRITE_LOCAL",
-			enableSkills: opts.enableSkills,
-			permissionMode: "acceptEdits",
-			cwd: process.cwd(),
-			abortController: controller,
-		});
+		fs.mkdirSync(LOCAL_INTEGRATION_CWD, { recursive: true });
+
+		const stream = agentUrl
+			? executeRemoteQuery(prompt, {
+					agentUrl,
+					scope: "telegram",
+					cwd: ".",
+					tier: opts.tier ?? "WRITE_LOCAL",
+					poolKey: `integration-test:sdk:${++integrationQueryCounter}`,
+					userId: "integration:sdk",
+					enableSkills: opts.enableSkills,
+					timeoutMs: opts.timeoutMs,
+					abortController: controller,
+				})
+			: executeQueryStream(prompt, {
+					tier: opts.tier ?? "WRITE_LOCAL",
+					enableSkills: opts.enableSkills,
+					permissionMode: "acceptEdits",
+					cwd: LOCAL_INTEGRATION_CWD,
+					abortController: controller,
+				});
 
 		for await (const chunk of stream) {
 			if (controller.signal.aborted) {
@@ -237,7 +249,7 @@ async function testAgentTransport(
 		const stream = executeRemoteQuery(`Reply only with this exact text: ${expected}`, {
 			agentUrl,
 			scope: "telegram",
-			cwd: process.cwd(),
+			cwd: ".",
 			tier: "READ_ONLY",
 			poolKey: "integration-test:agent",
 			userId: "integration:agent",
@@ -363,25 +375,29 @@ async function testEcho(
 }
 
 /**
- * Test environment variable passing through SDK.
- * Verifies that the SDK properly injects env vars (like OPENAI_API_KEY) into the sandbox
- * when running in FULL_ACCESS tier.
+ * Test the supported Docker runtime env contract.
+ * In the agent container we expect a writable cwd, HOME, proxy wiring, and no raw OpenAI key.
  */
 async function testEnvPassing(
 	verbose: boolean,
 	timeoutMs: number,
 	expectOpenAIKey: boolean,
 ): Promise<{ name: string; passed: boolean; message: string; duration?: number }> {
-	const name = "Env vars via SDK";
+	const name = "Docker runtime env via SDK";
+	const usesRemoteAgent = Boolean(process.env.TELCLAUDE_AGENT_URL);
 
 	try {
 		console.log("  Running environment variable test via SDK...");
 		const startTime = Date.now();
 
-		// Ask the SDK to check if OPENAI_API_KEY is in the environment
-		const checkVar = expectOpenAIKey ? "OPENAI_API_KEY" : "HOME";
 		const { output, error } = await runSdkQuery(
-			`Run this bash command and tell me if the environment variable is set: test -n "$${checkVar}" && echo "ENV_VAR_SET" || echo "ENV_VAR_EMPTY"`,
+			`Run these bash checks and report the exact markers you see:
+
+pwd
+test -w . && echo "CWD_WRITABLE" || echo "CWD_READONLY"
+test -n "$HOME" && echo "HOME_SET" || echo "HOME_EMPTY"
+test -n "$TELCLAUDE_CREDENTIAL_PROXY_URL" && echo "CRED_PROXY_SET" || echo "CRED_PROXY_EMPTY"
+test -z "$OPENAI_API_KEY" && echo "RAW_OPENAI_KEY_ABSENT" || echo "RAW_OPENAI_KEY_PRESENT"`,
 			{
 				enableSkills: false,
 				timeoutMs,
@@ -395,48 +411,39 @@ async function testEnvPassing(
 		);
 
 		const duration = Date.now() - startTime;
+		const cwdWritable = output.includes("CWD_WRITABLE");
+		const homeSet = output.includes("HOME_SET");
+		const credentialProxySet = output.includes("CRED_PROXY_SET");
+		const rawOpenAIKeyAbsent = output.includes("RAW_OPENAI_KEY_ABSENT");
 
-		// Check for various ways the model might respond
-		const outputLower = output.toLowerCase();
-		const isSet =
-			output.includes("ENV_VAR_SET") ||
-			outputLower.includes("is set") ||
-			outputLower.includes("is defined") ||
-			outputLower.includes("exists") ||
-			outputLower.includes("has a value") ||
-			outputLower.includes("non-empty");
-		const isEmpty =
-			output.includes("ENV_VAR_EMPTY") ||
-			outputLower.includes("is not set") ||
-			outputLower.includes("is empty") ||
-			outputLower.includes("not defined") ||
-			outputLower.includes("does not exist");
+		const passed = usesRemoteAgent
+			? cwdWritable && homeSet && credentialProxySet && rawOpenAIKeyAbsent
+			: cwdWritable && homeSet;
 
-		if (isSet && !isEmpty) {
+		if (passed) {
 			console.log(chalk.green(`  ✓ ${name} (${duration}ms)`));
 			if (verbose) {
-				console.log(chalk.gray(`    Checked: ${checkVar} is set in sandbox environment`));
+				console.log(chalk.gray(`    CWD writable: ${cwdWritable}`));
+				console.log(chalk.gray(`    HOME set: ${homeSet}`));
+				if (usesRemoteAgent) {
+					console.log(chalk.gray(`    Credential proxy set: ${credentialProxySet}`));
+					console.log(chalk.gray(`    Raw OpenAI key absent: ${rawOpenAIKeyAbsent}`));
+				}
 			}
 			return { name, passed: true, message: "OK", duration };
-		}
-		if (isEmpty) {
-			// This is expected if we're checking OPENAI_API_KEY and it wasn't injected
-			if (expectOpenAIKey) {
-				console.log(chalk.red(`  ✗ ${name}: OPENAI_API_KEY not passed to sandbox`));
-				return { name, passed: false, message: "OPENAI_API_KEY not in sandbox env" };
-			}
-			console.log(chalk.green(`  ✓ ${name} (${duration}ms)`));
-			return { name, passed: true, message: "OK (no key expected)", duration };
 		}
 		if (error) {
 			console.log(chalk.red(`  ✗ ${name}: ${error}`));
 			return { name, passed: false, message: error };
 		}
-		console.log(chalk.red(`  ✗ ${name}: Unexpected output`));
+		const details = usesRemoteAgent
+			? `cwdWritable=${cwdWritable}, homeSet=${homeSet}, credProxySet=${credentialProxySet}, rawOpenAIKeyAbsent=${rawOpenAIKeyAbsent}`
+			: `cwdWritable=${cwdWritable}, homeSet=${homeSet}`;
+		console.log(chalk.red(`  ✗ ${name}: ${details}`));
 		if (verbose) {
 			console.log(chalk.gray(`    Output: ${output.substring(0, 300)}`));
 		}
-		return { name, passed: false, message: "Unexpected output" };
+		return { name, passed: false, message: details };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		console.log(chalk.red(`  ✗ ${name}: ${message}`));
@@ -445,13 +452,8 @@ async function testEnvPassing(
 }
 
 /**
- * Test image generation through SDK.
- * This tests the full path: SDK → sandbox → OpenAI API
- *
- * Note: This test verifies the SDK can make OpenAI API calls from within the sandbox.
- * The `telclaude generate-image` CLI won't work inside the sandbox because it needs
- * access to ~/.telclaude for config. Instead, we test that the API is reachable and
- * that the OPENAI_API_KEY is properly passed (FULL_ACCESS tier).
+ * Test image generation through the supported telclaude path.
+ * In Docker this should use relay-backed credentials/capabilities, not raw key injection.
  */
 async function testImageGeneration(
 	verbose: boolean,
@@ -465,22 +467,14 @@ async function testImageGeneration(
 
 		let imagePath = "";
 
-		// Use curl to call OpenAI API directly (CLI can't access ~/.telclaude in sandbox)
-		// Uses gpt-image-1.5 with b64_json output to match prod (image-generation.ts)
 		const { output, error } = await runSdkQuery(
-			`Generate a simple test image using the OpenAI API. The OPENAI_API_KEY env var is available.
+			`Run this exact bash command to generate a tiny test image through telclaude and then print the saved absolute PNG path:
 
-Run this curl command to generate an image and save it:
-curl -s https://api.openai.com/v1/images/generations \\
-  -H "Authorization: Bearer $OPENAI_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{"model":"gpt-image-1.5","prompt":"red circle on white background","size":"1024x1024","output_format":"png"}' \\
-  | jq -r '.data[0].b64_json' | base64 -d > ./test-image.png
+telclaude generate-image "red circle on white background" --size 1024x1024 --quality low
 
-Verify the file was created with: ls -la ./test-image.png
-Tell me the absolute path to the saved PNG file.`,
+After it completes, verify the file exists with ls -la on that exact path and print the path again.`,
 			{
-				enableSkills: true,
+				enableSkills: false,
 				timeoutMs,
 				tier: "FULL_ACCESS",
 				onText: (text) => {
@@ -552,32 +546,36 @@ Tell me the absolute path to the saved PNG file.`,
 }
 
 /**
- * Test network proxy configuration through SDK.
- * Runs diagnostic commands inside the sandbox to verify the proxy chain.
- * Tests actual HTTP requests through the proxy to verify end-to-end connectivity.
+ * Test Docker runtime wiring through the supported agent path.
+ * Verifies relay health and credential-proxy health instead of retired SDK sandbox HTTP_PROXY behavior.
  */
 async function testNetworkProxy(
 	verbose: boolean,
 	timeoutMs: number,
 ): Promise<{ name: string; passed: boolean; message: string; duration?: number }> {
-	const name = "Network proxy via SDK";
+	const name = "Docker runtime wiring via SDK";
+	const usesRemoteAgent = Boolean(process.env.TELCLAUDE_AGENT_URL);
 
 	try {
-		console.log("  Running network proxy diagnostic via SDK...");
+		console.log("  Running Docker runtime wiring diagnostic via SDK...");
 		const startTime = Date.now();
 
-		// Test actual HTTP request through the proxy (this is what matters)
 		const { output, error } = await runSdkQuery(
-			`Test the sandbox network proxy by running these commands and reporting results:
+			usesRemoteAgent
+				? `Run these exact checks and report the markers:
 
-1. Show proxy environment:
-   echo "HTTP_PROXY=$HTTP_PROXY"
-   echo "SANDBOX_RUNTIME=$SANDBOX_RUNTIME"
+echo "CAPABILITIES=$TELCLAUDE_CAPABILITIES_URL"
+echo "CRED_PROXY=$TELCLAUDE_CREDENTIAL_PROXY_URL"
+curl -sf "$TELCLAUDE_CAPABILITIES_URL/health" && echo "CAP_HEALTH_OK" || echo "CAP_HEALTH_FAIL"
+curl -sf "$TELCLAUDE_CREDENTIAL_PROXY_URL/health" && echo "HTTP_PROXY_HEALTH_OK" || echo "HTTP_PROXY_HEALTH_FAIL"
 
-2. Test HTTPS fetch through proxy (this is the real test):
-   curl -s --max-time 10 https://api.openai.com/v1/models 2>&1 | head -c 200
+Report the exact markers only.`
+				: `Run these exact checks and report the markers:
 
-Report results clearly. Mark "FETCH_SUCCESS" if curl returns any JSON (even 401), "FETCH_FAIL" if it times out or errors.`,
+test -w . && echo "CWD_WRITABLE" || echo "CWD_READONLY"
+curl -sf http://localhost:8790/health && echo "CAP_HEALTH_OK" || echo "CAP_HEALTH_FAIL"
+
+Report the exact markers only.`,
 			{
 				enableSkills: false,
 				timeoutMs,
@@ -590,69 +588,37 @@ Report results clearly. Mark "FETCH_SUCCESS" if curl returns any JSON (even 401)
 		);
 
 		const duration = Date.now() - startTime;
-
-		// Check for proxy environment (port is dynamic, just check for localhost)
-		const hasProxy =
-			output.includes("HTTP_PROXY=http://localhost:") || output.includes("http://localhost:");
-
-		// Check for sandbox runtime
-		const inSandbox = output.includes("SANDBOX_RUNTIME=1");
-
-		// Check for successful fetch (any JSON response, including 401 auth error)
-		const fetchSuccess =
-			output.includes("FETCH_SUCCESS") ||
-			output.includes('"error"') || // OpenAI error response
-			output.includes('"data"') || // OpenAI success response
-			output.includes("invalid_api_key") || // Auth error = network worked
-			output.includes("401"); // Unauthorized = network worked
-
-		// Check for network failure
-		const fetchFail =
-			output.includes("FETCH_FAIL") ||
-			output.includes("Could not resolve host") ||
-			output.includes("Connection refused") ||
-			output.includes("Operation timed out") ||
-			output.includes("EAI_AGAIN");
+		const cwdWritable = output.includes("CWD_WRITABLE");
+		const capabilityHealthOk = output.includes("CAP_HEALTH_OK");
+		const httpProxyHealthOk = output.includes("HTTP_PROXY_HEALTH_OK");
 
 		if (verbose) {
-			console.log(chalk.gray(`\n    Proxy env detected: ${hasProxy}`));
-			console.log(chalk.gray(`    Running in sandbox: ${inSandbox}`));
-			console.log(chalk.gray(`    Fetch succeeded: ${fetchSuccess}`));
-			console.log(chalk.gray(`    Fetch failed: ${fetchFail}`));
+			console.log(chalk.gray(`\n    CWD writable: ${cwdWritable}`));
+			console.log(chalk.gray(`    Capabilities health OK: ${capabilityHealthOk}`));
+			if (usesRemoteAgent) {
+				console.log(chalk.gray(`    Credential proxy health OK: ${httpProxyHealthOk}`));
+			}
 		}
 
-		if (fetchSuccess && !fetchFail) {
+		if (
+			(usesRemoteAgent && capabilityHealthOk && httpProxyHealthOk) ||
+			(!usesRemoteAgent && cwdWritable && capabilityHealthOk)
+		) {
 			console.log(chalk.green(`  ✓ ${name} (${duration}ms)`));
-			return { name, passed: true, message: "Proxy working - HTTPS fetch succeeded", duration };
-		}
-		if (fetchFail) {
-			// This is the actual failure case we're investigating
-			const reason = output.includes("EAI_AGAIN")
-				? "DNS resolution failed (EAI_AGAIN)"
-				: output.includes("Connection refused")
-					? "Proxy connection refused"
-					: output.includes("Operation timed out")
-						? "Request timed out"
-						: "Network request failed";
-			console.log(chalk.red(`  ✗ ${name}: ${reason}`));
-			if (verbose) {
-				console.log(chalk.gray(`    Full output: ${output.substring(0, 800)}`));
-			}
-			return { name, passed: false, message: reason };
-		}
-		if (!hasProxy) {
-			console.log(chalk.red(`  ✗ ${name}: No proxy environment vars`));
-			return { name, passed: false, message: "HTTP_PROXY not set in sandbox" };
+			return { name, passed: true, message: "OK", duration };
 		}
 		if (error) {
 			console.log(chalk.red(`  ✗ ${name}: ${error}`));
 			return { name, passed: false, message: error };
 		}
-		console.log(chalk.yellow(`  ? ${name}: Unexpected output`));
+		const details = usesRemoteAgent
+			? `capabilityHealthOk=${capabilityHealthOk}, httpProxyHealthOk=${httpProxyHealthOk}`
+			: `cwdWritable=${cwdWritable}, capabilityHealthOk=${capabilityHealthOk}`;
+		console.log(chalk.red(`  ✗ ${name}: ${details}`));
 		if (verbose) {
-			console.log(chalk.gray(`    Output: ${output.substring(0, 500)}`));
+			console.log(chalk.gray(`    Output: ${output.substring(0, 800)}`));
 		}
-		return { name, passed: false, message: "Unexpected output" };
+		return { name, passed: false, message: details };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		console.log(chalk.red(`  ✗ ${name}: ${message}`));

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -25,12 +24,11 @@ import { startGitProxyServer } from "../relay/git-proxy.js";
 import { startHttpCredentialProxy } from "../relay/http-credential-proxy.js";
 import { initTokenManager } from "../relay/token-manager.js";
 import {
+	assertDockerRuntime,
 	buildAllowedDomainNames,
 	buildAllowedDomains,
 	DEFAULT_NETWORK_CONFIG,
 	getNetworkIsolationSummary,
-	getSandboxMode,
-	getSandboxRuntimeVersion,
 } from "../sandbox/index.js";
 import { destroySessionManager } from "../sdk/session-manager.js";
 import { isTOTPDaemonAvailable } from "../security/totp.js";
@@ -47,50 +45,6 @@ import { CONFIG_DIR } from "../utils.js";
 import { isVaultAvailable } from "../vault-daemon/index.js";
 
 const logger = getChildLogger({ module: "cmd-relay" });
-
-/**
- * Check if a binary is available on PATH.
- */
-function isBinaryAvailable(name: string): boolean {
-	try {
-		execSync(`which ${name}`, { stdio: "ignore" });
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Check host dependencies for native sandbox mode.
- * Returns list of missing dependencies.
- */
-interface SandboxDepsCheck {
-	criticalMissing: string[]; // Security-critical, hard fail
-	optionalMissing: string[]; // Nice-to-have, warn only
-}
-
-function checkNativeSandboxDeps(): SandboxDepsCheck {
-	const criticalMissing: string[] = [];
-	const optionalMissing: string[] = [];
-	const platform = os.platform();
-
-	if (platform === "linux") {
-		// Linux REQUIRES bubblewrap for sandbox (security-critical)
-		if (!isBinaryAvailable("bwrap")) {
-			criticalMissing.push("bubblewrap (bwrap)");
-		}
-		// socat needed for network proxy (security-critical for network isolation)
-		if (!isBinaryAvailable("socat")) {
-			criticalMissing.push("socat");
-		}
-	}
-	// ripgrep is nice-to-have for Grep tool but not security-critical
-	if (!isBinaryAvailable("rg")) {
-		optionalMissing.push("ripgrep (rg)");
-	}
-
-	return { criticalMissing, optionalMissing };
-}
 
 export type RelayOptions = {
 	verbose?: boolean;
@@ -114,6 +68,8 @@ export function registerRelayCommand(program: Command): void {
 			}
 
 			try {
+				assertDockerRuntime("telclaude relay");
+
 				const cfg = loadConfig();
 				const additionalDomains = cfg.security?.network?.additionalDomains ?? [];
 				const allowedDomainNames = buildAllowedDomainNames(additionalDomains);
@@ -307,109 +263,55 @@ export function registerRelayCommand(program: Command): void {
 					}
 				}
 
-				// Detect sandbox mode and verify sandbox availability
-				const sandboxMode = getSandboxMode();
 				const usesRemoteAgent = Boolean(process.env.TELCLAUDE_AGENT_URL);
-				if (sandboxMode === "docker") {
-					if (usesRemoteAgent) {
-						console.log("Sandbox: Docker mode (relay-only, SDK runs in agent container)");
-					} else {
-						console.log(
-							"Sandbox: Docker mode (SDK sandbox disabled, container provides isolation)",
+				if (usesRemoteAgent) {
+					console.log("Sandbox: Docker mode (relay-only, SDK runs in agent container)");
+				} else {
+					console.log("Sandbox: Docker mode (SDK sandbox disabled, container provides isolation)");
+				}
+				// SECURITY: Docker mode REQUIRES firewall for network isolation
+				if (process.env.TELCLAUDE_FIREWALL !== "1") {
+					if (process.env.TELCLAUDE_ACCEPT_NO_FIREWALL === "1") {
+						console.warn("  ⚠️  TELCLAUDE_FIREWALL not enabled - network isolation is OFF");
+						console.warn("     Running anyway due to TELCLAUDE_ACCEPT_NO_FIREWALL=1");
+						console.warn("     THIS IS A SECURITY RISK - use only for testing");
+						// AUDIT: Log the security bypass
+						logger.warn(
+							{ bypass: "TELCLAUDE_ACCEPT_NO_FIREWALL" },
+							"SECURITY BYPASS: Running Docker mode without network firewall",
 						);
-					}
-					// SECURITY: Docker mode REQUIRES firewall for network isolation
-					if (process.env.TELCLAUDE_FIREWALL !== "1") {
-						if (process.env.TELCLAUDE_ACCEPT_NO_FIREWALL === "1") {
-							console.warn("  ⚠️  TELCLAUDE_FIREWALL not enabled - network isolation is OFF");
-							console.warn("     Running anyway due to TELCLAUDE_ACCEPT_NO_FIREWALL=1");
-							console.warn("     THIS IS A SECURITY RISK - use only for testing");
-							// AUDIT: Log the security bypass
-							logger.warn(
-								{ bypass: "TELCLAUDE_ACCEPT_NO_FIREWALL" },
-								"SECURITY BYPASS: Running Docker mode without network firewall",
-							);
-						} else {
-							console.error("\n❌ SECURITY ERROR: Docker mode requires network firewall.\n");
-							console.error("In Docker mode, the SDK sandbox is disabled.");
-							console.error("Without TELCLAUDE_FIREWALL=1, container egress is not isolated");
-							console.error("and can reach arbitrary endpoints (including cloud metadata).\n");
-							console.error("To fix:");
-							console.error("  - Set TELCLAUDE_FIREWALL=1 in your docker/.env file");
-							console.error("  - Ensure init-firewall.sh runs (requires NET_ADMIN capability)\n");
-							console.error("To bypass (TESTING ONLY - NOT FOR PRODUCTION):");
-							console.error("  - Set TELCLAUDE_ACCEPT_NO_FIREWALL=1\n");
-							process.exit(1);
-						}
 					} else {
-						// TELCLAUDE_FIREWALL=1 - verify firewall is actually applied via sentinel file
-						const sentinelPath = "/run/telclaude/firewall-active";
-						if (!fsSync.existsSync(sentinelPath)) {
-							console.error("\n❌ SECURITY ERROR: Firewall enabled but not verified.\n");
-							console.error(
-								"TELCLAUDE_FIREWALL=1 is set, but the firewall sentinel file is missing.",
-							);
-							console.error(`Expected: ${sentinelPath}\n`);
-							console.error("This means init-firewall.sh failed or didn't run.");
-							console.error("Possible causes:");
-							console.error("  - Container missing --cap-add=NET_ADMIN capability");
-							console.error("  - iptables not available in container");
-							console.error("  - init-firewall.sh not executed at container start\n");
-							console.error("To fix:");
-							console.error("  - Ensure docker-compose.yml has cap_add: [NET_ADMIN]");
-							console.error("  - Check container logs for firewall setup errors\n");
-							process.exit(1);
-						}
-						console.log("  Firewall: verified (sentinel file present)");
+						console.error("\n❌ SECURITY ERROR: Docker mode requires network firewall.\n");
+						console.error("In Docker mode, the SDK sandbox is disabled.");
+						console.error("Without TELCLAUDE_FIREWALL=1, container egress is not isolated");
+						console.error("and can reach arbitrary endpoints (including cloud metadata).\n");
+						console.error("To fix:");
+						console.error("  - Set TELCLAUDE_FIREWALL=1 in your docker/.env file");
+						console.error("  - Ensure init-firewall.sh runs (requires NET_ADMIN capability)\n");
+						console.error("To bypass (TESTING ONLY - NOT FOR PRODUCTION):");
+						console.error("  - Set TELCLAUDE_ACCEPT_NO_FIREWALL=1\n");
+						process.exit(1);
 					}
 				} else {
-					// Native mode: verify SDK sandbox runtime is available
-					const sandboxVersion = getSandboxRuntimeVersion();
-					if (!sandboxVersion) {
-						console.error("\n❌ SECURITY ERROR: Sandbox runtime not available.\n");
+					// TELCLAUDE_FIREWALL=1 - verify firewall is actually applied via sentinel file
+					const sentinelPath = "/run/telclaude/firewall-active";
+					if (!fsSync.existsSync(sentinelPath)) {
+						console.error("\n❌ SECURITY ERROR: Firewall enabled but not verified.\n");
 						console.error(
-							"In native mode, the SDK sandbox (@anthropic-ai/sandbox-runtime) is required.",
+							"TELCLAUDE_FIREWALL=1 is set, but the firewall sentinel file is missing.",
 						);
-						console.error(
-							"This provides filesystem and network isolation via bubblewrap (Linux) or Seatbelt (macOS).\n",
-						);
+						console.error(`Expected: ${sentinelPath}\n`);
+						console.error("This means init-firewall.sh failed or didn't run.");
+						console.error("Possible causes:");
+						console.error("  - Container missing --cap-add=NET_ADMIN capability");
+						console.error("  - iptables not available in container");
+						console.error("  - init-firewall.sh not executed at container start\n");
 						console.error("To fix:");
-						console.error(
-							"  - Run: pnpm install (sandbox-runtime should be installed as a dependency)",
-						);
-						console.error("  - On Linux: ensure bubblewrap is installed (apt install bubblewrap)");
-						console.error("  - Alternatively, run in Docker mode for container-based isolation\n");
+						console.error("  - Ensure docker-compose.yml has cap_add: [NET_ADMIN]");
+						console.error("  - Check container logs for firewall setup errors\n");
 						process.exit(1);
 					}
-					console.log(`Sandbox: Native mode (SDK sandbox v${sandboxVersion})`);
-
-					// Check for host dependencies (bwrap, socat, rg)
-					const { criticalMissing, optionalMissing } = checkNativeSandboxDeps();
-
-					// Security-critical deps are a hard fail
-					if (criticalMissing.length > 0) {
-						console.error(
-							`\n❌ SECURITY ERROR: Missing critical sandbox dependencies: ${criticalMissing.join(", ")}\n`,
-						);
-						console.error("These are required for secure sandbox operation on Linux.");
-						console.error(
-							"Without them, the sandbox cannot provide filesystem/network isolation.\n",
-						);
-						console.error("To fix:");
-						console.error("  - Install: apt install bubblewrap socat");
-						console.error("  - Or run in Docker mode for container-based isolation\n");
-						process.exit(1);
-					}
-
-					// Optional deps are just a warning
-					if (optionalMissing.length > 0) {
-						console.warn(`  ⚠️  Missing optional: ${optionalMissing.join(", ")}`);
-						if (os.platform() === "linux") {
-							console.warn("     Install: apt install ripgrep");
-						} else {
-							console.warn("     Install: brew install ripgrep");
-						}
-					}
+					console.log("  Firewall: verified (sentinel file present)");
 				}
 
 				// Network policy - default is strict allowlist

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -192,6 +192,9 @@ export async function collectTelclaudeStatus(): Promise<TelclaudeStatus> {
 }
 
 export function formatTelclaudeStatus(status: TelclaudeStatus, telegram = false): string {
+	const sandboxModeLabel =
+		status.runtime.sandboxMode === "docker" ? "docker" : "native (unsupported)";
+
 	if (telegram) {
 		const lines: string[] = [
 			"=== Telclaude Status ===",
@@ -199,7 +202,7 @@ export function formatTelclaudeStatus(status: TelclaudeStatus, telegram = false)
 			"Runtime:",
 			`  Version: ${status.runtime.version}`,
 			`  Revision: ${status.runtime.revision}`,
-			`  Mode: ${status.runtime.sandboxMode}`,
+			`  Mode: ${sandboxModeLabel}`,
 			`  CLI Started: ${status.runtime.startedAt}`,
 			`  CLI Uptime: ${formatUptime(status.runtime.uptimeSeconds)}`,
 			"",
@@ -249,7 +252,7 @@ export function formatTelclaudeStatus(status: TelclaudeStatus, telegram = false)
 	lines.push("Runtime:");
 	lines.push(`  Version: ${status.runtime.version}`);
 	lines.push(`  Revision: ${status.runtime.revision}`);
-	lines.push(`  Mode: ${status.runtime.sandboxMode}`);
+	lines.push(`  Mode: ${sandboxModeLabel}`);
 	lines.push(`  CLI Started: ${status.runtime.startedAt}`);
 	lines.push(`  CLI Uptime: ${formatUptime(status.runtime.uptimeSeconds)}`);
 	lines.push("");

--- a/src/relay/anthropic-proxy.ts
+++ b/src/relay/anthropic-proxy.ts
@@ -412,7 +412,7 @@ async function buildAuthHeader(): Promise<AuthHeader | null> {
 		return { name: "x-api-key", value: apiKey, source: "env" };
 	}
 
-	// 4. Credentials file fallback (dev/native mode, before vault import)
+	// 4. Credentials file fallback (legacy/local auth files, before vault import)
 	const authDir = process.env.TELCLAUDE_AUTH_DIR;
 	const credentialsCandidates = [
 		process.env.CLAUDE_CODE_CREDENTIALS_PATH,

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -13,9 +13,9 @@ import {
  * - BLOCKED_METADATA_DOMAINS: Used by isBlockedHost for SSRF protection
  * - BLOCKED_PRIVATE_NETWORKS: Used by isBlockedHost for RFC1918 blocking
  *
- * NOTE: The actual sandbox (bubblewrap/Seatbelt) is managed by SDK in native mode,
- * or by Docker in container mode. These constants provide application-level
- * defense-in-depth via canUseTool and PreToolUse hooks.
+ * NOTE: The supported runtime uses Docker as the isolation boundary. These
+ * constants provide application-level defense-in-depth via canUseTool and
+ * PreToolUse hooks.
  */
 
 /**

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -32,6 +32,8 @@ export {
 } from "./fetch-guard.js";
 // Mode detection
 export {
+	assertDockerRuntime,
+	getDockerRuntimeRequirementMessage,
 	getSandboxMode,
 	isDockerEnvironment,
 	type SandboxMode,

--- a/src/sandbox/mode.ts
+++ b/src/sandbox/mode.ts
@@ -1,14 +1,10 @@
 /**
- * Sandbox mode detection.
+ * Runtime environment detection.
  *
- * Determines whether to use Docker-provided isolation or SDK's native sandbox.
- *
- * Architecture:
- * - Docker mode: SDK sandbox DISABLED. Docker container provides isolation.
- * - Native mode: SDK sandbox ENABLED. bubblewrap (Linux) or Seatbelt (macOS).
- *
- * This follows Anthropic's recommended pattern: use ONE isolation boundary,
- * not layered sandboxes which cause complexity and compatibility issues.
+ * Telclaude's supported runtime is Docker-only. We still expose mode detection
+ * helpers because diagnostics and unit tests need to distinguish Docker from
+ * non-Docker environments, but service/runtime entrypoints must fail closed
+ * outside Docker.
  */
 
 import fs from "node:fs";
@@ -17,6 +13,10 @@ import { getChildLogger } from "../logging.js";
 const logger = getChildLogger({ module: "sandbox-mode" });
 
 export type SandboxMode = "docker" | "native";
+
+export function getDockerRuntimeRequirementMessage(context = "Telclaude runtime"): string {
+	return `${context} requires Docker. Native/non-Docker deployment is retired and unsupported. Run it inside the Docker Compose stack.`;
+}
 
 /**
  * Detect if running inside Docker container.
@@ -51,12 +51,19 @@ export function isDockerEnvironment(): boolean {
  */
 export function getSandboxMode(): SandboxMode {
 	if (isDockerEnvironment()) {
-		logger.debug("detected Docker environment - SDK sandbox will be disabled");
+		logger.debug("detected Docker environment");
 		return "docker";
 	}
 
-	logger.debug("detected native environment - SDK sandbox will be enabled");
+	logger.debug("detected non-Docker environment");
 	return "native";
+}
+
+export function assertDockerRuntime(context = "Telclaude runtime"): void {
+	if (isDockerEnvironment()) {
+		return;
+	}
+	throw new Error(getDockerRuntimeRequirementMessage(context));
 }
 
 /**

--- a/src/sandbox/sdk-settings.ts
+++ b/src/sandbox/sdk-settings.ts
@@ -34,9 +34,9 @@ function withGlobVariants(p: string): string[] {
 /**
  * Build Claude Code permission rules for @anthropic-ai/claude-agent-sdk.
  *
- * Filesystem isolation is handled by:
- * - Docker mode: Container filesystem isolation
- * - Native mode: SDK sandbox (bubblewrap/Seatbelt)
+ * Filesystem isolation is handled by the supported Docker container runtime.
+ * The non-Docker SDK-sandbox path still exists in tests, but is not a
+ * supported deployment mode.
  *
  * These permission rules provide defense-in-depth via canUseTool callback.
  *

--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -36,7 +36,7 @@ import {
 import { buildInternalAuthHeaders } from "../internal-auth.js";
 import { getChildLogger } from "../logging.js";
 import { buildAllowedDomainNames, domainMatchesPattern } from "../sandbox/domains.js";
-import { shouldEnableSdkSandbox } from "../sandbox/mode.js";
+import { assertDockerRuntime, shouldEnableSdkSandbox } from "../sandbox/mode.js";
 import { checkPrivateNetworkAccess } from "../sandbox/network-proxy.js";
 import { buildSdkPermissionsForTier } from "../sandbox/sdk-settings.js";
 import { redactSecrets } from "../security/output-filter.js";
@@ -159,20 +159,6 @@ export type TelclaudeQueryOptions = {
 
 	/** Structured output format (JSON Schema). Agent returns validated data instead of free-form text. */
 	outputFormat?: OutputFormat;
-
-	/** Native/dev fallback credentials.
-	 * Docker deployments must keep raw credentials inside the relay and use
-	 * the git proxy / HTTP credential proxy instead of sandbox env injection. */
-	exposedCredentials?: ExposedCredentials;
-};
-
-/**
- * Native/dev fallback credentials.
- * Narrow type — avoids turning the relay→agent payload into arbitrary env injection.
- */
-export type ExposedCredentials = {
-	githubToken?: string;
-	openaiApiKey?: string;
 };
 
 /**
@@ -788,9 +774,9 @@ function createSensitivePathHook(tier: PermissionTier): HookCallbackMatcher {
 /**
  * Build SDK options based on tier and configuration.
  *
- * Sandbox mode detection:
- * - Docker: SDK sandbox DISABLED. Docker container provides isolation.
- * - Native: SDK sandbox ENABLED. bubblewrap (Linux) or Seatbelt (macOS).
+ * Runtime execution is Docker-only. This builder still computes SDK options
+ * from the current environment so unit tests can exercise hook and settings
+ * behavior without depending on the Docker container.
  */
 export async function buildSdkOptions(opts: TelclaudeQueryOptions): Promise<SDKOptions> {
 	// Create abort controller with timeout if specified
@@ -818,22 +804,22 @@ export async function buildSdkOptions(opts: TelclaudeQueryOptions): Promise<SDKO
 	// a custom env causes the spawn process to hang. Instead, set variables in
 	// process.env before calling the SDK - the sandbox inherits from process.env.
 	//
-	// In Docker mode (sandbox disabled), pass explicit env to control what
-	// variables the spawned process sees.
+	// In the supported Docker runtime (sandbox disabled), pass explicit env to
+	// control what variables the spawned process sees.
 	let sandboxEnv: Record<string, string> | undefined;
 
 	if (sandboxEnabled) {
-		// Native mode: Don't pass custom env (causes hang with sandbox.enabled).
+		// Non-Docker/test path: don't pass custom env (causes hang with sandbox.enabled).
 		// User ID for rate limiting is passed via system prompt below instead of
 		// env var to avoid race conditions with concurrent requests.
 		// OPENAI_API_KEY and GITHUB_TOKEN should already be in process.env.
 		//
-		// Session token: In native mode we must use process.env since there's no
+		// Session token: on this path we must use process.env since there's no
 		// sandboxEnv to inject into (SDK hangs with custom env + sandbox.enabled).
-		// KNOWN LIMITATION: Under concurrent requests in native mode, there is a
+		// KNOWN LIMITATION: Under concurrent requests on this path, there is a
 		// race window between this set and the SDK subprocess spawn. This is an
-		// inherent SDK constraint — the production Docker path uses per-request
-		// sandboxEnv and is fully race-free. Native mode is dev/test only.
+		// inherent SDK constraint — the supported Docker path uses per-request
+		// sandboxEnv and is fully race-free. This branch is for tests only.
 		// Always set-or-delete to prevent stale tokens from prior requests.
 		if (opts.sessionToken) {
 			process.env.TELCLAUDE_SESSION_TOKEN = opts.sessionToken;
@@ -841,7 +827,7 @@ export async function buildSdkOptions(opts: TelclaudeQueryOptions): Promise<SDKO
 			delete process.env.TELCLAUDE_SESSION_TOKEN;
 		}
 	} else {
-		// Docker mode: Pass explicit env since container provides isolation
+		// Docker mode: pass explicit env since the container provides isolation
 		// Use cwd as HOME when actual HOME is read-only (e.g., social agent's HOME=/social)
 		// This ensures tools like agent-browser can create temp files
 		const effectiveHome = isWritableDir(process.env.HOME ?? "")
@@ -914,7 +900,7 @@ export async function buildSdkOptions(opts: TelclaudeQueryOptions): Promise<SDKO
 		abortController,
 		resume: opts.resumeSessionId,
 		// Only pass env in Docker mode (when sandboxEnv is defined)
-		// In native mode, let SDK use process.env and handle sandbox env internally
+		// On the non-Docker/test path, let SDK use process.env and handle sandbox env internally
 		...(sandboxEnv && { env: sandboxEnv }),
 		...(opts.outputFormat && { outputFormat: opts.outputFormat }),
 	};
@@ -940,9 +926,9 @@ export async function buildSdkOptions(opts: TelclaudeQueryOptions): Promise<SDKO
 
 	// Sandbox configuration based on environment:
 	// - Docker: SDK sandbox DISABLED (container provides isolation)
-	// - Native: SDK sandbox ENABLED (bubblewrap/Seatbelt)
+	// - Non-Docker/test path: SDK sandbox ENABLED
 	if (sandboxEnabled) {
-		logger.debug("native mode: enabling SDK sandbox");
+		logger.debug("non-Docker path: enabling SDK sandbox (unsupported at runtime)");
 		sdkOpts.sandbox = {
 			enabled: true,
 			allowUnsandboxedCommands: false,
@@ -1370,6 +1356,7 @@ export async function* executeQueryStream(
 	prompt: string,
 	inputOpts: TelclaudeQueryOptions,
 ): AsyncGenerator<StreamChunk, void, unknown> {
+	assertDockerRuntime("Claude SDK execution");
 	const startTime = Date.now();
 
 	const sdkOpts = await buildSdkOptions({
@@ -1410,6 +1397,7 @@ export async function* executePooledQuery(
 	prompt: string,
 	inputOpts: PooledQueryOptions,
 ): AsyncGenerator<StreamChunk, void, unknown> {
+	assertDockerRuntime("Claude SDK execution");
 	const startTime = Date.now();
 
 	const sdkOpts = await buildSdkOptions({

--- a/src/security/permissions.ts
+++ b/src/security/permissions.ts
@@ -133,9 +133,8 @@ export function getUserPermissionTier(
 		tier = securityConfig?.permissions?.defaultTier ?? "READ_ONLY";
 	}
 
-	// Note: In native mode, SDK sandbox provides isolation.
-	// In Docker mode, the container provides isolation.
-	// FULL_ACCESS is safe in both cases since there's always a security boundary.
+	// Supported runtime is Docker-only. FULL_ACCESS still relies on the
+	// container boundary plus relay-mediated credential access.
 	if (tier === "FULL_ACCESS" && !shouldEnableSdkSandbox()) {
 		logger.debug(
 			{ userId: normalizedId, tier },

--- a/tests/agent/client.test.ts
+++ b/tests/agent/client.test.ts
@@ -15,11 +15,6 @@ const withTimeoutImpl = vi.hoisted(
 );
 const issueTokenImpl = vi.hoisted(() => vi.fn(async () => ({ token: "session-token" })));
 const isTokenManagerActiveImpl = vi.hoisted(() => vi.fn(() => true));
-const isDockerEnvironmentImpl = vi.hoisted(() => vi.fn(() => true));
-const getGitCredentialsImpl = vi.hoisted(
-	() => vi.fn(async () => ({ username: "bot", email: "bot@example.com", token: "github-secret" })),
-);
-const getOpenAIKeyImpl = vi.hoisted(() => vi.fn(async () => "openai-secret"));
 
 vi.mock("../../src/infra/network-errors.js", () => ({
 	isTransientNetworkError: () => false,
@@ -51,20 +46,6 @@ vi.mock("../../src/relay/token-manager.js", () => ({
 	issueToken: (...args: Parameters<typeof issueTokenImpl>) => issueTokenImpl(...args),
 	isTokenManagerActive: (...args: Parameters<typeof isTokenManagerActiveImpl>) =>
 		isTokenManagerActiveImpl(...args),
-}));
-
-vi.mock("../../src/sandbox/mode.js", () => ({
-	isDockerEnvironment: (...args: Parameters<typeof isDockerEnvironmentImpl>) =>
-		isDockerEnvironmentImpl(...args),
-}));
-
-vi.mock("../../src/services/git-credentials.js", () => ({
-	getGitCredentials: (...args: Parameters<typeof getGitCredentialsImpl>) =>
-		getGitCredentialsImpl(...args),
-}));
-
-vi.mock("../../src/services/openai-client.js", () => ({
-	getOpenAIKey: (...args: Parameters<typeof getOpenAIKeyImpl>) => getOpenAIKeyImpl(...args),
 }));
 
 import { executeRemoteQuery } from "../../src/agent/client.js";
@@ -110,9 +91,7 @@ describe("executeRemoteQuery credential forwarding", () => {
 		vi.clearAllMocks();
 	});
 
-	it("does not serialize exposed credentials in Docker mode", async () => {
-		isDockerEnvironmentImpl.mockReturnValue(true);
-
+	it("does not serialize exposed credentials", async () => {
 		const chunks = [];
 		for await (const chunk of executeRemoteQuery("hi", {
 			agentUrl: "http://agent",
@@ -130,29 +109,5 @@ describe("executeRemoteQuery credential forwarding", () => {
 		expect(chunks).toHaveLength(1);
 		expect(capturedBody?.sessionToken).toBe("session-token");
 		expect(capturedBody?.exposedCredentials).toBeUndefined();
-		expect(getGitCredentialsImpl).not.toHaveBeenCalled();
-		expect(getOpenAIKeyImpl).not.toHaveBeenCalled();
-	});
-
-	it("keeps native fallback credential forwarding for non-Docker environments", async () => {
-		isDockerEnvironmentImpl.mockReturnValue(false);
-
-		for await (const _chunk of executeRemoteQuery("hi", {
-			agentUrl: "http://agent",
-			cwd: "/workspace",
-			tier: "FULL_ACCESS",
-			poolKey: "pool",
-			userId: "user-1",
-			scope: "telegram",
-			enableSkills: false,
-			timeoutMs: 1000,
-		})) {
-			// drain stream
-		}
-
-		expect(capturedBody?.exposedCredentials).toEqual({
-			githubToken: "github-secret",
-			openaiApiKey: "openai-secret",
-		});
 	});
 });

--- a/tests/sdk/execute-pooled-query.test.ts
+++ b/tests/sdk/execute-pooled-query.test.ts
@@ -17,9 +17,16 @@ vi.mock("../../src/logging.js", () => ({
 
 import { executePooledQuery } from "../../src/sdk/client.js";
 
+const ORIGINAL_DOCKER_ENV = process.env.TELCLAUDE_DOCKER;
+
 afterEach(() => {
 	queryMock.mockReset();
 	vi.resetModules();
+	if (ORIGINAL_DOCKER_ENV === undefined) {
+		delete process.env.TELCLAUDE_DOCKER;
+	} else {
+		process.env.TELCLAUDE_DOCKER = ORIGINAL_DOCKER_ENV;
+	}
 });
 
 function collectChunks<T>(iterable: AsyncIterable<T>): Promise<T[]> {
@@ -32,6 +39,7 @@ function collectChunks<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 
 describe("executePooledQuery streaming", () => {
 	it("emits text -> tool_use -> done with streamed response", async () => {
+		process.env.TELCLAUDE_DOCKER = "1";
 		queryMock.mockReturnValueOnce(
 			(async function* () {
 				yield {
@@ -68,6 +76,7 @@ describe("executePooledQuery streaming", () => {
 	});
 
 	it("accumulates tool input from input_json_delta events", async () => {
+		process.env.TELCLAUDE_DOCKER = "1";
 		queryMock.mockReturnValueOnce(
 			(async function* () {
 				yield {
@@ -108,6 +117,7 @@ describe("executePooledQuery streaming", () => {
 	});
 
 	it("falls back to assistant message text when no stream events", async () => {
+		process.env.TELCLAUDE_DOCKER = "1";
 		queryMock.mockReturnValueOnce(
 			(async function* () {
 				yield {
@@ -135,5 +145,19 @@ describe("executePooledQuery streaming", () => {
 		expect(chunks.map((c: any) => c.type)).toEqual(["text", "done"]);
 		expect((chunks[0] as any).content).toBe("Fallback text");
 		expect((chunks[1] as any).result.response).toBe("Fallback text");
+	});
+
+	it("fails closed outside Docker", async () => {
+		delete process.env.TELCLAUDE_DOCKER;
+
+		await expect(
+			collectChunks(
+				executePooledQuery("prompt", {
+					cwd: "/tmp",
+					tier: "READ_ONLY",
+					poolKey: "chat-4",
+				}),
+			),
+		).rejects.toThrow(/requires Docker/);
 	});
 });


### PR DESCRIPTION
## What changed
- retire native/non-Docker telclaude runtime support and fail closed outside Docker
- remove the remaining relay-to-agent raw credential handoff path
- rework `integration-test` to validate the supported Docker contract instead of the old native env-injection path
- align README/architecture/docs with the Docker-only deployment model

## Why
The supported security boundary is the Docker relay+agent deployment. Keeping a native runtime path and native-style integration checks created two problems:
1. the code still carried legacy behavior for credential exposure outside the Docker boundary
2. `integration-test --all` could report false failures in a healthy Docker deployment because it was still checking native assumptions

This change makes the runtime model explicit and fail-closed, and updates the verification path to match the real deployment.

## Impact
- `telclaude relay`, `telclaude agent`, SDK execution, and `integration-test` now require Docker runtime
- the agent request path no longer carries `exposedCredentials`
- Docker FULL_ACCESS continues to use relay-managed proxies/session auth instead of raw provider keys in the agent sandbox

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm vitest run tests/agent/client.test.ts tests/sdk/execute-pooled-query.test.ts`
- `pnpm test`
