### PR TITLE
feat(skills): Share the managed skill catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ API keys (OpenAI, GitHub) are exposed for FULL_ACCESS tier only. READ_ONLY and W
 - **6 containers**: `telclaude` (relay), `telclaude-agent` (private persona), `agent-social` (social persona), `google-services`, `totp`, `vault`.
 - **Secrets storage**: `telclaude secrets setup-openai`, `telclaude secrets setup-git`; encrypted in volume.
 - **Workspace path**: `WORKSPACE_PATH` in `docker/.env` must point to valid host path.
-- **Claude profiles**: Docker uses a shared skills profile (`/home/telclaude-skills`) and a relay-only auth profile (`/home/telclaude-auth`). Anthropic access goes through the relay proxy; credentials never mount in agent containers.
+- **Claude profiles**: Docker uses per-agent Claude profiles (`/home/telclaude-skills` for private/social, `/home/telclaude-auth` for relay auth) plus a shared skill catalog (`/home/telclaude-skill-catalog`). `agent-social` mounts the shared catalog read-only; Anthropic access goes through the relay proxy and credentials never mount in agent containers.
 - **Remote deployment**: Build locally and transfer images to the deployment target:
   ```bash
   cd docker && docker compose build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,12 +139,13 @@ RUN groupmod -g ${USER_GID} node \
     && mkdir -p /home/node/.telclaude/sandbox-tmp \
     && mkdir -p /home/telclaude-auth \
     && mkdir -p /home/telclaude-skills \
+    && mkdir -p /home/telclaude-skill-catalog \
     && mkdir -p /workspace \
     && mkdir -p /data \
     # Remove shell rc files to prevent noisy "Permission denied" errors
     # when bash tries to source them inside the sandbox (which blocks reads)
     && rm -f /home/node/.bashrc /home/node/.profile \
-    && chown -R node:node /home/node /home/telclaude-auth /home/telclaude-skills /workspace /data
+    && chown -R node:node /home/node /home/telclaude-auth /home/telclaude-skills /home/telclaude-skill-catalog /workspace /data
 
 # Copy Claude CLI from builder stage
 COPY --from=claude-cli /usr/local/lib/node_modules/@anthropic-ai /usr/local/lib/node_modules/@anthropic-ai

--- a/docker/README.md
+++ b/docker/README.md
@@ -109,7 +109,7 @@ for containers that need initial root privileges.
 ./setup-volumes.sh
 ```
 
-This creates `telclaude-claude-auth`, `telclaude-totp-data`, and `telclaude-vault-data` as external volumes that **cannot be deleted** by `docker compose down -v`.
+This creates `telclaude-claude-auth`, `telclaude-skill-catalog`, `telclaude-totp-data`, and `telclaude-vault-data` as external volumes that **cannot be deleted** by `docker compose down -v`.
 
 **Note:** `docker compose up` will fail if these volumes don't exist. Always run `setup-volumes.sh` first.
 
@@ -140,13 +140,9 @@ docker run --rm -v telclaude-claude:/old:ro -v telclaude-claude-auth:/new \
   alpine cp -a /old/.credentials.json /new/ 2>/dev/null || true
 ```
 
-If you had custom skills in the old volume, copy them into the new shared skills volume:
-```bash
-docker volume create telclaude-claude-skills
-# Use your old volume name (e.g., telclaude-claude or telclaude-claude-private)
-docker run --rm -v telclaude-claude:/old:ro -v telclaude-claude-skills:/new \
-  alpine cp -a /old/skills /new/ 2>/dev/null || true
-```
+If you had custom skills in the old profile volumes, the new entrypoint will migrate
+legacy `skills/` and `skills-draft/` directories into `telclaude-skill-catalog`
+automatically on first boot.
 
 ## Volume Safety
 
@@ -157,12 +153,13 @@ Some volumes contain **critical secrets** that cannot be recovered if deleted.
 | Volume | Contains | If Deleted |
 |--------|----------|------------|
 | `telclaude-claude-auth` | Claude OAuth tokens | Must re-run `claude login` |
+| `telclaude-skill-catalog` | Shared active + draft skill catalog | Must reinstall or recreate custom skills |
 | `telclaude-totp-data` | Encrypted 2FA secrets | **UNRECOVERABLE** - must re-enroll all 2FA |
 | `telclaude-vault-data` | Encrypted credentials (API keys, OAuth tokens) | **UNRECOVERABLE** - must re-add all credentials |
 
 These are marked `external: true` in docker-compose.yml, so `docker compose down -v` **cannot delete them**.
 
-**Skills volume note:** Skills volumes (`telclaude-skills-telegram`, `telclaude-skills-social`) are **not** external and will be recreated automatically on restart.
+**Profile volume note:** The per-agent profile volumes (`telclaude-skills-telegram`, `telclaude-skills-social`) are **not** external. They only store profile-local state; the shared skill catalog lives in `telclaude-skill-catalog`.
 
 ### Safe Operations
 
@@ -208,8 +205,9 @@ docker run --rm -v telclaude-claude-auth:/data:ro -v $(pwd):/backup \
 | `telclaude-agent` | `/workspace` | Your projects folder | Host mount |
 | `telclaude` | `/data` | SQLite DB, config, sessions | Named volume |
 | `telclaude` | `/home/telclaude-auth` | Claude auth profile (OAuth tokens) | External volume |
-| `telclaude-agent` | `/home/telclaude-skills` | Claude skills + compiled private working-memory cache | Named volume |
-| `agent-social` | `/home/telclaude-skills` | Claude skills for social persona (no private Telegram memory) | Named volume |
+| `telclaude` + `telclaude-agent` + `agent-social` | `/home/telclaude-skill-catalog` | Shared active + draft skill catalog (`agent-social` mounts it read-only) | External volume |
+| `telclaude-agent` | `/home/telclaude-skills` | Private profile state (settings/cache, catalog symlinked in) | Named volume |
+| `agent-social` | `/home/telclaude-skills` | Social profile state (settings/cache, catalog symlinked in) | Named volume |
 | `telclaude` + `telclaude-agent` | `/media/inbox` + `/media/outbox` | Shared media (inbox/outbox split) | Named volume |
 | `agent-social` | `/social/sandbox` | Social isolated workspace | Named volume |
 | `telclaude` + `agent-social` | `/social/memory` | Social memory (relay RW, agent RO) | Named volume |
@@ -435,14 +433,14 @@ docker compose exec -e CLAUDE_CONFIG_DIR=/home/telclaude-auth telclaude claude l
 ### Reset session data (keeps secrets)
 
 ```bash
