### PR TITLE
chore(dependabot): ignore pnpm action major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,5 +31,9 @@ updates:
     labels:
       - "ci"
       - "dependencies"
+    ignore:
+      - dependency-name: "pnpm/action-setup"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary
- ignore semver-major updates for `pnpm/action-setup`
- keep Dependabot noise down until we explicitly evaluate the next major action line
- supersedes the stale red branch on #77

## Validation
- config-only change
- current main verified locally with `corepack pnpm install --frozen-lockfile`