### PR TITLE
ci(release): switch to release PR workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,4 +33,3 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,39 +2,304 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)release (e.g. v0.6.2)"
+        required: true
+        type: string
+      publish-to-npm:
+        description: "Publish to npm via trusted publishing after the GitHub release"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
-# Prevent race conditions: only one release per tag, cancel stale runs
 concurrency:
-  group: release-${{ github.ref_name }}
-  cancel-in-progress: true
+  group: release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Release
+  prepare:
+    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release): v') }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      tag: ${{ steps.prepare.outputs.tag }}
+      version: ${{ steps.prepare.outputs.version }}
+      release_ref: ${{ steps.prepare.outputs.release_ref }}
+      release_sha: ${{ steps.prepare.outputs.release_sha }}
+      prerelease: ${{ steps.prepare.outputs.prerelease }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
+      - name: Resolve release metadata
+        id: prepare
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        shell: bash
+        run: |
+          set -euo pipefail
 
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
+          validate_tag() {
+            local tag="$1"
+            if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+              echo "::error::Release identifiers must use vX.Y.Z style tags."
+              exit 1
+            fi
+          }
+
+          tag_commit_sha() {
+            git rev-parse "refs/tags/${1}^{commit}" 2>/dev/null || git rev-parse "refs/tags/${1}"
+          }
+
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              tag="$INPUT_TAG"
+              validate_tag "$tag"
+              git fetch --force --tags origin
+              if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+                echo "::error::Tag ${tag} does not exist. workflow_dispatch is only for rerunning an existing release."
+                exit 1
+              fi
+              git checkout --detach "$tag"
+              version="${tag#v}"
+              ./scripts/check-release-version.sh "$version"
+              release_ref="$tag"
+              release_sha="$(tag_commit_sha "$tag")"
+              ;;
+            push)
+              commit_subject="${COMMIT_MESSAGE%%$'\n'*}"
+              tag="${commit_subject#chore(release): }"
+              tag="${tag%% \(#*}"
+              validate_tag "$tag"
+
+              version="${tag#v}"
+              ./scripts/check-release-version.sh "$version"
+
+              release_sha="${GITHUB_SHA}"
+              if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+                existing_sha="$(tag_commit_sha "$tag")"
+                if [[ "$existing_sha" != "$release_sha" ]]; then
+                  echo "::error::Tag ${tag} already exists but points to ${existing_sha}, not ${release_sha}."
+                  exit 1
+                fi
+              fi
+              release_ref="${release_sha}"
+              ;;
+            *)
+              echo "::error::Unsupported event: ${EVENT_NAME}"
+              exit 1
+              ;;
+          esac
+
+          prerelease=false
+          if [[ "$tag" == *-* ]]; then
+            prerelease=true
+          fi
+
+          {
+            echo "tag=${tag}"
+            echo "version=${version}"
+            echo "release_ref=${release_ref}"
+            echo "release_sha=${release_sha}"
+            echo "prerelease=${prerelease}"
+          } >> "$GITHUB_OUTPUT"
+
+  verify:
+    needs: prepare
+    if: needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          node-version: 25
-          cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.release_ref }}
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify release metadata
+        run: ./scripts/check-release-version.sh "${{ needs.prepare.outputs.version }}"
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify build artifacts
+        run: |
+          test -f dist/index.js
+          test -f dist/index.d.ts
+
+  release:
+    needs: [prepare, verify]
+    if: needs.prepare.result == 'success' && needs.verify.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.release_ref }}
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create release tag after verification
+        shell: bash
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+
+          tag_commit_sha() {
+            git rev-parse "refs/tags/${1}^{commit}" 2>/dev/null || git rev-parse "refs/tags/${1}"
+          }
+
+          git fetch --force --tags origin
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+            existing_sha="$(tag_commit_sha "$TAG")"
+            if [[ "$existing_sha" != "$RELEASE_SHA" ]]; then
+              echo "::error::Tag ${TAG} already exists but points to ${existing_sha}, not ${RELEASE_SHA}."
+              exit 1
+            fi
+          else
+            git tag "$TAG" "$RELEASE_SHA"
+            git push origin "refs/tags/${TAG}"
+          fi
+
+      - name: Build package artifacts
+        run: |
+          rm -rf dist-release
+          pnpm run build
+          mkdir -p dist-release
+          pnpm pack --pack-destination dist-release
+          (
+            cd dist-release
+            sha256sum *.tgz > SHA256SUMS.txt
+          )
+
+      - name: Extract release notes
+        shell: bash
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          python3 - "$VERSION" <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          version = sys.argv[1]
+          text = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          pattern = re.compile(
+              rf"(?ms)^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}\n.*?(?=^## \[|\Z)"
+          )
+          match = pattern.search(text)
+          if not match:
+            raise SystemExit(f"missing changelog section for {version}")
+          pathlib.Path("RELEASE_NOTES.md").write_text(match.group(0).strip() + "\n", encoding="utf-8")
+          PY
+
+      - name: Collect attestation subjects
+        id: attestation_subjects
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t subjects < <(find dist-release -maxdepth 1 -type f | sort)
+          if ((${#subjects[@]} == 0)); then
+            echo "::error::No release artifacts found to attest."
+            exit 1
+          fi
+          {
+            echo "subjects<<EOF"
+            printf '%s\n' "${subjects[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ${{ steps.attestation_subjects.outputs.subjects }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          target_commitish: ${{ needs.prepare.outputs.release_sha }}
+          name: ${{ needs.prepare.outputs.tag }}
+          prerelease: ${{ needs.prepare.outputs.prerelease }}
+          overwrite_files: true
+          body_path: RELEASE_NOTES.md
+          files: |
+            dist-release/*.tgz
+            dist-release/SHA256SUMS.txt
+
+  npm-publish:
+    needs: [prepare, release]
+    if: >-
+      needs.release.result == 'success' &&
+      (
+        inputs.publish-to-npm == true ||
+        (github.event_name == 'push' && vars.TELCLAUDE_PUBLISH_NPM == 'true')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.release_ref }}
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,31 +307,5 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Test
-        run: pnpm test
-
-      - name: Extract release notes
-        id: extract-release-notes
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          NOTES=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
-          if [ -z "$NOTES" ]; then
-            echo "::error::No release notes found for version $VERSION in CHANGELOG.md"
-            exit 1
-          fi
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          echo "$NOTES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
-        with:
-          body: ${{ steps.extract-release-notes.outputs.notes }}
-          draft: false
-          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
-
-      # Uncomment to publish to npm
-      # - name: Publish to npm
-      #   run: pnpm publish --access public --no-git-checks
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,31 @@
+# Release handbook
+
+## Contract
+
+- Release from `main` only through `./scripts/release.sh X.Y.Z` and the resulting release PR.
+- Do not create manual tags or GitHub releases.
+- The merged `chore(release): vX.Y.Z` commit is the source of truth for the tag, GitHub release notes, and `package.json` version.
+- The release workflow re-verifies that merged commit before creating the tag, builds the npm tarball as a release asset, and emits GitHub build provenance attestations for the shipped files.
+
+## Fast path
+
+```bash
+./scripts/release.sh 0.6.2
+```
+
+This script:
+
+1. Verifies the worktree is clean and `HEAD` matches `origin/main`.
+2. Creates `release/vX.Y.Z`.
+3. Moves `CHANGELOG.md`'s `Unreleased` section into the new release entry.
+4. Bumps `package.json` to the release version.
+5. Runs install/lint/typecheck/test/build unless `--skip-verify` is used.
+6. Opens a release PR and enables squash auto-merge by default.
+
+## After merge
+
+- `.github/workflows/release.yml` detects the merged `chore(release): vX.Y.Z` commit on `main`.
+- CI validates the merged release commit, creates the tag only after verification, builds the package tarball, and publishes the GitHub release from the committed changelog entry.
+- Optional npm publishing is available through trusted publishing. It stays off by default until the repo variable `TELCLAUDE_PUBLISH_NPM=true` or a manual dispatch with `publish-to-npm=true` is used and npm trusted publishing is configured for the package.
+
+`workflow_dispatch` is only for rerunning an existing tag.

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: ./scripts/check-release-version.sh <version|tag>" >&2
+}
+
+normalize_version() {
+  local raw="$1"
+  raw="${raw#v}"
+  if [[ ! "$raw" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+    echo "error: version must look like 0.6.2 or v0.6.2" >&2
+    exit 1
+  fi
+  printf '%s\n' "$raw"
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="$(normalize_version "$1")"
+
+python3 - "$VERSION" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+version = sys.argv[1]
+errors = []
+
+package = pathlib.Path("package.json")
+if not package.exists():
+    errors.append("package.json is missing")
+else:
+    package_version = json.loads(package.read_text(encoding="utf-8")).get("version")
+    if package_version != version:
+        errors.append(f"package.json version is {package_version!r}, expected {version!r}")
+
+changelog = pathlib.Path("CHANGELOG.md")
+if not changelog.exists():
+    errors.append("CHANGELOG.md is missing")
+else:
+    text = changelog.read_text(encoding="utf-8")
+    pattern = re.compile(rf"(?m)^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}$")
+    if not pattern.search(text):
+        errors.append(f"CHANGELOG.md is missing a release heading for {version}")
+
+if errors:
+    for err in errors:
+        print(f"error: {err}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"release metadata ok: v{version}")
+PY

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/release.sh X.Y.Z [options]
+
+Prepares a release PR from the default branch by:
+- verifying the worktree is clean
+- verifying HEAD matches origin/<default-branch>
+- creating release/vX.Y.Z
+- moving CHANGELOG.md's Unreleased section into a versioned release entry
+- bumping package.json to the release version
+- validating the release metadata
+- optionally running install/lint/typecheck/test/build
+- creating and pushing the release commit
+- opening a GitHub PR and enabling squash auto-merge
+
+Options:
+  --date YYYY-MM-DD  Override release date (default: today in UTC)
+  --skip-verify      Skip local verification gates
+  --allow-empty      Allow releasing with an empty Unreleased section
+  --no-auto-merge    Create the PR but do not enable auto-merge
+  -h, --help         Show this help text
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+normalize_version() {
+  local raw="$1"
+  raw="${raw#v}"
+  if [[ ! "$raw" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+    echo "error: version must look like 0.6.2 or v0.6.2" >&2
+    exit 1
+  fi
+  printf '%s\n' "$raw"
+}
+
+default_branch() {
+  local ref
+  ref="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [[ -z "$ref" ]]; then
+    echo "main"
+  else
+    echo "${ref#origin/}"
+  fi
+}
+
+version=""
+release_date="$(date -u +%Y-%m-%d)"
+skip_verify=0
+allow_empty=0
+auto_merge=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --date)
+      [[ $# -ge 2 ]] || { echo "error: --date requires a value" >&2; exit 1; }
+      release_date="$2"
+      shift 2
+      ;;
+    --skip-verify)
+      skip_verify=1
+      shift
+      ;;
+    --allow-empty)
+      allow_empty=1
+      shift
+      ;;
+    --no-auto-merge)
+      auto_merge=0
+      shift
+      ;;
+    --*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$version" ]]; then
+        echo "error: version already set to $version; unexpected extra argument: $1" >&2
+        usage >&2
+        exit 1
+      fi
+      version="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$version" ]] || { usage >&2; exit 1; }
+
+require_command git
+require_command gh
+require_command pnpm
+require_command python3
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="$(normalize_version "$version")"
+TAG="v${VERSION}"
+BRANCH="release/${TAG}"
+DEFAULT_BRANCH="$(default_branch)"
+
+git diff --quiet --ignore-submodules HEAD -- || {
+  echo "error: worktree is dirty; commit or stash first" >&2
+  exit 1
+}
+git diff --cached --quiet --ignore-submodules -- || {
+  echo "error: index has staged changes; commit or unstage first" >&2
+  exit 1
+}
+
+CURRENT_BRANCH="$(git branch --show-current)"
+[[ "$CURRENT_BRANCH" == "$DEFAULT_BRANCH" ]] || {
+  echo "error: releases must start from ${DEFAULT_BRANCH}; current branch is ${CURRENT_BRANCH}" >&2
+  exit 1
+}
+
+git fetch --quiet origin "$DEFAULT_BRANCH" --tags
+
+LOCAL_HEAD="$(git rev-parse HEAD)"
+REMOTE_HEAD="$(git rev-parse "origin/${DEFAULT_BRANCH}")"
+[[ "$LOCAL_HEAD" == "$REMOTE_HEAD" ]] || {
+  echo "error: local ${DEFAULT_BRANCH} is not at origin/${DEFAULT_BRANCH}; pull or fast-forward before releasing" >&2
+  exit 1
+}
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  echo "error: branch already exists locally: ${BRANCH}" >&2
+  exit 1
+fi
+if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+  echo "error: branch already exists on origin: ${BRANCH}" >&2
+  exit 1
+fi
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "error: tag already exists locally: ${TAG}" >&2
+  exit 1
+fi
+if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "error: tag already exists on origin: ${TAG}" >&2
+  exit 1
+fi
+
+git switch -c "$BRANCH"
+
+python3 - "$VERSION" "$release_date" "$allow_empty" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+version, release_date, allow_empty = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+
+changelog = pathlib.Path("CHANGELOG.md")
+text = changelog.read_text(encoding="utf-8")
+marker = "## [Unreleased]"
+if marker not in text:
+    raise SystemExit("error: CHANGELOG.md is missing the Unreleased section")
+
+start = text.index(marker)
+after_marker = start + len(marker)
+rest = text[after_marker:]
+match = re.search(r"(?m)^## \[", rest)
+if match:
+    unreleased_body = rest[:match.start()]
+    suffix = rest[match.start():]
+else:
+    unreleased_body = rest
+    suffix = ""
+
+if not unreleased_body.strip() and not allow_empty:
+    raise SystemExit("error: CHANGELOG.md Unreleased section is empty; add release notes first or pass --allow-empty")
+
+release_header = f"\n\n## [{version}] - {release_date}\n"
+new_text = text[:start] + marker + release_header + unreleased_body.lstrip("\n")
+if suffix:
+    new_text += suffix if suffix.startswith("\n") else "\n" + suffix
+changelog.write_text(new_text, encoding="utf-8")
+
+package_path = pathlib.Path("package.json")
+data = json.loads(package_path.read_text(encoding="utf-8"))
+data["version"] = version
+package_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [[ "$skip_verify" -eq 0 ]]; then
+  pnpm install --frozen-lockfile
+  pnpm run lint
+  pnpm run typecheck
+  pnpm test
+  pnpm run build
+fi
+
+./scripts/check-release-version.sh "$VERSION"
+
+git add CHANGELOG.md package.json
+git diff --cached --quiet && {
+  echo "error: release prep produced no staged changes" >&2
+  exit 1
+}
+
+git commit -m "chore(release): ${TAG}"
+git push -u origin "$BRANCH"
+
+PR_BODY=$(
+  cat <<EOF
+## Release
+
+- updates \`CHANGELOG.md\` for \`${TAG}\`
+- bumps \`package.json\` to \`${VERSION}\`
+- merge triggers \`.github/workflows/release.yml\`, which verifies the merged release commit before tagging
+- GitHub release assets are checksummed and attested; optional npm publishing is available through trusted publishing when enabled
+EOF
+)
+
+PR_URL="$(
+  gh pr create \
+    --base "$DEFAULT_BRANCH" \
+    --head "$BRANCH" \
+    --title "chore(release): ${TAG}" \
+    --body "$PR_BODY"
+)"
+
+if [[ "$auto_merge" -eq 1 ]]; then
+  gh pr merge "$PR_URL" --squash --auto --delete-branch
+fi
+
+echo "Created release PR: $PR_URL"


### PR DESCRIPTION
## Summary
- replace direct tag-push releases with a release PR flow
- verify the merged release commit before tagging and publishing
- add artifact attestations and optional npm trusted publishing