-# Remove containers and non-external volumes (keeps TOTP secrets, vault creds, and Claude auth)
+# Remove containers and non-external volumes (keeps auth, shared skills, TOTP secrets, and vault creds)
 docker compose down -v
 
 # Rebuild fresh
 docker compose up -d --build
 ```
 
-**Note:** External volumes (`telclaude-claude-auth`, `telclaude-totp-data`, `telclaude-vault-data`) are protected and will NOT be deleted by `docker compose down -v`.
+**Note:** External volumes (`telclaude-claude-auth`, `telclaude-skill-catalog`, `telclaude-totp-data`, `telclaude-vault-data`) are protected and will NOT be deleted by `docker compose down -v`.
 
 ## TOTP Daemon (2FA Support)
 

--- a/docker/apparmor/telclaude-agent
+++ b/docker/apparmor/telclaude-agent
@@ -45,8 +45,9 @@ profile telclaude-agent flags=(attach_disconnected,mediate_deleted) {
   # Workspace (read/write - this is where Claude works)
   /workspace/** rwklix,
 
-  # Claude skills profile (per-agent isolated volume)
+  # Claude profile state + shared skill catalog
   /home/telclaude-skills/** rwklix,
+  /home/telclaude-skill-catalog/** rwklix,
 
   # Deny social memory (telegram agent has no access — air-gap isolation)
   deny /social/memory/** rwklx,

--- a/docker/apparmor/telclaude-relay
+++ b/docker/apparmor/telclaude-relay
@@ -48,6 +48,7 @@ profile telclaude-relay flags=(attach_disconnected,mediate_deleted) {
   # Auth profile (OAuth tokens, skills)
   /home/telclaude-auth/** rwklix,
   /home/telclaude-skills/** rwklix,
+  /home/telclaude-skill-catalog/** rwklix,
 
   # Sidecar sockets (TOTP + vault)
   /run/totp/** rw,

--- a/docker/apparmor/telclaude-social
+++ b/docker/apparmor/telclaude-social
@@ -49,8 +49,10 @@ profile telclaude-social flags=(attach_disconnected,mediate_deleted) {
   /social/memory/** r,
   deny /social/memory/** wklx,
 
-  # Claude skills profile (shared)
+  # Claude profile state + shared skill catalog
   /home/telclaude-skills/** rwklix,
+  /home/telclaude-skill-catalog/** rklix,
+  deny /home/telclaude-skill-catalog/** w,
 
   # Config file (read-only)
   /data/telclaude.json r,

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -68,10 +68,11 @@ services:
       - TELCLAUDE_DATA_DIR=/data
       - TELCLAUDE_LOG_LEVEL=${TELCLAUDE_LOG_LEVEL:-info}
 
-      # Claude config dir = auth volume (relay-only, no skills needed)
+      # Relay keeps its own auth/profile state, but skills live in the shared catalog.
       - CLAUDE_CONFIG_DIR=/home/telclaude-auth
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-auth
       - TELCLAUDE_AUTH_DIR=/home/telclaude-auth
+      - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
 
       # Agent routing
       - TELCLAUDE_AGENT_URL=http://telclaude-agent:8788
@@ -111,6 +112,7 @@ services:
       - ./telclaude.json:/data/telclaude.json:ro
       - ./telclaude-private.json:/data/telclaude-private.json:ro
       - telclaude-claude-auth:/home/telclaude-auth:rw
+      - telclaude-skill-catalog:/home/telclaude-skill-catalog:rw
       - totp-socket:/run/totp:rw
       - vault-socket:/run/vault:ro
       - social-memory:/social/memory:rw
@@ -213,9 +215,10 @@ services:
       # Data dir (agent is stateless; uses tmpfs)
       - TELCLAUDE_DATA_DIR=/home/node/.telclaude
 
-      # Claude skills profile (shared)
+      # Private profile state stays local; installed skills come from the shared catalog.
       - CLAUDE_CONFIG_DIR=/home/telclaude-skills
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-skills
+      - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
 
       # Network / firewall
       - TELCLAUDE_FIREWALL=${TELCLAUDE_FIREWALL:-1}
@@ -232,6 +235,7 @@ services:
       - ${WORKSPACE_PATH:?WORKSPACE_PATH is required}:/workspace:rw
       - ./telclaude.json:/data/telclaude.json:ro
       - telclaude-skills-telegram:/home/telclaude-skills:rw
+      - telclaude-skill-catalog:/home/telclaude-skill-catalog:rw
       - media-inbox:/media/inbox:ro
       - media-outbox:/media/outbox:ro
 
@@ -299,6 +303,7 @@ services:
       - SOCIAL_RPC_RELAY_PUBLIC_KEY=${SOCIAL_RPC_RELAY_PUBLIC_KEY:-}
       - TELCLAUDE_CREDENTIAL_PROXY_URL=http://telclaude:8792
       - TELCLAUDE_DATA_DIR=/home/node/.telclaude
+      - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
       - TELCLAUDE_FIREWALL=${TELCLAUDE_FIREWALL:-1}
       - TELCLAUDE_FIREWALL_SKIP_PROVIDERS=1
       - TELCLAUDE_RUN_AS_ROOT=0
@@ -313,6 +318,7 @@ services:
       - ./telclaude.json:/data/telclaude.json:ro
       - social-memory:/social/memory:ro
       - telclaude-skills-social:/home/telclaude-skills:rw
+      - telclaude-skill-catalog:/home/telclaude-skill-catalog:ro
 
     user: "0:0"
 
@@ -553,12 +559,17 @@ volumes:
   media-outbox:
     name: telclaude-media-outbox
 
-  # Claude skills profiles (per-agent isolation — no shared state between personas)
+  # Per-agent Claude profile state (settings/cache). Skills live in the shared catalog below.
   telclaude-skills-telegram:
     name: telclaude-skills-telegram
 
   telclaude-skills-social:
     name: telclaude-skills-social
+
+  # Shared operator-managed skill catalog (active + draft) across all personas.
+  telclaude-skill-catalog:
+    name: telclaude-skill-catalog
+    external: true
 
   # Social isolated workspace (agent-social RW)
   social-sandbox:

--- a/docker/docker-compose.override.yml.example
+++ b/docker/docker-compose.override.yml.example
@@ -13,10 +13,10 @@
 #      - telclaude-media-outbox
 #   3. Proper permissions (containers run as UID 1000)
 #
-# NOTE: telclaude-claude-auth / telclaude-claude-skills are intentionally NOT included here.
-# They stay on local storage because NFS with UID squashing can cause
-# permission issues with Claude config files. The volumes are small
-# (config only) so local storage performance is fine.
+# NOTE: telclaude-claude-auth / telclaude-skill-catalog / telclaude-skills-* are
+# intentionally NOT included here. They stay on local storage because NFS with
+# UID squashing can cause permission issues with Claude config files and the
+# shared skill catalog. The volumes are small, so local storage performance is fine.
 #
 # Usage:
 #   cp docker-compose.override.yml.example docker-compose.override.yml

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,10 +67,11 @@ services:
       - TELCLAUDE_PRIVATE_CONFIG=/data/telclaude-private.json
       - TELCLAUDE_DATA_DIR=/data
       - TELCLAUDE_LOG_LEVEL=${TELCLAUDE_LOG_LEVEL:-info}
-      # Claude config dir = auth volume (relay-only).
+      # Relay keeps its own auth/profile state, but skills live in the shared catalog.
       - CLAUDE_CONFIG_DIR=/home/telclaude-auth
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-auth
       - TELCLAUDE_AUTH_DIR=/home/telclaude-auth
+      - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
       - TELCLAUDE_AGENT_URL=http://telclaude-agent:8788
       - TELCLAUDE_SOCIAL_AGENT_URL=http://agent-social:8789
       # X/Twitter — relay routes through its own credential proxy
@@ -115,8 +116,10 @@ services:
       - ./telclaude.json:/data/telclaude.json:ro
       - ./telclaude-private.json:/data/telclaude-private.json:ro
 
-      # Claude config (auth + skills installed at runtime) — relay-only
+      # Claude auth/profile state (OAuth tokens + settings) — relay-only
       - telclaude-claude-auth:/home/telclaude-auth:rw
+      # Shared skill catalog (active + draft) across relay, private, and social.
+      - telclaude-skill-catalog:/home/telclaude-skill-catalog:rw
 
       # Shared socket for TOTP daemon communication
       - totp-socket:/run/totp:rw
@@ -241,9 +244,10 @@ services:
       # Data dir override (agent is stateless; uses tmpfs instead of /data volume)
       - TELCLAUDE_DATA_DIR=/home/node/.telclaude
 
-      # Claude skills profile (shared with relay)
+      # Private profile state stays local; installed skills come from the shared catalog.
       - CLAUDE_CONFIG_DIR=/home/telclaude-skills
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-skills
+      - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
 
       # SECURITY: Network firewall for tool egress control (Docker mode)
       - TELCLAUDE_FIREWALL=${TELCLAUDE_FIREWALL:-1}
@@ -267,8 +271,10 @@ services:
       # Policy config (no secrets — providers, network rules, etc.)
       - ./telclaude.json:/data/telclaude.json:ro
 
-      # Claude skills profile (per-agent isolation — no shared state with social agent)
+      # Private profile state (settings/cache) stays isolated.
       - telclaude-skills-telegram:/home/telclaude-skills:rw
+      # Shared operator-managed skill catalog.
+      - telclaude-skill-catalog:/home/telclaude-skill-catalog:rw
 
       # Shared media volumes (inbox/outbox split)
       - media-inbox:/media/inbox:ro
@@ -340,6 +346,7 @@ services:
       - HOME=/social
       - CLAUDE_CONFIG_DIR=/home/telclaude-skills
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-skills
+      - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
       # Social auth — agent holds AGENT PRIVATE key (signs agent→relay) + RELAY PUBLIC key (verifies relay→agent)
       - SOCIAL_RPC_AGENT_PRIVATE_KEY=${SOCIAL_RPC_AGENT_PRIVATE_KEY:-}
       - SOCIAL_RPC_RELAY_PUBLIC_KEY=${SOCIAL_RPC_RELAY_PUBLIC_KEY:-}
@@ -361,6 +368,7 @@ services:
       - ./telclaude.json:/data/telclaude.json:ro
       - social-memory:/social/memory:ro
       - telclaude-skills-social:/home/telclaude-skills:rw
+      - telclaude-skill-catalog:/home/telclaude-skill-catalog:ro
 
     user: "0:0"
 
@@ -743,12 +751,17 @@ volumes:
   social-memory:
     name: telclaude-social-memory
 
-  # Claude skills profiles (per-agent isolation — no shared state between personas)
+  # Per-agent Claude profile state (settings/cache). Skills live in the shared catalog below.
   telclaude-skills-telegram:
     name: telclaude-skills-telegram
 
   telclaude-skills-social:
     name: telclaude-skills-social
+
+  # Shared operator-managed skill catalog (active + draft) across all personas.
+  telclaude-skill-catalog:
+    name: telclaude-skill-catalog
+    external: true
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Networks

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -25,6 +25,7 @@ TELCLAUDE_UID="${TELCLAUDE_UID:-1000}"
 TELCLAUDE_GID="${TELCLAUDE_GID:-1000}"
 TELCLAUDE_CLAUDE_HOME="${TELCLAUDE_CLAUDE_HOME:-${CLAUDE_CONFIG_DIR:-/home/telclaude-skills}}"
 TELCLAUDE_AUTH_DIR="${TELCLAUDE_AUTH_DIR:-/home/telclaude-auth}"
+TELCLAUDE_SKILL_CATALOG_DIR="${TELCLAUDE_SKILL_CATALOG_DIR:-}"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Privileged Operations (run as root)
@@ -63,7 +64,7 @@ if [ "$(id -u)" = "0" ]; then
     touch /home/node/.telclaude/logs/telclaude.log
     chown -R "${TELCLAUDE_UID}:${TELCLAUDE_GID}" /home/node/.telclaude 2>/dev/null || true
 
-    for dir in /data /home/node "${TELCLAUDE_CLAUDE_HOME}" "${TELCLAUDE_AUTH_DIR}" /media/inbox /media/outbox; do
+    for dir in /data /home/node "${TELCLAUDE_CLAUDE_HOME}" "${TELCLAUDE_AUTH_DIR}" "${TELCLAUDE_SKILL_CATALOG_DIR}" /media/inbox /media/outbox; do
         if [ -d "$dir" ]; then
             # Only chown if not already owned by the target user
             if [ "$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)" != "$TELCLAUDE_UID" ]; then

--- a/docker/install-claude-assets.sh
+++ b/docker/install-claude-assets.sh
@@ -1,32 +1,125 @@
 #!/bin/sh
-# Install bundled Claude assets into the writable profile volume.
+# Install bundled Claude assets into the writable profile volume or the shared
+# skill catalog.
 #
 # Repo-local `.claude/skills/*` entries are symlinks into `.agents/skills/*`.
-# When these are copied into a different root (for example `/home/telclaude-auth`)
-# the relative symlinks break unless we dereference them during install.
+# When these are copied into a different root (for example `/home/telclaude-auth`
+# or `/home/telclaude-skill-catalog`) the relative symlinks break unless we
+# dereference them during install. We also migrate any legacy per-profile
+# `skills/` and `skills-draft/` directories into the shared catalog before
+# replacing them with symlinks.
 set -eu
 
 TELCLAUDE_CLAUDE_HOME="${TELCLAUDE_CLAUDE_HOME:-${CLAUDE_CONFIG_DIR:-/home/telclaude-skills}}"
+TELCLAUDE_SKILL_CATALOG_DIR="${TELCLAUDE_SKILL_CATALOG_DIR:-}"
 TELCLAUDE_BUNDLED_CLAUDE_DIR="${TELCLAUDE_BUNDLED_CLAUDE_DIR:-/app/.claude}"
 TELCLAUDE_UID="${TELCLAUDE_UID:-1000}"
 TELCLAUDE_GID="${TELCLAUDE_GID:-1000}"
+ACTIVE_SKILLS_DIR="${TELCLAUDE_CLAUDE_HOME}/skills"
+DRAFT_SKILLS_DIR="${TELCLAUDE_CLAUDE_HOME}/skills-draft"
+CAN_MUTATE_SKILL_CATALOG=1
 
-if [ -d "${TELCLAUDE_BUNDLED_CLAUDE_DIR}/skills" ]; then
+can_write_dir() {
+	dir="$1"
+	test_file="${dir}/.telclaude-write-test.$$"
+
+	if ! mkdir -p "${dir}" 2>/dev/null; then
+		return 1
+	fi
+
+	if ! (umask 077 && : >"${test_file}") 2>/dev/null; then
+		return 1
+	fi
+
+	rm -f "${test_file}"
+	return 0
+}
+
+merge_missing_entries() {
+	source_dir="$1"
+	target_dir="$2"
+
+	if [ ! -d "${source_dir}" ] || [ -L "${source_dir}" ]; then
+		return 0
+	fi
+
+	echo "[entrypoint] Migrating legacy skill data from ${source_dir} to ${target_dir}"
+	mkdir -p "${target_dir}"
+
+	for entry in "${source_dir}"/* "${source_dir}"/.[!.]* "${source_dir}"/..?*; do
+		if [ ! -e "${entry}" ] && [ ! -L "${entry}" ]; then
+			continue
+		fi
+
+		entry_name=$(basename "${entry}")
+		if [ -e "${target_dir}/${entry_name}" ] || [ -L "${target_dir}/${entry_name}" ]; then
+			continue
+		fi
+
+		cp -a "${entry}" "${target_dir}/${entry_name}"
+	done
+}
+
+ensure_symlink() {
+	link_path="$1"
+	target_path="$2"
+
+	if [ -L "${link_path}" ] && [ "$(readlink "${link_path}")" = "${target_path}" ]; then
+		return 0
+	fi
+
+	rm -rf "${link_path}"
+	ln -s "${target_path}" "${link_path}"
+}
+
+materialize_skill() {
+	source_path="$1"
+	skill_name=$(basename "${source_path}")
+	target_path="${ACTIVE_SKILLS_DIR}/${skill_name}"
+
+	if [ -L "${target_path}" ] || [ -f "${target_path}" ]; then
+		rm -rf "${target_path}"
+	fi
+
+	mkdir -p "${target_path}"
+	cp -RL "${source_path}/." "${target_path}/"
+}
+
+if [ -n "${TELCLAUDE_SKILL_CATALOG_DIR}" ]; then
+	ACTIVE_SKILLS_DIR="${TELCLAUDE_SKILL_CATALOG_DIR}/skills"
+	DRAFT_SKILLS_DIR="${TELCLAUDE_SKILL_CATALOG_DIR}/skills-draft"
+	mkdir -p "${TELCLAUDE_CLAUDE_HOME}"
+	if can_write_dir "${TELCLAUDE_SKILL_CATALOG_DIR}"; then
+		mkdir -p "${ACTIVE_SKILLS_DIR}" "${DRAFT_SKILLS_DIR}"
+		merge_missing_entries "${TELCLAUDE_CLAUDE_HOME}/skills" "${ACTIVE_SKILLS_DIR}"
+		merge_missing_entries "${TELCLAUDE_CLAUDE_HOME}/skills-draft" "${DRAFT_SKILLS_DIR}"
+	else
+		CAN_MUTATE_SKILL_CATALOG=0
+		echo "[entrypoint] Shared skill catalog is read-only; skipping catalog mutation"
+	fi
+	ensure_symlink "${TELCLAUDE_CLAUDE_HOME}/skills" "${ACTIVE_SKILLS_DIR}"
+	ensure_symlink "${TELCLAUDE_CLAUDE_HOME}/skills-draft" "${DRAFT_SKILLS_DIR}"
+fi
+
+if [ "${CAN_MUTATE_SKILL_CATALOG}" = "1" ] && [ -d "${TELCLAUDE_BUNDLED_CLAUDE_DIR}/skills" ]; then
 	echo "[entrypoint] Installing bundled skills"
-	mkdir -p "${TELCLAUDE_CLAUDE_HOME}/skills"
+	mkdir -p "${ACTIVE_SKILLS_DIR}"
 
 	for skill_path in "${TELCLAUDE_BUNDLED_CLAUDE_DIR}"/skills/*; do
 		if [ ! -e "${skill_path}" ] && [ ! -L "${skill_path}" ]; then
 			continue
 		fi
 
-		skill_name=$(basename "${skill_path}")
-		rm -rf "${TELCLAUDE_CLAUDE_HOME}/skills/${skill_name}"
-		cp -RL "${skill_path}" "${TELCLAUDE_CLAUDE_HOME}/skills/${skill_name}"
+		materialize_skill "${skill_path}"
 	done
 
 	# chown may fail on NFS with UID squashing; the copied files remain readable.
-	chown -R "${TELCLAUDE_UID}:${TELCLAUDE_GID}" "${TELCLAUDE_CLAUDE_HOME}" 2>/dev/null || true
+	chown -R "${TELCLAUDE_UID}:${TELCLAUDE_GID}" \
+		"${TELCLAUDE_CLAUDE_HOME}" \
+		"${ACTIVE_SKILLS_DIR}" \
+		"${DRAFT_SKILLS_DIR}" 2>/dev/null || true
+elif [ "${CAN_MUTATE_SKILL_CATALOG}" = "0" ] && [ -d "${TELCLAUDE_BUNDLED_CLAUDE_DIR}/skills" ]; then
+	echo "[entrypoint] Shared skill catalog is read-only; assuming another container materialized bundled skills"
 fi
 
 if [ -f "${TELCLAUDE_BUNDLED_CLAUDE_DIR}/CLAUDE.md" ]; then

--- a/docker/setup-volumes.sh
+++ b/docker/setup-volumes.sh
@@ -22,6 +22,14 @@ else
     echo "✓ Created telclaude-claude-auth"
 fi
 
+# Shared skill catalog (active + draft skills for private + social agents)
+if docker volume inspect telclaude-skill-catalog >/dev/null 2>&1; then
+    echo "✓ telclaude-skill-catalog already exists"
+else
+    docker volume create telclaude-skill-catalog
+    echo "✓ Created telclaude-skill-catalog"
+fi
+
 # TOTP secrets (encrypted 2FA seeds) - CRITICAL
 if docker volume inspect telclaude-totp-data >/dev/null 2>&1; then
     echo "✓ telclaude-totp-data already exists"
@@ -43,6 +51,7 @@ echo "Volume setup complete!"
 echo ""
 echo "⚠️  IMPORTANT: Back up these volumes regularly:"
 echo "   - telclaude-claude-auth: Claude OAuth tokens"
+echo "   - telclaude-skill-catalog: Shared installed + draft skills"
 echo "   - telclaude-totp-data: Encrypted 2FA secrets (CANNOT be recovered if lost)"
 echo "   - telclaude-vault-data: Encrypted credentials (CANNOT be recovered if lost)"
 echo ""

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,16 +1,19 @@
 # Skills — scaffold, promote, and doctor
 
-Telclaude skills live under `.claude/skills/<name>/`. Draft skills live under
-`.claude/skills-draft/<name>/` until promoted. This document explains the
-lifecycle: scaffold → edit → doctor/scan → promote → reload.
+Telclaude has one canonical writable skill store plus optional read-only skill
+roots. Active skills live under `<skill-root>/skills/<name>/`. Draft skills
+live under `<skill-root>/skills-draft/<name>/` until promoted. This document
+explains the lifecycle: scaffold → edit → doctor/scan → promote → reload.
 
 ## The canonical skill root
 
-The writable skill root is resolved by `getSkillRoot()` in
-`src/commands/skill-path.ts`. Candidates, in priority order, are:
+The writable skill root is resolved by `getSkillRoot()` /
+`getDraftSkillRoot()` in `src/commands/skill-path.ts`. Candidates, in priority
+order, are:
 
-1. `<cwd>/.claude/skills/` (project-local)
+1. `$TELCLAUDE_SKILL_CATALOG_DIR/skills/` and `/skills-draft/` when set
 2. `$CLAUDE_CONFIG_DIR/skills/` or `$TELCLAUDE_CLAUDE_HOME/skills/`
+3. `<cwd>/.claude/skills/` and `.claude/skills-draft/`
 
 If none of these are writable, `getSkillRoot()` throws
 `SkillRootUnavailableError`. There is no silent fallback to prompt-injection
@@ -21,10 +24,16 @@ Read-only consumers (e.g. `telclaude skill-path`) additionally fall back to
 the bundled skill directory shipped inside the telclaude package. Writers
 never touch that directory.
 
+In Docker, telclaude uses the Hermes-style idiom: both private and social keep
+their own Claude profile state, but they share one operator-managed skill
+catalog. `agent-social` mounts that catalog read-only; social-specific
+restrictions are enforced at runtime policy plus the container boundary, not by
+installing skills into a different location.
+
 ## `telclaude skills scaffold <name>`
 
-Creates a new draft skill under `.claude/skills-draft/<name>/` from a
-template. The scaffold is pre-filled with:
+Creates a new draft skill under the canonical draft root from a template. The
+scaffold is pre-filled with:
 
 - `SKILL.md` — valid YAML frontmatter (`name`, `description`, `allowed-tools`).
 - `scripts/`, `references/`, `assets/` — empty subdirectories with `.gitkeep`.
@@ -45,13 +54,13 @@ telclaude skills scaffold my-helper --template api-client \
   --description "Use when the user asks about the Acme API."
 ```
 
-Collisions (existing `.claude/skills-draft/<name>/`) fail with an explicit
+Collisions (existing draft with the same name in the canonical draft root) fail with an explicit
 error — the scaffold refuses to overwrite.
 
 ## `telclaude skills doctor`
 
-Walks every active (under `.claude/skills/`) and draft (under
-`.claude/skills-draft/`) skill, and for each emits one of:
+Walks every active and draft skill discovered through the canonical root
+helpers, and for each emits one of:
 
 - `[PASS]` — frontmatter valid, scanner clean.
 - `[WARN]` — scanner saw medium-severity findings, frontmatter has
@@ -95,6 +104,6 @@ removes the draft. Rules:
 
 - `security-gate` and `telegram-reply` are **immutable core skills** — any
   attempt to promote them is rejected.
-- Imports from OpenClaw land in `.claude/skills-draft/<name>/` and must go
-  through the same `/skills promote` gate.
+- Imports from OpenClaw land in the canonical draft root and must go through
+  the same `/skills promote` gate.
 - Promotion re-runs the scanner; critical/high findings block promotion.

--- a/src/commands/audit-collectors.ts
+++ b/src/commands/audit-collectors.ts
@@ -21,6 +21,7 @@ import { getSandboxMode } from "../sandbox/index.js";
 import { auditSandboxPosture } from "../sandbox/validate-config.js";
 import { TIER_TOOLS } from "../security/permissions.js";
 import { scanAllSkills } from "../security/skill-scanner.js";
+import { getAllDraftSkillRoots, getWritableSkillRootCandidates } from "./skill-path.js";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Types
@@ -307,17 +308,9 @@ export function collectFilesystemFindings(cwd: string): AuditFinding[] {
 
 export function collectSkillTrustFindings(cwd: string): AuditFinding[] {
 	const findings: AuditFinding[] = [];
-
-	const skillRoots = [
-		path.join(cwd, ".claude", "skills"),
-		path.join(cwd, ".claude", "skills-draft"),
-	];
-
-	// Also check CLAUDE_CONFIG_DIR skills (Docker profiles)
-	const configDir = process.env.CLAUDE_CONFIG_DIR;
-	if (configDir) {
-		skillRoots.push(path.join(configDir, "skills"));
-	}
+	const activeRoots = getWritableSkillRootCandidates(cwd);
+	const draftRoots = getAllDraftSkillRoots(cwd);
+	const skillRoots = [...activeRoots, ...draftRoots];
 
 	let totalSkills = 0;
 	let blockedSkills = 0;
@@ -350,8 +343,8 @@ export function collectSkillTrustFindings(cwd: string): AuditFinding[] {
 	}
 
 	// Skills-draft directory exists — draft skills are unvetted
-	const draftDir = path.join(cwd, ".claude", "skills-draft");
-	if (fs.existsSync(draftDir)) {
+	for (const draftDir of draftRoots) {
+		if (!fs.existsSync(draftDir)) continue;
 		try {
 			const entries = fs.readdirSync(draftDir, { withFileTypes: true });
 			const draftCount = entries.filter((e) => e.isDirectory()).length;

--- a/src/commands/doctor-helpers.ts
+++ b/src/commands/doctor-helpers.ts
@@ -17,7 +17,7 @@ import path from "node:path";
 import type { TelclaudeConfig } from "../config/config.js";
 import { fetchWithTimeout } from "../infra/timeout.js";
 import { getChildLogger } from "../logging.js";
-import { getAllSkillRoots } from "./skill-path.js";
+import { getAllDraftSkillRoots, getAllSkillRoots } from "./skill-path.js";
 
 const logger = getChildLogger({ module: "doctor-helpers" });
 
@@ -537,11 +537,7 @@ export async function checkProviders(cfg: TelclaudeConfig): Promise<CheckResult[
  */
 export async function checkSkills(cwd: string = process.cwd()): Promise<CheckResult[]> {
 	const { scanAllSkills } = await import("../security/skill-scanner.js");
-	const roots = getAllSkillRoots(cwd);
-	// Also include the project-local drafts root when it exists, so
-	// promotion candidates are vetted before they're flipped live.
-	const extra = path.join(cwd, ".claude", "skills-draft");
-	if (fs.existsSync(extra)) roots.push(extra);
+	const roots = [...getAllSkillRoots(cwd), ...getAllDraftSkillRoots(cwd)];
 
 	const checks: CheckResult[] = [];
 	let totalScanned = 0;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import path from "node:path";
 import type { Command } from "commander";
 import { loadConfig } from "../config/config.js";
 import { resolveConfigPath } from "../config/path.js";
@@ -33,7 +32,7 @@ import {
 	type DoctorReport,
 	worstStatus,
 } from "./doctor-helpers.js";
-import { getAllSkillRoots } from "./skill-path.js";
+import { getAllDraftSkillRoots, getAllSkillRoots } from "./skill-path.js";
 
 const logger = getChildLogger({ module: "cmd-doctor" });
 
@@ -294,10 +293,7 @@ function runSecretsDump(stream: NodeJS.WriteStream): void {
 
 function runSkillsDump(stream: NodeJS.WriteStream): void {
 	stream.write("\n\u{1F50D} Skill Static Code Scanner\n");
-	// Canonical roots + draft staging area.
-	const roots = getAllSkillRoots();
-	const draftRoot = path.join(process.cwd(), ".claude", "skills-draft");
-	if (fs.existsSync(draftRoot)) roots.push(draftRoot);
+	const roots = [...getAllSkillRoots(), ...getAllDraftSkillRoots()];
 
 	let totalResults: ReturnType<typeof scanAllSkills> = [];
 	for (const root of roots) {

--- a/src/commands/skill-path.ts
+++ b/src/commands/skill-path.ts
@@ -10,7 +10,7 @@ export class SkillRootUnavailableError extends Error {
 	constructor(searched: string[]) {
 		super(
 			`No writable skill root found. Searched:\n${searched.map((p) => `  - ${p}`).join("\n")}\n\n` +
-				`Fix by creating one of these directories with write access, or set CLAUDE_CONFIG_DIR / TELCLAUDE_CLAUDE_HOME to a writable absolute path.`,
+				`Fix by creating one of these directories with write access, or set TELCLAUDE_SKILL_CATALOG_DIR / CLAUDE_CONFIG_DIR / TELCLAUDE_CLAUDE_HOME to a writable absolute path.`,
 		);
 		this.name = "SkillRootUnavailableError";
 		this.searched = searched;
@@ -19,6 +19,14 @@ export class SkillRootUnavailableError extends Error {
 
 function getConfiguredClaudeHome(): string | null {
 	const raw = process.env.CLAUDE_CONFIG_DIR ?? process.env.TELCLAUDE_CLAUDE_HOME;
+	if (!raw || raw.startsWith("~") || !path.isAbsolute(raw)) {
+		return null;
+	}
+	return raw.replace(/[/\\]+$/, "");
+}
+
+function getConfiguredSkillCatalog(): string | null {
+	const raw = process.env.TELCLAUDE_SKILL_CATALOG_DIR;
 	if (!raw || raw.startsWith("~") || !path.isAbsolute(raw)) {
 		return null;
 	}
@@ -59,15 +67,43 @@ function dedupePaths(paths: readonly (string | null | undefined)[]): string[] {
 
 /**
  * Build the ordered list of candidate skill roots (writable or not),
- * used for READING bundled assets. Order: project-local, configured Claude home,
- * bundled distribution root.
+ * used for READING skill assets. In catalog mode the managed catalog wins,
+ * with project-local skills treated as external overlays. Otherwise we keep
+ * the historical project-local → configured home → bundled order.
  */
 export function getAllSkillRoots(cwd: string = process.cwd()): string[] {
 	const configuredClaudeHome = getConfiguredClaudeHome();
+	const configuredSkillCatalog = getConfiguredSkillCatalog();
+	if (configuredSkillCatalog) {
+		return dedupePaths([
+			path.join(configuredSkillCatalog, "skills"),
+			path.join(cwd, ".claude", "skills"),
+			getBundledSkillsRoot(),
+		]);
+	}
 	return dedupePaths([
 		path.join(cwd, ".claude", "skills"),
 		configuredClaudeHome ? path.join(configuredClaudeHome, "skills") : null,
 		getBundledSkillsRoot(),
+	]);
+}
+
+/**
+ * Build the ordered list of candidate draft-skill roots for READING and
+ * scanning. Mirrors getAllSkillRoots() but targets the quarantine area.
+ */
+export function getAllDraftSkillRoots(cwd: string = process.cwd()): string[] {
+	const configuredClaudeHome = getConfiguredClaudeHome();
+	const configuredSkillCatalog = getConfiguredSkillCatalog();
+	if (configuredSkillCatalog) {
+		return dedupePaths([
+			path.join(configuredSkillCatalog, "skills-draft"),
+			path.join(cwd, ".claude", "skills-draft"),
+		]);
+	}
+	return dedupePaths([
+		path.join(cwd, ".claude", "skills-draft"),
+		configuredClaudeHome ? path.join(configuredClaudeHome, "skills-draft") : null,
 	]);
 }
 
@@ -78,8 +114,12 @@ export function getAllSkillRoots(cwd: string = process.cwd()): string[] {
  */
 export function getWritableSkillRootCandidates(cwd: string = process.cwd()): string[] {
 	const configuredClaudeHome = getConfiguredClaudeHome();
+	const configuredSkillCatalog = getConfiguredSkillCatalog();
 	return dedupePaths([
-		configuredClaudeHome ? path.join(configuredClaudeHome, "skills") : null,
+		configuredSkillCatalog ? path.join(configuredSkillCatalog, "skills") : null,
+		!configuredSkillCatalog && configuredClaudeHome
+			? path.join(configuredClaudeHome, "skills")
+			: null,
 		path.join(cwd, ".claude", "skills"),
 	]);
 }
@@ -90,8 +130,12 @@ export function getWritableSkillRootCandidates(cwd: string = process.cwd()): str
  */
 export function getWritableDraftSkillRootCandidates(cwd: string = process.cwd()): string[] {
 	const configuredClaudeHome = getConfiguredClaudeHome();
+	const configuredSkillCatalog = getConfiguredSkillCatalog();
 	return dedupePaths([
-		configuredClaudeHome ? path.join(configuredClaudeHome, "skills-draft") : null,
+		configuredSkillCatalog ? path.join(configuredSkillCatalog, "skills-draft") : null,
+		!configuredSkillCatalog && configuredClaudeHome
+			? path.join(configuredClaudeHome, "skills-draft")
+			: null,
 		path.join(cwd, ".claude", "skills-draft"),
 	]);
 }

--- a/src/commands/skill-scaffold.ts
+++ b/src/commands/skill-scaffold.ts
@@ -1,7 +1,7 @@
 /**
  * Skill scaffold command.
  *
- * Creates a new draft skill under `.claude/skills-draft/<name>/` populated
+ * Creates a new draft skill under the canonical draft-skill root populated
  * from a template. The scaffold fills in frontmatter, creates the expected
  * subdirectories (scripts/, references/, assets/) and drops a PREVIEW.md
  * checklist the operator walks before promotion.
@@ -79,7 +79,7 @@ function renderPreview(name: string, template: SkillTemplate): string {
 		`- [ ] Trim \`allowed-tools\` to the minimum set needed. Avoid Bash/Write/Edit/NotebookEdit unless required.`,
 		`- [ ] Delete the boilerplate sections you do not need. Keep the prose tight.`,
 		`- [ ] Add or remove bundled resources in \`scripts/\`, \`references/\`, \`assets/\` to match the skill.`,
-		`- [ ] Run \`telclaude skills scan --path .claude/skills-draft/${name}\` and fix any findings.`,
+		`- [ ] Run \`telclaude skills scan --path <this-draft-dir>\` and fix any findings.`,
 		`- [ ] Run \`telclaude skills doctor\` and confirm this skill passes.`,
 		`- [ ] When ready, promote via \`telclaude skills promote ${name}\` or \`/skills promote ${name}\`.`,
 		"",

--- a/src/commands/skills-doctor.ts
+++ b/src/commands/skills-doctor.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 import type { Command } from "commander";
 import { getChildLogger } from "../logging.js";
 import { type ScanResult, scanSkill } from "../security/skill-scanner.js";
-import { getAllSkillRoots, getWritableDraftSkillRootCandidates } from "./skill-path.js";
+import { getAllDraftSkillRoots, getAllSkillRoots } from "./skill-path.js";
 
 const logger = getChildLogger({ module: "cmd-skills-doctor" });
 
@@ -249,7 +249,7 @@ export function runSkillsDoctor(options?: {
 	draftRoots?: string[];
 }): SkillDoctorReport {
 	const activeRoots = options?.activeRoots ?? getAllSkillRoots(options?.cwd);
-	const draftRoots = options?.draftRoots ?? getWritableDraftSkillRootCandidates(options?.cwd);
+	const draftRoots = options?.draftRoots ?? getAllDraftSkillRoots(options?.cwd);
 
 	const active = collectSkillsFromRoots(activeRoots, "active");
 	const draft = collectSkillsFromRoots(draftRoots, "draft");

--- a/src/commands/skills-import.ts
+++ b/src/commands/skills-import.ts
@@ -5,14 +5,14 @@
  * OpenClaw skills are pure markdown (SKILL.md + frontmatter) — same family
  * as Claude skills. Most work in telclaude with a thin adapter.
  *
- * Imports land in the draft quarantine (.claude/skills-draft/<name>/); operator
+ * Imports land in the canonical draft quarantine (<draft-root>/<name>); operator
  * runs `telclaude skills promote <name>` or `/skills promote <name>` to activate.
  * This keeps imports on the same review path as locally authored skills.
  *
  * Steps:
  * 1. Read OpenClaw skill dirs (skills/, .agents/skills/, extensions/&lt;ext&gt;/skills)
  * 2. Convert frontmatter: keep name, description, allowed-tools; strip OpenClaw-specific
- * 3. Copy to .claude/skills-draft/<skill-name>/SKILL.md (quarantine, not active)
+ * 3. Copy to <draft-root>/<skill-name>/SKILL.md (quarantine, not active)
  * 4. Run skill scanner before activation — block malicious patterns
  * 5. Refuse auto-install directives
  * 6. Report results
@@ -22,6 +22,12 @@ import fs from "node:fs";
 import path from "node:path";
 import type { Command } from "commander";
 import { scanSkill } from "../security/skill-scanner.js";
+import {
+	getAllDraftSkillRoots,
+	getAllSkillRoots,
+	getDraftSkillRoot,
+	SkillRootUnavailableError,
+} from "./skill-path.js";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // OpenClaw Skill Discovery
@@ -343,13 +349,12 @@ export function registerSkillsImportSubcommands(parent: Command): void {
 	parent
 		.command("import-openclaw")
 		.description(
-			"Import skills from an OpenClaw-format directory into the draft quarantine (.claude/skills-draft/)",
+			"Import skills from an OpenClaw-format directory into the canonical draft quarantine",
 		)
 		.argument("<source>", "Path to OpenClaw source directory")
 		.option(
 			"--target <dir>",
-			"Target directory for imported skills (default: .claude/skills-draft/; promote with `telclaude skills promote <name>`)",
-			path.join(process.cwd(), ".claude", "skills-draft"),
+			"Target directory for imported skills (default: the canonical draft-skill root; promote with `telclaude skills promote <name>`)",
 		)
 		.option("--dry-run", "Show what would be imported without copying")
 		.option(
@@ -359,7 +364,7 @@ export function registerSkillsImportSubcommands(parent: Command): void {
 		.action(
 			async (
 				source: string,
-				options: { target: string; dryRun?: boolean; allowAutoInstall?: boolean },
+				options: { target?: string; dryRun?: boolean; allowAutoInstall?: boolean },
 			) => {
 				const sourceDir = path.resolve(source);
 
@@ -368,9 +373,20 @@ export function registerSkillsImportSubcommands(parent: Command): void {
 					process.exit(1);
 				}
 
+				let targetRoot: string;
+				try {
+					targetRoot = options.target ? path.resolve(options.target) : getDraftSkillRoot();
+				} catch (err) {
+					if (err instanceof SkillRootUnavailableError) {
+						console.error(err.message);
+						process.exit(1);
+					}
+					throw err;
+				}
+
 				console.log(`=== OpenClaw Skill Import ===\n`);
 				console.log(`Source: ${sourceDir}`);
-				console.log(`Target: ${options.target}\n`);
+				console.log(`Target: ${targetRoot}\n`);
 
 				if (options.dryRun) {
 					console.log("(dry run — no files will be copied)\n");
@@ -386,7 +402,7 @@ export function registerSkillsImportSubcommands(parent: Command): void {
 					return;
 				}
 
-				const result = importSkills(sourceDir, options.target, options.allowAutoInstall);
+				const result = importSkills(sourceDir, targetRoot, options.allowAutoInstall);
 
 				console.log("\n=== Import Summary ===");
 				console.log(
@@ -424,13 +440,10 @@ export function registerSkillsImportSubcommands(parent: Command): void {
 			if (options.path) {
 				skillRoots.push(path.resolve(options.path));
 			} else {
-				const cwd = process.cwd();
-				skillRoots.push(path.join(cwd, ".claude", "skills"));
-				skillRoots.push(path.join(cwd, ".claude", "skills-draft"));
-				const configDir = process.env.CLAUDE_CONFIG_DIR;
-				if (configDir) {
-					skillRoots.push(path.join(configDir, "skills"));
-				}
+				skillRoots.push(
+					...getAllSkillRoots(process.cwd()),
+					...getAllDraftSkillRoots(process.cwd()),
+				);
 			}
 
 			console.log("=== Skill Scanner ===\n");

--- a/src/commands/skills-promote.ts
+++ b/src/commands/skills-promote.ts
@@ -1,11 +1,11 @@
 /**
  * Skill promotion command.
  *
- * Promotes agent-drafted skills from quarantine (.claude/skills-draft/)
- * to the active skill directory (.claude/skills/) after validation.
+ * Promotes agent-drafted skills from the canonical draft quarantine to the
+ * canonical active skill directory after validation.
  *
  * Flow:
- * 1. Agent writes to .claude/skills-draft/<name>/SKILL.md (quarantine)
+ * 1. Agent writes to <draft-root>/<name>/SKILL.md (quarantine)
  * 2. Operator reviews via /promote-skill <name> or CLI
  * 3. Scanner + validation runs on the draft
  * 4. On pass, skill is moved to active directory
@@ -26,6 +26,7 @@ import { CardKind } from "../telegram/cards/types.js";
 import type { VaultClient } from "../vault-daemon/client.js";
 import { copyDirRecursive } from "./cli-utils.js";
 import {
+	getAllDraftSkillRoots,
 	getAllSkillRoots,
 	getDraftSkillRoot,
 	getSkillRoot,
@@ -232,7 +233,7 @@ function findExistingDraftRootFor(skillName: string): string | null {
  * when cwd isn't writable) are still surfaced.
  */
 export function listDraftSkills(draftRoot?: string): string[] {
-	const roots = draftRoot ? [draftRoot] : getWritableDraftSkillRootCandidates();
+	const roots = draftRoot ? [draftRoot] : getAllDraftSkillRoots();
 	const seen = new Set<string>();
 	for (const root of roots) {
 		if (!fs.existsSync(root)) continue;

--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -629,7 +629,15 @@ function createSocialToolRestrictionHook(actorUserId?: string): HookCallbackMatc
 
 	// Paths where writes are blocked via Write/Edit tools (all actors, trusted or not)
 	const writeProtectedPaths = [
-		/\/home\/telclaude-skills(?:\/|$)/i, // skill poisoning: write skill → trusted loads it
+		/\/home\/telclaude-skills(?:\/|$)/i, // profile-local skill path (symlinked into catalog in Docker)
+		...(process.env.TELCLAUDE_SKILL_CATALOG_DIR
+			? [
+					new RegExp(
+						`^${process.env.TELCLAUDE_SKILL_CATALOG_DIR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:[/\\\\]|$)`,
+						"i",
+					),
+				]
+			: []), // shared operator-managed skill catalog
 		/\/home\/telclaude-auth(?:\/|$)/i, // auth tokens (not mounted, but explicit)
 		/\/social\/memory(?:\/|$)/i, // memory integrity (container has :ro, belt-and-suspenders)
 	];
@@ -696,19 +704,29 @@ function createSocialToolRestrictionHook(actorUserId?: string): HookCallbackMatc
 
 /**
  * Patterns matching active skill directories (Write/Edit blocked).
- * Agent can write to .claude/skills-draft/ but NOT .claude/skills/.
+ * Agent can write to draft skill directories but NOT active skill directories.
  */
-const ACTIVE_SKILL_WRITE_PATTERNS: RegExp[] = [
-	/(?:^|[/\\])\.claude[/\\]skills[/\\]/i,
-	...(process.env.CLAUDE_CONFIG_DIR
-		? [
-				new RegExp(
-					`^${process.env.CLAUDE_CONFIG_DIR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:[/\\\\])skills(?:[/\\\\])`,
-					"i",
-				),
-			]
-		: []),
-];
+function getActiveSkillWritePatterns(): RegExp[] {
+	return [
+		/(?:^|[/\\])\.claude[/\\]skills[/\\]/i,
+		...(process.env.CLAUDE_CONFIG_DIR
+			? [
+					new RegExp(
+						`^${process.env.CLAUDE_CONFIG_DIR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:[/\\\\])skills(?:[/\\\\])`,
+						"i",
+					),
+				]
+			: []),
+		...(process.env.TELCLAUDE_SKILL_CATALOG_DIR
+			? [
+					new RegExp(
+						`^${process.env.TELCLAUDE_SKILL_CATALOG_DIR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:[/\\\\])skills(?:[/\\\\])`,
+						"i",
+					),
+				]
+			: []),
+	];
+}
 
 /**
  * Check if a path is an active skill directory (NOT skills-draft).
@@ -728,13 +746,20 @@ function isActiveSkillPath(filePath: string): boolean {
 		normalized.startsWith(`${process.env.CLAUDE_CONFIG_DIR.replace(/\\/g, "/")}/skills-draft/`)
 	)
 		return false;
+	if (
+		process.env.TELCLAUDE_SKILL_CATALOG_DIR &&
+		normalized.startsWith(
+			`${process.env.TELCLAUDE_SKILL_CATALOG_DIR.replace(/\\/g, "/")}/skills-draft/`,
+		)
+	)
+		return false;
 
-	return ACTIVE_SKILL_WRITE_PATTERNS.some((p) => p.test(filePath));
+	return getActiveSkillWritePatterns().some((p) => p.test(filePath));
 }
 
 /**
  * Create a PreToolUse hook that blocks writes to active skill directories.
- * Agents can only write to .claude/skills-draft/<name>/; promotion is operator-only.
+ * Agents can only write to draft skill directories; promotion is operator-only.
  */
 function createSkillWriteProtectionHook(): HookCallbackMatcher {
 	const hookCallback: HookCallback = async (input: HookInput) => {
@@ -753,7 +778,7 @@ function createSkillWriteProtectionHook(): HookCallbackMatcher {
 					"[hook] blocked write to active skill directory",
 				);
 				return denyHookResponse(
-					"Cannot write to active skill directory. Use .claude/skills-draft/<name>/ instead, then ask the operator to promote with /promote-skill.",
+					"Cannot write to an active skill directory. Draft changes under the canonical skills-draft root instead, then ask the operator to promote with /promote-skill.",
 				);
 			}
 		}
@@ -762,7 +787,7 @@ function createSkillWriteProtectionHook(): HookCallbackMatcher {
 			if (isActiveSkillPath(toolInput.file_path)) {
 				logger.warn({ path: toolInput.file_path }, "[hook] blocked edit of active skill file");
 				return denyHookResponse(
-					"Cannot edit active skill files. Draft changes to .claude/skills-draft/<name>/ instead.",
+					"Cannot edit active skill files. Draft changes under the canonical skills-draft root instead.",
 				);
 			}
 		}

--- a/src/security/permissions.ts
+++ b/src/security/permissions.ts
@@ -27,6 +27,7 @@ import {
 	VALIDATED_CLAUDE_AUTH_DIR,
 	VALIDATED_CLAUDE_CONFIG_DIR,
 	VALIDATED_DATA_DIR,
+	VALIDATED_SKILL_CATALOG_DIR,
 } from "../utils.js";
 import { getIdentityLink } from "./linking.js";
 import { getPairedChat } from "./pairing.js";
@@ -490,6 +491,14 @@ const SENSITIVE_PATH_PATTERNS: RegExp[] = [
 		? [
 				new RegExp(
 					`^${escapeRegex(VALIDATED_CLAUDE_CONFIG_DIR)}(?:[/\\\\])skills(?:[/\\\\])security-gate(?:[/\\\\]|$)`,
+					"i",
+				),
+			]
+		: []),
+	...(VALIDATED_SKILL_CATALOG_DIR
+		? [
+				new RegExp(
+					`^${escapeRegex(VALIDATED_SKILL_CATALOG_DIR)}(?:[/\\\\])skills(?:[/\\\\])security-gate(?:[/\\\\]|$)`,
 					"i",
 				),
 			]

--- a/src/telegram/cards/renderers/skill-picker.ts
+++ b/src/telegram/cards/renderers/skill-picker.ts
@@ -1,9 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import {
-	getAllSkillRoots,
-	getWritableDraftSkillRootCandidates,
-} from "../../../commands/skill-path.js";
+import { getAllDraftSkillRoots, getAllSkillRoots } from "../../../commands/skill-path.js";
 import {
 	listActiveSkills,
 	listDraftSkills,
@@ -48,7 +45,7 @@ function clampPage(page: number, count: number): number {
  * `skills-sign.ts` / `skills-promote.ts`.
  */
 function findSkillDir(skillName: string, status: "draft" | "active"): string | null {
-	const roots = status === "draft" ? getWritableDraftSkillRootCandidates() : getAllSkillRoots();
+	const roots = status === "draft" ? getAllDraftSkillRoots() : getAllSkillRoots();
 	for (const root of roots) {
 		const candidate = path.join(root, skillName);
 		if (fs.existsSync(path.join(candidate, "SKILL.md"))) {

--- a/src/telegram/control-command-actions.ts
+++ b/src/telegram/control-command-actions.ts
@@ -394,7 +394,7 @@ export async function sendSkillsImportCommand(
 		"",
 		"  telclaude skills import-openclaw <source>",
 		"",
-		"Imports land in `.claude/skills-draft/` and can be promoted via /skills promote.",
+		"Imports land in the canonical draft-skill catalog and can be promoted via /skills promote.",
 	].join("\n");
 	await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
 	return { callbackText: "Run `telclaude skills import-openclaw` from the CLI." };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,6 +115,10 @@ export const VALIDATED_CLAUDE_AUTH_DIR = resolveEnvDir(
 	process.env.TELCLAUDE_AUTH_DIR,
 	"TELCLAUDE_AUTH_DIR",
 );
+export const VALIDATED_SKILL_CATALOG_DIR = resolveEnvDir(
+	process.env.TELCLAUDE_SKILL_CATALOG_DIR,
+	"TELCLAUDE_SKILL_CATALOG_DIR",
+);
 
 // Use TELCLAUDE_DATA_DIR if set and valid (Docker), otherwise ~/.telclaude (native)
 export const CONFIG_DIR = VALIDATED_DATA_DIR || `${os.homedir()}/.telclaude`;

--- a/tests/commands/audit-collectors.test.ts
+++ b/tests/commands/audit-collectors.test.ts
@@ -262,12 +262,19 @@ describe("collectFilesystemFindings", () => {
 
 describe("collectSkillTrustFindings", () => {
 	let tempDir: string;
+	let originalClaudeConfigDir: string | undefined;
 
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-skills-test-"));
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
 	});
 
 	afterEach(() => {
+		if (originalClaudeConfigDir === undefined) {
+			delete process.env.CLAUDE_CONFIG_DIR;
+		} else {
+			process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		}
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
 
@@ -292,6 +299,19 @@ describe("collectSkillTrustFindings", () => {
 		const draftDir = path.join(tempDir, ".claude", "skills-draft", "unvetted-skill");
 		fs.mkdirSync(draftDir, { recursive: true });
 		fs.writeFileSync(path.join(draftDir, "SKILL.md"), "# Unvetted", "utf-8");
+
+		const findings = collectSkillTrustFindings(tempDir);
+		const finding = findByMessage(findings, "skills-draft");
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe("warning");
+	});
+
+	it("flags draft skills discovered via CLAUDE_CONFIG_DIR", () => {
+		const claudeHome = path.join(tempDir, "claude-home");
+		process.env.CLAUDE_CONFIG_DIR = claudeHome;
+		const draftDir = path.join(claudeHome, "skills-draft", "shared-draft");
+		fs.mkdirSync(draftDir, { recursive: true });
+		fs.writeFileSync(path.join(draftDir, "SKILL.md"), "# Draft", "utf-8");
 
 		const findings = collectSkillTrustFindings(tempDir);
 		const finding = findByMessage(findings, "skills-draft");

--- a/tests/commands/skill-path.test.ts
+++ b/tests/commands/skill-path.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	getAllDraftSkillRoots,
 	getAllSkillRoots,
 	getDraftSkillRoot,
 	getSkillRoot,
@@ -21,17 +22,22 @@ describe("resolveSkillAssetPath", () => {
 	let tempRoot = "";
 	let projectRoot = "";
 	let claudeHome = "";
+	let skillCatalog = "";
 	let originalClaudeConfigDir: string | undefined;
 	let originalTelclaudeClaudeHome: string | undefined;
+	let originalSkillCatalogDir: string | undefined;
 
 	beforeEach(() => {
 		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "skill-path-test-"));
 		projectRoot = path.join(tempRoot, "project");
 		claudeHome = path.join(tempRoot, "claude-home");
+		skillCatalog = path.join(tempRoot, "skill-catalog");
 		fs.mkdirSync(projectRoot, { recursive: true });
 		fs.mkdirSync(claudeHome, { recursive: true });
+		fs.mkdirSync(skillCatalog, { recursive: true });
 		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
 		originalTelclaudeClaudeHome = process.env.TELCLAUDE_CLAUDE_HOME;
+		originalSkillCatalogDir = process.env.TELCLAUDE_SKILL_CATALOG_DIR;
 	});
 
 	afterEach(() => {
@@ -45,6 +51,12 @@ describe("resolveSkillAssetPath", () => {
 			delete process.env.TELCLAUDE_CLAUDE_HOME;
 		} else {
 			process.env.TELCLAUDE_CLAUDE_HOME = originalTelclaudeClaudeHome;
+		}
+
+		if (originalSkillCatalogDir === undefined) {
+			delete process.env.TELCLAUDE_SKILL_CATALOG_DIR;
+		} else {
+			process.env.TELCLAUDE_SKILL_CATALOG_DIR = originalSkillCatalogDir;
 		}
 
 		if (tempRoot && fs.existsSync(tempRoot)) {
@@ -101,6 +113,36 @@ describe("resolveSkillAssetPath", () => {
 		);
 	});
 
+	it("prefers TELCLAUDE_SKILL_CATALOG_DIR over CLAUDE_CONFIG_DIR for skill resolution", () => {
+		process.env.CLAUDE_CONFIG_DIR = claudeHome;
+		process.env.TELCLAUDE_SKILL_CATALOG_DIR = skillCatalog;
+		const managedFile = writeSkillFile(skillCatalog, "weather", "scripts/weather.sh", "managed");
+		writeSkillFile(claudeHome, "weather", "scripts/weather.sh", "configured");
+
+		expect(resolveSkillAssetPath("weather", "scripts/weather.sh", { cwd: projectRoot })).toBe(
+			managedFile,
+		);
+	});
+
+	it("prefers TELCLAUDE_SKILL_CATALOG_DIR over project-local skills", () => {
+		process.env.TELCLAUDE_SKILL_CATALOG_DIR = skillCatalog;
+		const projectFile = path.join(
+			projectRoot,
+			".claude",
+			"skills",
+			"weather",
+			"scripts",
+			"weather.sh",
+		);
+		fs.mkdirSync(path.dirname(projectFile), { recursive: true });
+		fs.writeFileSync(projectFile, "project", "utf8");
+		const managedFile = writeSkillFile(skillCatalog, "weather", "scripts/weather.sh", "managed");
+
+		expect(resolveSkillAssetPath("weather", "scripts/weather.sh", { cwd: projectRoot })).toBe(
+			managedFile,
+		);
+	});
+
 	it("rejects traversal attempts in relative paths", () => {
 		expect(() =>
 			resolveSkillAssetPath("weather", "../secrets.txt", { cwd: projectRoot }),
@@ -117,15 +159,20 @@ describe("resolveSkillAssetPath", () => {
 describe("getSkillRoot / getDraftSkillRoot", () => {
 	let tempRoot = "";
 	let projectRoot = "";
+	let skillCatalog = "";
 	let originalClaudeConfigDir: string | undefined;
 	let originalTelclaudeClaudeHome: string | undefined;
+	let originalSkillCatalogDir: string | undefined;
 
 	beforeEach(() => {
 		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "skill-root-test-"));
 		projectRoot = path.join(tempRoot, "project");
+		skillCatalog = path.join(tempRoot, "skill-catalog");
 		fs.mkdirSync(projectRoot, { recursive: true });
+		fs.mkdirSync(skillCatalog, { recursive: true });
 		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
 		originalTelclaudeClaudeHome = process.env.TELCLAUDE_CLAUDE_HOME;
+		originalSkillCatalogDir = process.env.TELCLAUDE_SKILL_CATALOG_DIR;
 	});
 
 	afterEach(() => {
@@ -141,6 +188,12 @@ describe("getSkillRoot / getDraftSkillRoot", () => {
 			process.env.TELCLAUDE_CLAUDE_HOME = originalTelclaudeClaudeHome;
 		}
 
+		if (originalSkillCatalogDir === undefined) {
+			delete process.env.TELCLAUDE_SKILL_CATALOG_DIR;
+		} else {
+			process.env.TELCLAUDE_SKILL_CATALOG_DIR = originalSkillCatalogDir;
+		}
+
 		if (tempRoot && fs.existsSync(tempRoot)) {
 			fs.rmSync(tempRoot, { recursive: true, force: true });
 		}
@@ -149,6 +202,7 @@ describe("getSkillRoot / getDraftSkillRoot", () => {
 	it("creates and returns the project-local skills root", () => {
 		delete process.env.CLAUDE_CONFIG_DIR;
 		delete process.env.TELCLAUDE_CLAUDE_HOME;
+		delete process.env.TELCLAUDE_SKILL_CATALOG_DIR;
 
 		const root = getSkillRoot(projectRoot);
 		expect(root).toBe(path.join(projectRoot, ".claude", "skills"));
@@ -171,9 +225,19 @@ describe("getSkillRoot / getDraftSkillRoot", () => {
 		}
 	});
 
+	it("prefers TELCLAUDE_SKILL_CATALOG_DIR over CLAUDE_CONFIG_DIR for writable roots", () => {
+		process.env.CLAUDE_CONFIG_DIR = path.join(tempRoot, "claude-home");
+		process.env.TELCLAUDE_SKILL_CATALOG_DIR = skillCatalog;
+		fs.mkdirSync(process.env.CLAUDE_CONFIG_DIR, { recursive: true });
+
+		expect(getSkillRoot(projectRoot)).toBe(path.join(skillCatalog, "skills"));
+		expect(getDraftSkillRoot(projectRoot)).toBe(path.join(skillCatalog, "skills-draft"));
+	});
+
 	it("throws SkillRootUnavailableError when no candidate is writable", () => {
 		delete process.env.CLAUDE_CONFIG_DIR;
 		delete process.env.TELCLAUDE_CLAUDE_HOME;
+		delete process.env.TELCLAUDE_SKILL_CATALOG_DIR;
 		// Make the cwd's .claude parent unwritable.
 		fs.chmodSync(projectRoot, 0o500);
 		try {
@@ -186,6 +250,7 @@ describe("getSkillRoot / getDraftSkillRoot", () => {
 	it("exposes the matching draft root", () => {
 		delete process.env.CLAUDE_CONFIG_DIR;
 		delete process.env.TELCLAUDE_CLAUDE_HOME;
+		delete process.env.TELCLAUDE_SKILL_CATALOG_DIR;
 
 		const root = getDraftSkillRoot(projectRoot);
 		expect(root).toBe(path.join(projectRoot, ".claude", "skills-draft"));
@@ -195,11 +260,21 @@ describe("getSkillRoot / getDraftSkillRoot", () => {
 	it("returns all skill roots including the bundled fallback", () => {
 		delete process.env.CLAUDE_CONFIG_DIR;
 		delete process.env.TELCLAUDE_CLAUDE_HOME;
+		delete process.env.TELCLAUDE_SKILL_CATALOG_DIR;
 
 		const roots = getAllSkillRoots(projectRoot);
 		// First root should be project-local.
 		expect(roots[0]).toBe(path.join(projectRoot, ".claude", "skills"));
 		// At least one bundled root at the end (resolved inside the telclaude package).
 		expect(roots.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("returns all draft roots including the managed catalog when configured", () => {
+		process.env.TELCLAUDE_SKILL_CATALOG_DIR = skillCatalog;
+
+		const roots = getAllDraftSkillRoots(projectRoot);
+		expect(roots).toContain(path.join(projectRoot, ".claude", "skills-draft"));
+		expect(roots).toContain(path.join(skillCatalog, "skills-draft"));
+		expect(roots).not.toContain(path.join(projectRoot, ".claude", "skills"));
 	});
 });

--- a/tests/commands/skills-import.test.ts
+++ b/tests/commands/skills-import.test.ts
@@ -22,6 +22,7 @@ describe("skills import-openclaw", () => {
 	let tempRoot = "";
 	let sourceRoot = "";
 	let targetRoot = "";
+	let originalClaudeConfigDir: string | undefined;
 
 	beforeEach(() => {
 		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "skills-import-test-"));
@@ -30,6 +31,7 @@ describe("skills import-openclaw", () => {
 		fs.mkdirSync(sourceRoot, { recursive: true });
 		fs.mkdirSync(targetRoot, { recursive: true });
 		process.exitCode = undefined;
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
 		vi.spyOn(console, "log").mockImplementation(() => {});
 		vi.spyOn(console, "error").mockImplementation(() => {});
 	});
@@ -37,6 +39,11 @@ describe("skills import-openclaw", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		process.exitCode = undefined;
+		if (originalClaudeConfigDir === undefined) {
+			delete process.env.CLAUDE_CONFIG_DIR;
+		} else {
+			process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		}
 		if (tempRoot && fs.existsSync(tempRoot)) {
 			fs.rmSync(tempRoot, { recursive: true, force: true });
 		}
@@ -90,5 +97,28 @@ describe("skills import-openclaw", () => {
 		expect(fs.existsSync(importedPath)).toBe(true);
 		const importedContent = fs.readFileSync(importedPath, "utf8");
 		expect(importedContent).not.toContain("auto-install:");
+	});
+
+	it("defaults to the canonical draft root when --target is omitted", async () => {
+		const claudeHome = path.join(tempRoot, "claude-home");
+		process.env.CLAUDE_CONFIG_DIR = claudeHome;
+		writeOpenClawSkill(
+			sourceRoot,
+			"hello-skill",
+			[
+				"---",
+				"name: hello-skill",
+				"description: clean import",
+				"---",
+				"",
+				"Skill body.",
+			].join("\n"),
+		);
+
+		await runSkillsCli(["skills", "import-openclaw", sourceRoot]);
+
+		expect(fs.existsSync(path.join(claudeHome, "skills-draft", "hello-skill", "SKILL.md"))).toBe(
+			true,
+		);
 	});
 });

--- a/tests/docker/install-claude-assets.test.ts
+++ b/tests/docker/install-claude-assets.test.ts
@@ -56,6 +56,167 @@ describe("docker/install-claude-assets.sh", () => {
 		expect(fs.readFileSync(path.join(claudeHome, "CLAUDE.md"), "utf8")).toContain("Bundled Claude");
 	});
 
+	it("migrates legacy profile skills into the shared catalog and rewires profile dirs", () => {
+		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "install-claude-assets-"));
+		const appDir = path.join(tempRoot, "app");
+		const bundledClaudeDir = path.join(appDir, ".claude");
+		const bundledSkillsDir = path.join(bundledClaudeDir, "skills");
+		const bundledAgentsSkillDir = path.join(appDir, ".agents", "skills", "memory");
+		const claudeHome = path.join(tempRoot, "claude-home");
+		const skillCatalog = path.join(tempRoot, "skill-catalog");
+		const legacyActiveDir = path.join(claudeHome, "skills", "legacy-skill");
+		const legacyDraftDir = path.join(claudeHome, "skills-draft", "draft-skill");
+		const catalogActiveDir = path.join(skillCatalog, "skills", "legacy-skill");
+
+		fs.mkdirSync(bundledSkillsDir, { recursive: true });
+		fs.mkdirSync(bundledAgentsSkillDir, { recursive: true });
+		fs.mkdirSync(legacyActiveDir, { recursive: true });
+		fs.mkdirSync(legacyDraftDir, { recursive: true });
+		fs.mkdirSync(catalogActiveDir, { recursive: true });
+
+		fs.writeFileSync(path.join(bundledAgentsSkillDir, "SKILL.md"), "# Memory\n", "utf8");
+		fs.writeFileSync(path.join(legacyActiveDir, "SKILL.md"), "# Legacy Skill\n", "utf8");
+		fs.writeFileSync(path.join(legacyDraftDir, "SKILL.md"), "# Draft Skill\n", "utf8");
+		fs.writeFileSync(path.join(catalogActiveDir, "SKILL.md"), "# Existing Catalog Skill\n", "utf8");
+		fs.symlinkSync(
+			path.relative(bundledSkillsDir, bundledAgentsSkillDir),
+			path.join(bundledSkillsDir, "memory"),
+		);
+
+		execFileSync("bash", ["docker/install-claude-assets.sh"], {
+			cwd: path.resolve("."),
+			env: {
+				...process.env,
+				TELCLAUDE_BUNDLED_CLAUDE_DIR: bundledClaudeDir,
+				TELCLAUDE_CLAUDE_HOME: claudeHome,
+				TELCLAUDE_SKILL_CATALOG_DIR: skillCatalog,
+				TELCLAUDE_UID: String(process.getuid?.() ?? 0),
+				TELCLAUDE_GID: String(process.getgid?.() ?? 0),
+			},
+			stdio: "pipe",
+		});
+
+		expect(fs.lstatSync(path.join(claudeHome, "skills")).isSymbolicLink()).toBe(true);
+		expect(fs.readlinkSync(path.join(claudeHome, "skills"))).toBe(path.join(skillCatalog, "skills"));
+		expect(fs.lstatSync(path.join(claudeHome, "skills-draft")).isSymbolicLink()).toBe(true);
+		expect(fs.readlinkSync(path.join(claudeHome, "skills-draft"))).toBe(
+			path.join(skillCatalog, "skills-draft"),
+		);
+		expect(fs.readFileSync(path.join(skillCatalog, "skills", "memory", "SKILL.md"), "utf8")).toContain(
+			"Memory",
+		);
+		expect(
+			fs.readFileSync(path.join(skillCatalog, "skills-draft", "draft-skill", "SKILL.md"), "utf8"),
+		).toContain("Draft Skill");
+		expect(fs.readFileSync(path.join(skillCatalog, "skills", "legacy-skill", "SKILL.md"), "utf8")).toContain(
+			"Existing Catalog Skill",
+		);
+	});
+
+	it("preserves runtime-generated files while refreshing bundled skill contents in the shared catalog", () => {
+		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "install-claude-assets-"));
+		const appDir = path.join(tempRoot, "app");
+		const bundledClaudeDir = path.join(appDir, ".claude");
+		const bundledSkillsDir = path.join(bundledClaudeDir, "skills");
+		const bundledAgentsSkillDir = path.join(appDir, ".agents", "skills", "external-provider");
+		const claudeHome = path.join(tempRoot, "claude-home");
+		const skillCatalog = path.join(tempRoot, "skill-catalog");
+		const runtimeSkillDir = path.join(skillCatalog, "skills", "external-provider");
+		const runtimeRefsDir = path.join(runtimeSkillDir, "references");
+
+		fs.mkdirSync(bundledSkillsDir, { recursive: true });
+		fs.mkdirSync(path.join(bundledAgentsSkillDir, "references"), { recursive: true });
+		fs.mkdirSync(runtimeRefsDir, { recursive: true });
+		fs.mkdirSync(claudeHome, { recursive: true });
+
+		fs.writeFileSync(path.join(bundledAgentsSkillDir, "SKILL.md"), "# External Provider v2\n", "utf8");
+		fs.writeFileSync(
+			path.join(bundledAgentsSkillDir, "references", "catalog.md"),
+			"bundled reference\n",
+			"utf8",
+		);
+		fs.writeFileSync(path.join(runtimeRefsDir, "provider-schema.md"), "runtime schema\n", "utf8");
+		fs.symlinkSync(
+			path.relative(bundledSkillsDir, bundledAgentsSkillDir),
+			path.join(bundledSkillsDir, "external-provider"),
+		);
+
+		execFileSync("bash", ["docker/install-claude-assets.sh"], {
+			cwd: path.resolve("."),
+			env: {
+				...process.env,
+				TELCLAUDE_BUNDLED_CLAUDE_DIR: bundledClaudeDir,
+				TELCLAUDE_CLAUDE_HOME: claudeHome,
+				TELCLAUDE_SKILL_CATALOG_DIR: skillCatalog,
+				TELCLAUDE_UID: String(process.getuid?.() ?? 0),
+				TELCLAUDE_GID: String(process.getgid?.() ?? 0),
+			},
+			stdio: "pipe",
+		});
+
+		expect(fs.readFileSync(path.join(runtimeSkillDir, "SKILL.md"), "utf8")).toContain(
+			"External Provider v2",
+		);
+		expect(fs.readFileSync(path.join(runtimeRefsDir, "catalog.md"), "utf8")).toContain(
+			"bundled reference",
+		);
+		expect(fs.readFileSync(path.join(runtimeRefsDir, "provider-schema.md"), "utf8")).toContain(
+			"runtime schema",
+		);
+	});
+
+	it("rewires profile skill dirs even when the shared catalog is mounted read-only", () => {
+		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "install-claude-assets-"));
+		const appDir = path.join(tempRoot, "app");
+		const bundledClaudeDir = path.join(appDir, ".claude");
+		const bundledSkillsDir = path.join(bundledClaudeDir, "skills");
+		const bundledAgentsSkillDir = path.join(appDir, ".agents", "skills", "memory");
+		const claudeHome = path.join(tempRoot, "claude-home");
+		const skillCatalog = path.join(tempRoot, "skill-catalog");
+
+		fs.mkdirSync(bundledSkillsDir, { recursive: true });
+		fs.mkdirSync(bundledAgentsSkillDir, { recursive: true });
+		fs.mkdirSync(path.join(skillCatalog, "skills"), { recursive: true });
+		fs.mkdirSync(path.join(skillCatalog, "skills-draft"), { recursive: true });
+		fs.mkdirSync(claudeHome, { recursive: true });
+
+		fs.writeFileSync(path.join(bundledAgentsSkillDir, "SKILL.md"), "# Memory\n", "utf8");
+		fs.symlinkSync(
+			path.relative(bundledSkillsDir, bundledAgentsSkillDir),
+			path.join(bundledSkillsDir, "memory"),
+		);
+		fs.chmodSync(skillCatalog, 0o555);
+		fs.chmodSync(path.join(skillCatalog, "skills"), 0o555);
+		fs.chmodSync(path.join(skillCatalog, "skills-draft"), 0o555);
+
+		try {
+			execFileSync("bash", ["docker/install-claude-assets.sh"], {
+				cwd: path.resolve("."),
+				env: {
+					...process.env,
+					TELCLAUDE_BUNDLED_CLAUDE_DIR: bundledClaudeDir,
+					TELCLAUDE_CLAUDE_HOME: claudeHome,
+					TELCLAUDE_SKILL_CATALOG_DIR: skillCatalog,
+					TELCLAUDE_UID: String(process.getuid?.() ?? 0),
+					TELCLAUDE_GID: String(process.getgid?.() ?? 0),
+				},
+				stdio: "pipe",
+			});
+		} finally {
+			fs.chmodSync(path.join(skillCatalog, "skills-draft"), 0o755);
+			fs.chmodSync(path.join(skillCatalog, "skills"), 0o755);
+			fs.chmodSync(skillCatalog, 0o755);
+		}
+
+		expect(fs.lstatSync(path.join(claudeHome, "skills")).isSymbolicLink()).toBe(true);
+		expect(fs.readlinkSync(path.join(claudeHome, "skills"))).toBe(path.join(skillCatalog, "skills"));
+		expect(fs.lstatSync(path.join(claudeHome, "skills-draft")).isSymbolicLink()).toBe(true);
+		expect(fs.readlinkSync(path.join(claudeHome, "skills-draft"))).toBe(
+			path.join(skillCatalog, "skills-draft"),
+		);
+		expect(fs.existsSync(path.join(skillCatalog, "skills", "memory"))).toBe(false);
+	});
+
 	it("keeps agent skill markdown in the Docker build context", () => {
 		const dockerignore = fs.readFileSync(path.join(process.cwd(), ".dockerignore"), "utf8");
 		expect(dockerignore).toContain("!.agents/skills/**/*.md");

--- a/tests/sdk/skill-write-protection-hook.test.ts
+++ b/tests/sdk/skill-write-protection-hook.test.ts
@@ -47,6 +47,10 @@ async function runPreToolUse(
 }
 
 describe("createSkillWriteProtectionHook (PreToolUse)", () => {
+	afterEach(() => {
+		delete process.env.TELCLAUDE_SKILL_CATALOG_DIR;
+	});
+
 	it("denies writes to active skills even when path contains skills-draft substring", async () => {
 		const sdkOpts = await buildSdkOptions({
 			cwd: "/tmp",
@@ -58,6 +62,25 @@ describe("createSkillWriteProtectionHook (PreToolUse)", () => {
 
 		const res = await runPreToolUse(sdkOpts, "Write", {
 			file_path: ".claude/skills/skills-draft-evil/SKILL.md",
+			content: "malicious override",
+		});
+
+		expect(res.permissionDecision).toBe("deny");
+		expect(res.permissionDecisionReason).toContain("active skill directory");
+	});
+
+	it("denies direct writes to the shared skill catalog active root", async () => {
+		process.env.TELCLAUDE_SKILL_CATALOG_DIR = "/home/telclaude-skill-catalog";
+		const sdkOpts = await buildSdkOptions({
+			cwd: "/tmp",
+			tier: "WRITE_LOCAL",
+			poolKey: "skill-write-guard",
+			userId: "tg:123",
+			enableSkills: true,
+		});
+
+		const res = await runPreToolUse(sdkOpts, "Write", {
+			file_path: "/home/telclaude-skill-catalog/skills/my-skill/SKILL.md",
 			content: "malicious override",
 		});
 

--- a/tests/sdk/social-tool-restriction-hook.test.ts
+++ b/tests/sdk/social-tool-restriction-hook.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { buildSdkOptions } from "../../src/sdk/client.js";
 
@@ -50,6 +50,10 @@ async function runPreToolUse(
 }
 
 describe("createSocialToolRestrictionHook (PreToolUse)", () => {
+	afterEach(() => {
+		delete process.env.TELCLAUDE_SKILL_CATALOG_DIR;
+	});
+
 	it("denies Bash for untrusted social actors (notifications)", async () => {
 		const sdkOpts = await buildSdkOptions({
 			cwd: "/tmp",
@@ -119,5 +123,22 @@ describe("createSocialToolRestrictionHook (PreToolUse)", () => {
 		expect(res.permissionDecision).toBe("deny");
 		expect(res.permissionDecisionReason).toContain("writing to this location is not permitted");
 	});
-});
 
+	it("denies Write to the shared skill catalog for all social actors", async () => {
+		process.env.TELCLAUDE_SKILL_CATALOG_DIR = "/home/telclaude-skill-catalog";
+		const sdkOpts = await buildSdkOptions({
+			cwd: "/tmp",
+			tier: "SOCIAL",
+			poolKey: "xtwitter:social",
+			userId: "social:xtwitter:operator",
+			enableSkills: true,
+		});
+
+		const res = await runPreToolUse(sdkOpts, "Write", {
+			file_path: "/home/telclaude-skill-catalog/skills/browser-automation/SKILL.md",
+			content: "pwned",
+		});
+		expect(res.permissionDecision).toBe("deny");
+		expect(res.permissionDecisionReason).toContain("writing to this location is not permitted");
+	});
+});


### PR DESCRIPTION
Share one operator-managed skill catalog across private and social so both personas use the same import, review, promote, and reload workflow.

This moves skill resolution and Docker runtime setup to a canonical catalog, migrates legacy profile skill data into it, and keeps per-agent Claude profile state separate. The social container mounts the shared catalog read-only so the stricter social perimeter still holds at the OS boundary instead of depending only on hook enforcement.

I initially landed this directly on main by mistake while trying to deploy it. This PR re-lands the exact reviewed change through the normal path.