### PR TITLE
feat(plugins): Manage official Claude plugins per persona

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ API keys (OpenAI, GitHub) are exposed for FULL_ACCESS tier only. READ_ONLY and W
 - **6 containers**: `telclaude` (relay), `telclaude-agent` (private persona), `agent-social` (social persona), `google-services`, `totp`, `vault`.
 - **Secrets storage**: `telclaude secrets setup-openai`, `telclaude secrets setup-git`; encrypted in volume.
 - **Workspace path**: `WORKSPACE_PATH` in `docker/.env` must point to valid host path.
-- **Claude profiles**: Docker uses per-agent Claude profiles (`/home/telclaude-skills` for private/social, `/home/telclaude-auth` for relay auth) plus a shared skill catalog (`/home/telclaude-skill-catalog`). `agent-social` mounts the shared catalog read-only; Anthropic access goes through the relay proxy and credentials never mount in agent containers.
+- **Claude profiles**: Docker uses per-agent Claude profiles (`/home/telclaude-skills` inside each agent, `/home/telclaude-auth` for relay auth) plus a shared standalone skill catalog (`/home/telclaude-skill-catalog`). Official Claude plugins live in the per-agent profiles; the relay mounts those real profile volumes separately for operator `telclaude plugins ...` management. `agent-social` mounts the standalone skill catalog read-only; Anthropic access goes through the relay proxy and credentials never mount in agent containers.
 - **Remote deployment**: Build locally and transfer images to the deployment target:
   ```bash
   cd docker && docker compose build

--- a/docker/README.md
+++ b/docker/README.md
@@ -159,7 +159,7 @@ Some volumes contain **critical secrets** that cannot be recovered if deleted.
 
 These are marked `external: true` in docker-compose.yml, so `docker compose down -v` **cannot delete them**.
 
-**Profile volume note:** The per-agent profile volumes (`telclaude-skills-telegram`, `telclaude-skills-social`) are **not** external. They only store profile-local state; the shared skill catalog lives in `telclaude-skill-catalog`.
+**Profile volume note:** The per-agent profile volumes (`telclaude-skills-telegram`, `telclaude-skills-social`) are **not** external. They store profile-local state plus official Claude plugins. Standalone telclaude skills still live in the shared `telclaude-skill-catalog`.
 
 ### Safe Operations
 
@@ -206,8 +206,8 @@ docker run --rm -v telclaude-claude-auth:/data:ro -v $(pwd):/backup \
 | `telclaude` | `/data` | SQLite DB, config, sessions | Named volume |
 | `telclaude` | `/home/telclaude-auth` | Claude auth profile (OAuth tokens) | External volume |
 | `telclaude` + `telclaude-agent` + `agent-social` | `/home/telclaude-skill-catalog` | Shared active + draft skill catalog (`agent-social` mounts it read-only) | External volume |
-| `telclaude-agent` | `/home/telclaude-skills` | Private profile state (settings/cache, catalog symlinked in) | Named volume |
-| `agent-social` | `/home/telclaude-skills` | Social profile state (settings/cache, catalog symlinked in) | Named volume |
+| `telclaude` + `telclaude-agent` | `/home/telclaude-private-profile` / `/home/telclaude-skills` | Private profile state and official Claude plugins | Named volume |
+| `telclaude` + `agent-social` | `/home/telclaude-social-profile` / `/home/telclaude-skills` | Social profile state and official Claude plugins | Named volume |
 | `telclaude` + `telclaude-agent` | `/media/inbox` + `/media/outbox` | Shared media (inbox/outbox split) | Named volume |
 | `agent-social` | `/social/sandbox` | Social isolated workspace | Named volume |
 | `telclaude` + `agent-social` | `/social/memory` | Social memory (relay RW, agent RO) | Named volume |

--- a/docker/apparmor/telclaude-relay
+++ b/docker/apparmor/telclaude-relay
@@ -45,9 +45,10 @@ profile telclaude-relay flags=(attach_disconnected,mediate_deleted) {
   # Data directory (SQLite, sessions, config)
   /data/** rwklix,
 
-  # Auth profile (OAuth tokens, skills)
+  # Relay auth profile + operator-managed persona profiles
   /home/telclaude-auth/** rwklix,
-  /home/telclaude-skills/** rwklix,
+  /home/telclaude-private-profile/** rwklix,
+  /home/telclaude-social-profile/** rwklix,
   /home/telclaude-skill-catalog/** rwklix,
 
   # Sidecar sockets (TOTP + vault)

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -72,6 +72,8 @@ services:
       - CLAUDE_CONFIG_DIR=/home/telclaude-auth
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-auth
       - TELCLAUDE_AUTH_DIR=/home/telclaude-auth
+      - TELCLAUDE_PRIVATE_CLAUDE_HOME=/home/telclaude-private-profile
+      - TELCLAUDE_SOCIAL_CLAUDE_HOME=/home/telclaude-social-profile
       - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
 
       # Agent routing
@@ -112,6 +114,8 @@ services:
       - ./telclaude.json:/data/telclaude.json:ro
       - ./telclaude-private.json:/data/telclaude-private.json:ro
       - telclaude-claude-auth:/home/telclaude-auth:rw
+      - telclaude-skills-telegram:/home/telclaude-private-profile:rw
+      - telclaude-skills-social:/home/telclaude-social-profile:rw
       - telclaude-skill-catalog:/home/telclaude-skill-catalog:rw
       - totp-socket:/run/totp:rw
       - vault-socket:/run/vault:ro
@@ -215,7 +219,8 @@ services:
       # Data dir (agent is stateless; uses tmpfs)
       - TELCLAUDE_DATA_DIR=/home/node/.telclaude
 
-      # Private profile state stays local; installed skills come from the shared catalog.
+      # Private profile state stays local; standalone skills come from the shared catalog,
+      # while official Claude plugins remain profile-local.
       - CLAUDE_CONFIG_DIR=/home/telclaude-skills
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-skills
       - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       - CLAUDE_CONFIG_DIR=/home/telclaude-auth
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-auth
       - TELCLAUDE_AUTH_DIR=/home/telclaude-auth
+      - TELCLAUDE_PRIVATE_CLAUDE_HOME=/home/telclaude-private-profile
+      - TELCLAUDE_SOCIAL_CLAUDE_HOME=/home/telclaude-social-profile
       - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
       - TELCLAUDE_AGENT_URL=http://telclaude-agent:8788
       - TELCLAUDE_SOCIAL_AGENT_URL=http://agent-social:8789
@@ -118,6 +120,9 @@ services:
 
       # Claude auth/profile state (OAuth tokens + settings) — relay-only
       - telclaude-claude-auth:/home/telclaude-auth:rw
+      # Relay manages the real persona profiles for official `claude plugin ...` lifecycle commands.
+      - telclaude-skills-telegram:/home/telclaude-private-profile:rw
+      - telclaude-skills-social:/home/telclaude-social-profile:rw
       # Shared skill catalog (active + draft) across relay, private, and social.
       - telclaude-skill-catalog:/home/telclaude-skill-catalog:rw
 
@@ -244,7 +249,8 @@ services:
       # Data dir override (agent is stateless; uses tmpfs instead of /data volume)
       - TELCLAUDE_DATA_DIR=/home/node/.telclaude
 
-      # Private profile state stays local; installed skills come from the shared catalog.
+      # Private profile state stays local; standalone skills come from the shared catalog,
+      # while official Claude plugins remain profile-local.
       - CLAUDE_CONFIG_DIR=/home/telclaude-skills
       - TELCLAUDE_CLAUDE_HOME=/home/telclaude-skills
       - TELCLAUDE_SKILL_CATALOG_DIR=/home/telclaude-skill-catalog
@@ -271,9 +277,9 @@ services:
       # Policy config (no secrets — providers, network rules, etc.)
       - ./telclaude.json:/data/telclaude.json:ro
 
-      # Private profile state (settings/cache) stays isolated.
+      # Private profile state (settings/cache, official plugins) stays isolated.
       - telclaude-skills-telegram:/home/telclaude-skills:rw
-      # Shared operator-managed skill catalog.
+      # Shared operator-managed standalone skill catalog.
       - telclaude-skill-catalog:/home/telclaude-skill-catalog:rw
 
       # Shared media volumes (inbox/outbox split)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -26,6 +26,8 @@ TELCLAUDE_GID="${TELCLAUDE_GID:-1000}"
 TELCLAUDE_CLAUDE_HOME="${TELCLAUDE_CLAUDE_HOME:-${CLAUDE_CONFIG_DIR:-/home/telclaude-skills}}"
 TELCLAUDE_AUTH_DIR="${TELCLAUDE_AUTH_DIR:-/home/telclaude-auth}"
 TELCLAUDE_SKILL_CATALOG_DIR="${TELCLAUDE_SKILL_CATALOG_DIR:-}"
+TELCLAUDE_PRIVATE_CLAUDE_HOME="${TELCLAUDE_PRIVATE_CLAUDE_HOME:-}"
+TELCLAUDE_SOCIAL_CLAUDE_HOME="${TELCLAUDE_SOCIAL_CLAUDE_HOME:-}"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Privileged Operations (run as root)
@@ -64,7 +66,7 @@ if [ "$(id -u)" = "0" ]; then
     touch /home/node/.telclaude/logs/telclaude.log
     chown -R "${TELCLAUDE_UID}:${TELCLAUDE_GID}" /home/node/.telclaude 2>/dev/null || true
 
-    for dir in /data /home/node "${TELCLAUDE_CLAUDE_HOME}" "${TELCLAUDE_AUTH_DIR}" "${TELCLAUDE_SKILL_CATALOG_DIR}" /media/inbox /media/outbox; do
+    for dir in /data /home/node "${TELCLAUDE_CLAUDE_HOME}" "${TELCLAUDE_AUTH_DIR}" "${TELCLAUDE_SKILL_CATALOG_DIR}" "${TELCLAUDE_PRIVATE_CLAUDE_HOME}" "${TELCLAUDE_SOCIAL_CLAUDE_HOME}" /media/inbox /media/outbox; do
         if [ -d "$dir" ]; then
             # Only chown if not already owned by the target user
             if [ "$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)" != "$TELCLAUDE_UID" ]; then

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,73 @@
+# Official Claude Plugins
+
+Official Claude plugins are not the same thing as standalone telclaude skills.
+
+- Standalone telclaude skills use the shared draft/promote catalog described in [skills.md](./skills.md).
+- Official Claude plugins use Claude Code's own marketplace/install/update lifecycle and stay scoped to a Claude profile.
+
+This split is intentional:
+
+- plugins can carry more than skills (`bin/`, hooks, agents, settings, MCP, monitors)
+- private vs social is a profile boundary, not a catalog-copying trick
+- private defaults broad; social stays fail-closed at runtime
+
+## Persona model
+
+Each persona has its own Claude profile volume:
+
+- private profile: `/home/telclaude-skills`
+- social profile: `/home/telclaude-skills` inside `agent-social`
+- relay mounts both real profile volumes at `/home/telclaude-private-profile` and `/home/telclaude-social-profile` so operator CLI commands act on the live Linux runtime state
+
+Telclaude manages official plugins with:
+
+```bash
+telclaude plugins list [--persona private|social|both]
+telclaude plugins install <plugin@marketplace> [--persona ...] [--marketplace-source <source>]
+telclaude plugins update <plugin@marketplace> [--persona ...] [--marketplace-source <source>]
+telclaude plugins uninstall <plugin@marketplace> [--persona ...]
+```
+
+Default persona is `private`.
+
+## First install vs later updates
+
+Use `--marketplace-source` the first time a profile does not know the marketplace yet. The source is passed straight through to Claude's official marketplace add command, so it can be a GitHub shorthand, git URL, remote `marketplace.json` URL, or local test path.
+
+Example:
+
+```bash
+telclaude plugins install shaon@avivsinai-marketplace \
+  --persona private \
+  --marketplace-source avivsinai/skills-marketplace
+```
+
+Later updates usually only need:
+
+```bash
+telclaude plugins update shaon@avivsinai-marketplace --persona private
+```
+
+## Social boundary
+
+Installing a plugin into the social profile does not automatically authorize the social agent to invoke all of its skills.
+
+For social use, both of these must be true:
+
+1. the plugin is installed in the social profile
+2. the service's `allowedSkills` includes the plugin skill names (for example `shaon:attendance`)
+
+Private agents do not use `allowedSkills`; they can invoke any active skill/plugin in their own profile.
+
+## When to use which path
+
+Use `telclaude skills ...` when:
+
+- you are authoring or importing a standalone skill folder
+- you want draft quarantine, scanner review, and explicit promotion
+
+Use `telclaude plugins ...` when:
+
+- the upstream package is a real Claude plugin or marketplace entry
+- you want official install/update/uninstall semantics
+- the asset includes more than plain skills

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,5 +1,8 @@
 # Skills — scaffold, promote, and doctor
 
+This document is about standalone telclaude skills. For official Claude
+plugins and marketplaces, use [plugins.md](./plugins.md).
+
 Telclaude has one canonical writable skill store plus optional read-only skill
 roots. Active skills live under `<skill-root>/skills/<name>/`. Draft skills
 live under `<skill-root>/skills-draft/<name>/` until promoted. This document
@@ -24,11 +27,11 @@ Read-only consumers (e.g. `telclaude skill-path`) additionally fall back to
 the bundled skill directory shipped inside the telclaude package. Writers
 never touch that directory.
 
-In Docker, telclaude uses the Hermes-style idiom: both private and social keep
-their own Claude profile state, but they share one operator-managed skill
-catalog. `agent-social` mounts that catalog read-only; social-specific
-restrictions are enforced at runtime policy plus the container boundary, not by
-installing skills into a different location.
+In Docker, telclaude uses one operator-managed standalone skill catalog for
+both personas, while official Claude plugins stay profile-local. `agent-social`
+mounts the standalone skill catalog read-only; social-specific restrictions are
+enforced at runtime policy plus the container boundary, not by copying skills
+into a separate catalog.
 
 ## `telclaude skills scaffold <name>`
 
@@ -88,7 +91,7 @@ Catalog (un-hidden): `/skills list|new|import|scan|doctor|drafts|promote|reload`
 | `/skills` | Open the skills menu card (drafts + reload). |
 | `/skills list` | Active + draft skills with status. |
 | `/skills new [name]` | Scaffold a draft via a wizard (template + description prompts). |
-| `/skills import` | Prints the CLI instruction (imports require a filesystem path). |
+| `/skills import` | Prints the CLI instruction for standalone filesystem skills. |
 | `/skills scan` | Runs the scanner across active + draft roots. |
 | `/skills doctor` | Mirrors the CLI doctor output. |
 | `/skills drafts` | List draft skills awaiting promotion. |
@@ -107,3 +110,12 @@ removes the draft. Rules:
 - Imports from OpenClaw land in the canonical draft root and must go through
   the same `/skills promote` gate.
 - Promotion re-runs the scanner; critical/high findings block promotion.
+
+## Official plugins are separate
+
+Do not use `/skills import` for a real Claude plugin or marketplace package.
+Those go through the official profile-scoped lifecycle:
+
+```bash
+telclaude plugins install <plugin@marketplace> --persona private
+```

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -1,0 +1,525 @@
+import {
+	type SpawnSyncOptionsWithStringEncoding,
+	type SpawnSyncReturns,
+	spawnSync,
+} from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Command } from "commander";
+import JSON5 from "json5";
+
+export type PluginPersona = "private" | "social";
+export type PluginPersonaScope = PluginPersona | "both";
+
+export type PluginTarget = {
+	persona: PluginPersona;
+	claudeHome: string;
+};
+
+export type PluginCapabilities = {
+	disable: boolean;
+	enable: boolean;
+	install: boolean;
+	list: boolean;
+	marketplaceAdd: boolean;
+	marketplaceUpdate: boolean;
+	uninstall: boolean;
+	update: boolean;
+};
+
+export type ClaudePluginRunner = {
+	run(
+		cmd: string,
+		args: string[],
+		options?: SpawnSyncOptionsWithStringEncoding,
+	): SpawnSyncReturns<string>;
+};
+
+export type ManagedPluginTargetResult = PluginTarget & {
+	actions: string[];
+};
+
+export type ManagedPluginMutationResult = {
+	pluginId: string;
+	targets: ManagedPluginTargetResult[];
+};
+
+export type ManagedPluginState = {
+	pluginId: string;
+	enabled: boolean;
+	installed: boolean;
+	versions: string[];
+};
+
+export type ManagedPluginListEntry = PluginTarget & {
+	plugins: ManagedPluginState[];
+};
+
+type PluginCommandOptions = {
+	persona?: PluginPersonaScope;
+	env?: NodeJS.ProcessEnv;
+	runner?: ClaudePluginRunner;
+	marketplaceSource?: string;
+};
+
+type InstalledPluginsFile = {
+	plugins?: Record<string, Array<{ version?: string }>>;
+};
+
+type KnownMarketplacesFile = Record<string, unknown>;
+
+function createDefaultRunner(): ClaudePluginRunner {
+	return {
+		run(cmd, args, options) {
+			return spawnSync(cmd, args, {
+				encoding: "utf8",
+				stdio: "pipe",
+				...options,
+			});
+		},
+	};
+}
+
+function normalizeDir(raw: string): string {
+	return raw.replace(/[/\\]+$/, "");
+}
+
+function resolvePrivateClaudeHome(env: NodeJS.ProcessEnv): string {
+	const raw =
+		env.TELCLAUDE_PRIVATE_CLAUDE_HOME ??
+		env.CLAUDE_CONFIG_DIR ??
+		env.TELCLAUDE_CLAUDE_HOME ??
+		path.join(os.homedir(), ".claude");
+	return normalizeDir(path.resolve(raw));
+}
+
+function resolveSocialClaudeHome(env: NodeJS.ProcessEnv): string {
+	const raw = env.TELCLAUDE_SOCIAL_CLAUDE_HOME;
+	if (!raw) {
+		throw new Error("TELCLAUDE_SOCIAL_CLAUDE_HOME is not configured.");
+	}
+	return normalizeDir(path.resolve(raw));
+}
+
+export function resolvePluginTargets(
+	persona: PluginPersonaScope | string | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): PluginTarget[] {
+	switch (persona ?? "private") {
+		case "private":
+			return [{ persona: "private", claudeHome: resolvePrivateClaudeHome(env) }];
+		case "social":
+			return [{ persona: "social", claudeHome: resolveSocialClaudeHome(env) }];
+		case "both":
+			return [
+				{ persona: "private", claudeHome: resolvePrivateClaudeHome(env) },
+				{ persona: "social", claudeHome: resolveSocialClaudeHome(env) },
+			];
+		default:
+			throw new Error(`Invalid persona scope "${persona}". Expected private, social, or both.`);
+	}
+}
+
+function includesCommand(helpText: string, commandName: string): boolean {
+	return new RegExp(`(^|\\n)\\s*${commandName}\\b`, "m").test(helpText);
+}
+
+export function detectClaudePluginCapabilities(
+	runner: ClaudePluginRunner = createDefaultRunner(),
+): PluginCapabilities {
+	const pluginHelp = runner.run("claude", ["plugin", "--help"]);
+	const pluginStdout = pluginHelp.status === 0 ? pluginHelp.stdout : "";
+	const marketplaceHelp = runner.run("claude", ["plugin", "marketplace", "--help"]);
+	const marketplaceStdout = marketplaceHelp.status === 0 ? marketplaceHelp.stdout : "";
+
+	return {
+		disable: includesCommand(pluginStdout, "disable"),
+		enable: includesCommand(pluginStdout, "enable"),
+		install: includesCommand(pluginStdout, "install"),
+		list: includesCommand(pluginStdout, "list"),
+		marketplaceAdd: includesCommand(marketplaceStdout, "add"),
+		marketplaceUpdate: includesCommand(marketplaceStdout, "update"),
+		uninstall: includesCommand(pluginStdout, "uninstall"),
+		update: includesCommand(pluginStdout, "update"),
+	};
+}
+
+function assertCapabilities(
+	capabilities: PluginCapabilities,
+	required: Array<keyof PluginCapabilities>,
+	context: string,
+): void {
+	const missing = required.filter((key) => !capabilities[key]);
+	if (missing.length === 0) {
+		return;
+	}
+	throw new Error(
+		`The installed Claude CLI does not support ${context}. Missing subcommands: ${missing.join(", ")}.`,
+	);
+}
+
+function parsePluginId(pluginId: string): { pluginName: string; marketplaceName: string } {
+	const trimmed = pluginId.trim();
+	const match = /^(?<pluginName>[a-z0-9][a-z0-9-]*)@(?<marketplaceName>[a-z0-9][a-z0-9-]*)$/i.exec(
+		trimmed,
+	);
+	if (!match?.groups) {
+		throw new Error(
+			`Invalid plugin id "${pluginId}". Expected the official form <plugin-name>@<marketplace-name>.`,
+		);
+	}
+	return {
+		pluginName: match.groups.pluginName,
+		marketplaceName: match.groups.marketplaceName,
+	};
+}
+
+function readJsonFile<T>(filePath: string, fallback: T): T {
+	try {
+		const raw = fs.readFileSync(filePath, "utf8");
+		return JSON5.parse(raw) as T;
+	} catch (error) {
+		if (
+			typeof error === "object" &&
+			error !== null &&
+			"code" in error &&
+			(error as NodeJS.ErrnoException).code === "ENOENT"
+		) {
+			return fallback;
+		}
+		throw new Error(
+			`Failed to read Claude plugin metadata at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+function readSettingsEnabledPlugins(claudeHome: string): Record<string, boolean> {
+	const settings = readJsonFile<Record<string, unknown>>(
+		path.join(claudeHome, "settings.json"),
+		{},
+	);
+	const enabledPlugins = settings.enabledPlugins;
+	if (Array.isArray(enabledPlugins)) {
+		return Object.fromEntries(enabledPlugins.map((pluginId) => [String(pluginId), true]));
+	}
+	if (enabledPlugins && typeof enabledPlugins === "object") {
+		return Object.fromEntries(
+			Object.entries(enabledPlugins as Record<string, unknown>).map(([pluginId, enabled]) => [
+				pluginId,
+				Boolean(enabled),
+			]),
+		);
+	}
+	return {};
+}
+
+function readInstalledPlugins(claudeHome: string): Record<string, Array<{ version?: string }>> {
+	const installed = readJsonFile<InstalledPluginsFile>(
+		path.join(claudeHome, "plugins", "installed_plugins.json"),
+		{},
+	);
+	return installed.plugins ?? {};
+}
+
+function readKnownMarketplaces(claudeHome: string): KnownMarketplacesFile {
+	return readJsonFile<KnownMarketplacesFile>(
+		path.join(claudeHome, "plugins", "known_marketplaces.json"),
+		{},
+	);
+}
+
+function buildPluginEnv(baseEnv: NodeJS.ProcessEnv, claudeHome: string): NodeJS.ProcessEnv {
+	return {
+		...baseEnv,
+		CLAUDE_CONFIG_DIR: claudeHome,
+		TELCLAUDE_CLAUDE_HOME: claudeHome,
+	};
+}
+
+function runClaudePluginCommand(
+	runner: ClaudePluginRunner,
+	target: PluginTarget,
+	args: string[],
+	baseEnv: NodeJS.ProcessEnv,
+): SpawnSyncReturns<string> {
+	const result = runner.run("claude", args, {
+		encoding: "utf8",
+		env: buildPluginEnv(baseEnv, target.claudeHome),
+	});
+	if (result.status !== 0) {
+		const stderr = result.stderr.trim();
+		const stdout = result.stdout.trim();
+		throw new Error(
+			[
+				`Claude plugin command failed for ${target.persona} profile: claude ${args.join(" ")}`,
+				stderr || stdout || "Unknown error",
+			].join("\n"),
+		);
+	}
+	return result;
+}
+
+function getPluginState(target: PluginTarget): {
+	enabledPlugins: Record<string, boolean>;
+	installedPlugins: Record<string, Array<{ version?: string }>>;
+	knownMarketplaces: KnownMarketplacesFile;
+} {
+	return {
+		enabledPlugins: readSettingsEnabledPlugins(target.claudeHome),
+		installedPlugins: readInstalledPlugins(target.claudeHome),
+		knownMarketplaces: readKnownMarketplaces(target.claudeHome),
+	};
+}
+
+export function installManagedPlugin(
+	pluginId: string,
+	options: PluginCommandOptions = {},
+): ManagedPluginMutationResult {
+	const runner = options.runner ?? createDefaultRunner();
+	const env = options.env ?? process.env;
+	const targets = resolvePluginTargets(options.persona, env);
+	const capabilities = detectClaudePluginCapabilities(runner);
+	assertCapabilities(capabilities, ["install"], "official plugin installation");
+	const { marketplaceName } = parsePluginId(pluginId);
+
+	return {
+		pluginId,
+		targets: targets.map((target) => {
+			const state = getPluginState(target);
+			const actions: string[] = [];
+			const installed = Array.isArray(state.installedPlugins[pluginId]);
+			const enabled = state.enabledPlugins[pluginId] === true;
+			const marketplaceKnown = Object.hasOwn(state.knownMarketplaces, marketplaceName);
+
+			if (options.marketplaceSource && !marketplaceKnown) {
+				assertCapabilities(capabilities, ["marketplaceAdd"], "plugin marketplace add");
+				runClaudePluginCommand(
+					runner,
+					target,
+					["plugin", "marketplace", "add", options.marketplaceSource],
+					env,
+				);
+				actions.push("marketplace:add");
+			}
+
+			if (installed && !enabled) {
+				assertCapabilities(capabilities, ["enable"], "plugin enable");
+				runClaudePluginCommand(runner, target, ["plugin", "enable", pluginId], env);
+				actions.push("plugin:enable");
+			} else if (!installed) {
+				runClaudePluginCommand(runner, target, ["plugin", "install", pluginId], env);
+				actions.push("plugin:install");
+			}
+
+			return { ...target, actions };
+		}),
+	};
+}
+
+export function updateManagedPlugin(
+	pluginId: string,
+	options: PluginCommandOptions = {},
+): ManagedPluginMutationResult {
+	const runner = options.runner ?? createDefaultRunner();
+	const env = options.env ?? process.env;
+	const targets = resolvePluginTargets(options.persona, env);
+	const capabilities = detectClaudePluginCapabilities(runner);
+	assertCapabilities(capabilities, ["update"], "official plugin update");
+	const { marketplaceName } = parsePluginId(pluginId);
+
+	return {
+		pluginId,
+		targets: targets.map((target) => {
+			const state = getPluginState(target);
+			if (!Array.isArray(state.installedPlugins[pluginId])) {
+				throw new Error(
+					`Plugin "${pluginId}" is not installed in the ${target.persona} profile (${target.claudeHome}).`,
+				);
+			}
+
+			const actions: string[] = [];
+			const marketplaceKnown = Object.hasOwn(state.knownMarketplaces, marketplaceName);
+			if (marketplaceKnown) {
+				assertCapabilities(capabilities, ["marketplaceUpdate"], "plugin marketplace update");
+				runClaudePluginCommand(
+					runner,
+					target,
+					["plugin", "marketplace", "update", marketplaceName],
+					env,
+				);
+				actions.push("marketplace:update");
+			} else if (options.marketplaceSource) {
+				assertCapabilities(capabilities, ["marketplaceAdd"], "plugin marketplace add");
+				runClaudePluginCommand(
+					runner,
+					target,
+					["plugin", "marketplace", "add", options.marketplaceSource],
+					env,
+				);
+				actions.push("marketplace:add");
+			}
+
+			runClaudePluginCommand(runner, target, ["plugin", "update", pluginId], env);
+			actions.push("plugin:update");
+			return { ...target, actions };
+		}),
+	};
+}
+
+export function uninstallManagedPlugin(
+	pluginId: string,
+	options: PluginCommandOptions = {},
+): ManagedPluginMutationResult {
+	const runner = options.runner ?? createDefaultRunner();
+	const env = options.env ?? process.env;
+	const targets = resolvePluginTargets(options.persona, env);
+	const capabilities = detectClaudePluginCapabilities(runner);
+	assertCapabilities(capabilities, ["uninstall"], "official plugin uninstall");
+
+	return {
+		pluginId,
+		targets: targets.map((target) => {
+			runClaudePluginCommand(runner, target, ["plugin", "uninstall", pluginId], env);
+			return { ...target, actions: ["plugin:uninstall"] };
+		}),
+	};
+}
+
+export function listManagedPlugins(
+	options: { persona?: PluginPersonaScope; env?: NodeJS.ProcessEnv } = {},
+): ManagedPluginListEntry[] {
+	const targets = resolvePluginTargets(options.persona, options.env ?? process.env);
+	return targets.map((target) => {
+		const enabledPlugins = readSettingsEnabledPlugins(target.claudeHome);
+		const installedPlugins = readInstalledPlugins(target.claudeHome);
+		const pluginIds = Array.from(
+			new Set([...Object.keys(enabledPlugins), ...Object.keys(installedPlugins)]),
+		).sort((left, right) => left.localeCompare(right));
+
+		return {
+			...target,
+			plugins: pluginIds.map((pluginId) => ({
+				pluginId,
+				enabled: enabledPlugins[pluginId] === true,
+				installed: Array.isArray(installedPlugins[pluginId]),
+				versions: Array.from(
+					new Set(
+						(installedPlugins[pluginId] ?? [])
+							.map((entry) => entry.version?.trim())
+							.filter((version): version is string => Boolean(version)),
+					),
+				).sort((left, right) => left.localeCompare(right)),
+			})),
+		};
+	});
+}
+
+function logMutationResult(result: ManagedPluginMutationResult): void {
+	for (const target of result.targets) {
+		const actionSummary = target.actions.length > 0 ? target.actions.join(", ") : "no-op";
+		console.log(`${target.persona}: ${actionSummary} (${target.claudeHome})`);
+	}
+}
+
+function logPluginList(entries: ManagedPluginListEntry[]): void {
+	for (const entry of entries) {
+		console.log(`${entry.persona} (${entry.claudeHome})`);
+		if (entry.plugins.length === 0) {
+			console.log("  (no managed plugins)");
+			continue;
+		}
+		for (const plugin of entry.plugins) {
+			const versions = plugin.versions.length > 0 ? ` versions=${plugin.versions.join(",")}` : "";
+			console.log(
+				`  ${plugin.pluginId} installed=${plugin.installed ? "yes" : "no"} enabled=${plugin.enabled ? "yes" : "no"}${versions}`,
+			);
+		}
+	}
+}
+
+function handlePluginCommandError(err: unknown): never {
+	console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+	process.exit(1);
+}
+
+export function registerPluginsCommandGroup(parent: Command): void {
+	parent
+		.command("list")
+		.description("List official Claude plugins installed in the private and/or social profiles")
+		.option("--persona <scope>", "Target persona: private, social, or both", "private")
+		.option("--json", "Emit machine-readable JSON")
+		.action((options: { persona?: PluginPersonaScope; json?: boolean }) => {
+			try {
+				const entries = listManagedPlugins({ persona: options.persona });
+				if (options.json) {
+					process.stdout.write(`${JSON.stringify(entries, null, 2)}\n`);
+					return;
+				}
+				logPluginList(entries);
+			} catch (err) {
+				handlePluginCommandError(err);
+			}
+		});
+
+	parent
+		.command("install")
+		.description("Install an official Claude plugin into the target persona profile(s)")
+		.argument("<plugin-id>", "Plugin id in the form <plugin>@<marketplace>")
+		.option("--persona <scope>", "Target persona: private, social, or both", "private")
+		.option(
+			"--marketplace-source <source>",
+			"Marketplace source for first-time install (GitHub shorthand, git URL, remote marketplace.json URL, or local path)",
+		)
+		.action(
+			(pluginId: string, options: { persona?: PluginPersonaScope; marketplaceSource?: string }) => {
+				try {
+					logMutationResult(
+						installManagedPlugin(pluginId, {
+							persona: options.persona,
+							marketplaceSource: options.marketplaceSource,
+						}),
+					);
+				} catch (err) {
+					handlePluginCommandError(err);
+				}
+			},
+		);
+
+	parent
+		.command("update")
+		.description("Update an official Claude plugin in the target persona profile(s)")
+		.argument("<plugin-id>", "Plugin id in the form <plugin>@<marketplace>")
+		.option("--persona <scope>", "Target persona: private, social, or both", "private")
+		.option(
+			"--marketplace-source <source>",
+			"Marketplace source to add when the profile does not yet know the plugin marketplace",
+		)
+		.action(
+			(pluginId: string, options: { persona?: PluginPersonaScope; marketplaceSource?: string }) => {
+				try {
+					logMutationResult(
+						updateManagedPlugin(pluginId, {
+							persona: options.persona,
+							marketplaceSource: options.marketplaceSource,
+						}),
+					);
+				} catch (err) {
+					handlePluginCommandError(err);
+				}
+			},
+		);
+
+	parent
+		.command("uninstall")
+		.description("Uninstall an official Claude plugin from the target persona profile(s)")
+		.argument("<plugin-id>", "Plugin id in the form <plugin>@<marketplace>")
+		.option("--persona <scope>", "Target persona: private, social, or both", "private")
+		.action((pluginId: string, options: { persona?: PluginPersonaScope }) => {
+			try {
+				logMutationResult(uninstallManagedPlugin(pluginId, { persona: options.persona }));
+			} catch (err) {
+				handlePluginCommandError(err);
+			}
+		});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { registerNetworkCommand } from "./commands/network.js";
 import { registerOAuthCommand } from "./commands/oauth.js";
 import { registerOnboardCommand } from "./commands/onboard.js";
 import { registerPairingCommand } from "./commands/pairing.js";
+import { registerPluginsCommandGroup } from "./commands/plugins.js";
 import { registerProviderHealthCommand } from "./commands/provider-health.js";
 import { registerProviderQueryCommand } from "./commands/provider-query.js";
 import { registerProvidersCommandGroup } from "./commands/providers.js";
@@ -118,6 +119,12 @@ registerAdminSubcommands(admin);
 // --- providers ---
 const providers = program.command("providers").description("Manage external providers");
 registerProvidersCommandGroup(providers);
+
+// --- plugins ---
+const plugins = program
+	.command("plugins")
+	.description("Manage official Claude plugins in persona-scoped profiles");
+registerPluginsCommandGroup(plugins);
 
 // --- dev ---
 const dev = program.command("dev").description("Development and diagnostic tools");

--- a/src/telegram/control-command-actions.ts
+++ b/src/telegram/control-command-actions.ts
@@ -390,14 +390,23 @@ export async function sendSkillsImportCommand(
 	opts: { chatId: number; threadId?: number },
 ): Promise<CommandUiResult> {
 	const message = [
-		"`/skills import` runs from the CLI (requires filesystem source path):",
+		"`/skills import` is only for standalone filesystem skills.",
+		"",
+		"Official Claude plugins use:",
+		"",
+		"  telclaude plugins install <plugin@marketplace> --persona private",
+		"",
+		"Standalone skill imports still use:",
 		"",
 		"  telclaude skills import-openclaw <source>",
 		"",
 		"Imports land in the canonical draft-skill catalog and can be promoted via /skills promote.",
 	].join("\n");
 	await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
-	return { callbackText: "Run `telclaude skills import-openclaw` from the CLI." };
+	return {
+		callbackText:
+			"Use `telclaude plugins install` for plugins, `skills import-openclaw` for standalone skills.",
+	};
 }
 
 const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;

--- a/src/telegram/control-commands.ts
+++ b/src/telegram/control-commands.ts
@@ -476,7 +476,7 @@ const TELEGRAM_CONTROL_COMMANDS: TelegramControlCommandDefinition[] = [
 		domain: "skills",
 		subcommand: "import",
 		category: "Skills",
-		description: "Import OpenClaw-format skills into the draft quarantine (CLI).",
+		description: "Import standalone OpenClaw-format skills into the draft quarantine (CLI).",
 		usage: "/skills import <source-path>",
 		examples: ["/skills import /tmp/openclaw-skills"],
 		keywords: ["import skills", "openclaw", "import openclaw"],

--- a/tests/commands/plugins.test.ts
+++ b/tests/commands/plugins.test.ts
@@ -1,0 +1,463 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	detectClaudePluginCapabilities,
+	installManagedPlugin,
+	listManagedPlugins,
+	resolvePluginTargets,
+	type ClaudePluginRunner,
+	uninstallManagedPlugin,
+	updateManagedPlugin,
+} from "../../src/commands/plugins.js";
+
+type RunnerCall = {
+	cmd: string;
+	args: string[];
+	env?: NodeJS.ProcessEnv;
+};
+
+function createRunner(outputs: Record<string, { status?: number; stdout?: string; stderr?: string }>) {
+	const calls: RunnerCall[] = [];
+	const runner: ClaudePluginRunner = {
+		run(cmd, args, options) {
+			calls.push({ cmd, args, env: options?.env });
+			const key = [cmd, ...args].join(" ");
+			const next = outputs[key];
+			if (!next) {
+				throw new Error(`Unexpected runner call: ${key}`);
+			}
+			return {
+				status: next.status ?? 0,
+				stdout: next.stdout ?? "",
+				stderr: next.stderr ?? "",
+				pid: 1,
+				output: [],
+				signal: null,
+			};
+		},
+	};
+	return { runner, calls };
+}
+
+function writeJson(filePath: string, value: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf8");
+}
+
+describe("resolvePluginTargets", () => {
+	let tempRoot = "";
+
+	beforeEach(() => {
+		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "plugins-command-"));
+	});
+
+	afterEach(() => {
+		if (tempRoot && fs.existsSync(tempRoot)) {
+			fs.rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("defaults to the private persona", () => {
+		const privateHome = path.join(tempRoot, "private");
+		const targets = resolvePluginTargets(undefined, {
+			TELCLAUDE_PRIVATE_CLAUDE_HOME: privateHome,
+		});
+
+		expect(targets).toEqual([{ persona: "private", claudeHome: privateHome }]);
+	});
+
+	it("returns both personas when requested", () => {
+		const privateHome = path.join(tempRoot, "private");
+		const socialHome = path.join(tempRoot, "social");
+		const targets = resolvePluginTargets("both", {
+			TELCLAUDE_PRIVATE_CLAUDE_HOME: privateHome,
+			TELCLAUDE_SOCIAL_CLAUDE_HOME: socialHome,
+		});
+
+		expect(targets).toEqual([
+			{ persona: "private", claudeHome: privateHome },
+			{ persona: "social", claudeHome: socialHome },
+		]);
+	});
+
+	it("fails closed when the requested social profile is not configured", () => {
+		expect(() => resolvePluginTargets("social", {})).toThrow(
+			"TELCLAUDE_SOCIAL_CLAUDE_HOME is not configured",
+		);
+	});
+
+	it("rejects invalid persona scopes", () => {
+		expect(() =>
+			resolvePluginTargets("everywhere", {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: path.join(tempRoot, "private"),
+			}),
+		).toThrow('Invalid persona scope "everywhere"');
+	});
+});
+
+describe("detectClaudePluginCapabilities", () => {
+	it("detects install and marketplace support from the official CLI help", () => {
+		const { runner } = createRunner({
+			"claude plugin --help": {
+				stdout: `Usage: claude plugin [options] [command]
+
+Commands:
+  install [options] <plugin>
+  list [options]
+  marketplace
+  update [options] <plugin>
+  uninstall [options] <plugin>
+  enable [options] <plugin>
+  disable [options] [plugin]
+`,
+			},
+			"claude plugin marketplace --help": {
+				stdout: `Usage: claude plugin marketplace [options] [command]
+
+Commands:
+  add <source>
+  list
+  update [name]
+`,
+			},
+		});
+
+		expect(detectClaudePluginCapabilities(runner)).toEqual({
+			disable: true,
+			enable: true,
+			install: true,
+			list: true,
+			marketplaceAdd: true,
+			marketplaceUpdate: true,
+			uninstall: true,
+			update: true,
+		});
+	});
+
+	it("reports missing plugin management support on older CLI builds", () => {
+		const { runner } = createRunner({
+			"claude plugin --help": {
+				stdout: `Usage: claude plugin [options] [command]
+
+Commands:
+  validate <path>
+`,
+			},
+			"claude plugin marketplace --help": {
+				status: 1,
+				stderr: "Unknown command",
+			},
+		});
+
+		expect(detectClaudePluginCapabilities(runner)).toEqual({
+			disable: false,
+			enable: false,
+			install: false,
+			list: false,
+			marketplaceAdd: false,
+			marketplaceUpdate: false,
+			uninstall: false,
+			update: false,
+		});
+	});
+});
+
+describe("managed plugin commands", () => {
+	let tempRoot = "";
+	let privateHome = "";
+	let socialHome = "";
+
+	beforeEach(() => {
+		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "plugins-command-"));
+		privateHome = path.join(tempRoot, "private");
+		socialHome = path.join(tempRoot, "social");
+	});
+
+	afterEach(() => {
+		if (tempRoot && fs.existsSync(tempRoot)) {
+			fs.rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("installs into the requested persona profiles via official claude plugin commands", () => {
+		const { runner, calls } = createRunner({
+			"claude plugin --help": {
+				stdout:
+					"Commands:\n  install [options] <plugin>\n  list [options]\n  marketplace\n  update [options] <plugin>\n  uninstall [options] <plugin>\n  enable [options] <plugin>\n  disable [options] [plugin]\n",
+			},
+			"claude plugin marketplace --help": {
+				stdout: "Commands:\n  add <source>\n  update [name]\n",
+			},
+			"claude plugin marketplace add avivsinai/skills-marketplace": {
+				stdout: "added\n",
+			},
+			"claude plugin install shaon@avivsinai-marketplace": {
+				stdout: "installed\n",
+			},
+		});
+
+		const result = installManagedPlugin("shaon@avivsinai-marketplace", {
+			persona: "private",
+			marketplaceSource: "avivsinai/skills-marketplace",
+			env: {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: privateHome,
+			},
+			runner,
+		});
+
+		expect(result.targets).toEqual([
+			{
+				persona: "private",
+				claudeHome: privateHome,
+				actions: ["marketplace:add", "plugin:install"],
+			},
+		]);
+		expect(calls.at(-2)?.args).toEqual([
+			"plugin",
+			"marketplace",
+			"add",
+			"avivsinai/skills-marketplace",
+		]);
+		expect(calls.at(-1)?.args).toEqual(["plugin", "install", "shaon@avivsinai-marketplace"]);
+		expect(calls.at(-1)?.env?.CLAUDE_CONFIG_DIR).toBe(privateHome);
+	});
+
+	it("enables an already-installed but disabled plugin instead of reinstalling it", () => {
+		writeJson(path.join(privateHome, "settings.json"), {
+			enabledPlugins: {
+				"shaon@avivsinai-marketplace": false,
+			},
+		});
+		writeJson(path.join(privateHome, "plugins", "installed_plugins.json"), {
+			version: 2,
+			plugins: {
+				"shaon@avivsinai-marketplace": [
+					{
+						scope: "user",
+						installPath: path.join(privateHome, "plugins", "cache", "avivsinai-marketplace", "shaon", "0.8.3"),
+						version: "0.8.3",
+						installedAt: "2026-04-20T00:00:00.000Z",
+						lastUpdated: "2026-04-20T00:00:00.000Z",
+					},
+				],
+			},
+		});
+
+		const { runner } = createRunner({
+			"claude plugin --help": {
+				stdout:
+					"Commands:\n  install [options] <plugin>\n  list [options]\n  marketplace\n  update [options] <plugin>\n  uninstall [options] <plugin>\n  enable [options] <plugin>\n  disable [options] [plugin]\n",
+			},
+			"claude plugin marketplace --help": {
+				stdout: "Commands:\n  add <source>\n  update [name]\n",
+			},
+			"claude plugin enable shaon@avivsinai-marketplace": {
+				stdout: "enabled\n",
+			},
+		});
+
+		const result = installManagedPlugin("shaon@avivsinai-marketplace", {
+			persona: "private",
+			env: {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: privateHome,
+			},
+			runner,
+		});
+
+		expect(result.targets[0]?.actions).toEqual(["plugin:enable"]);
+	});
+
+	it("updates an installed plugin after refreshing the configured marketplace", () => {
+		writeJson(path.join(privateHome, "settings.json"), {
+			enabledPlugins: {
+				"shaon@avivsinai-marketplace": true,
+			},
+		});
+		writeJson(path.join(privateHome, "plugins", "installed_plugins.json"), {
+			version: 2,
+			plugins: {
+				"shaon@avivsinai-marketplace": [
+					{
+						scope: "user",
+						installPath: path.join(privateHome, "plugins", "cache", "avivsinai-marketplace", "shaon", "0.8.3"),
+						version: "0.8.3",
+						installedAt: "2026-04-20T00:00:00.000Z",
+						lastUpdated: "2026-04-20T00:00:00.000Z",
+					},
+				],
+			},
+		});
+		writeJson(path.join(privateHome, "plugins", "known_marketplaces.json"), {
+			"avivsinai-marketplace": {
+				source: {
+					source: "github",
+					repo: "avivsinai/skills-marketplace",
+				},
+			},
+		});
+
+		const { runner, calls } = createRunner({
+			"claude plugin --help": {
+				stdout:
+					"Commands:\n  install [options] <plugin>\n  list [options]\n  marketplace\n  update [options] <plugin>\n  uninstall [options] <plugin>\n  enable [options] <plugin>\n  disable [options] [plugin]\n",
+			},
+			"claude plugin marketplace --help": {
+				stdout: "Commands:\n  add <source>\n  update [name]\n",
+			},
+			"claude plugin marketplace update avivsinai-marketplace": {
+				stdout: "updated marketplace\n",
+			},
+			"claude plugin update shaon@avivsinai-marketplace": {
+				stdout: "updated plugin\n",
+			},
+		});
+
+		const result = updateManagedPlugin("shaon@avivsinai-marketplace", {
+			persona: "private",
+			marketplaceSource: "avivsinai/skills-marketplace",
+			env: {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: privateHome,
+			},
+			runner,
+		});
+
+		expect(result.targets[0]?.actions).toEqual(["marketplace:update", "plugin:update"]);
+		expect(calls.at(-2)?.args).toEqual([
+			"plugin",
+			"marketplace",
+			"update",
+			"avivsinai-marketplace",
+		]);
+		expect(calls.at(-1)?.args).toEqual(["plugin", "update", "shaon@avivsinai-marketplace"]);
+	});
+
+	it("lists the installed plugin state for each persona profile", () => {
+		writeJson(path.join(privateHome, "settings.json"), {
+			enabledPlugins: {
+				"shaon@avivsinai-marketplace": true,
+			},
+		});
+		writeJson(path.join(privateHome, "plugins", "installed_plugins.json"), {
+			version: 2,
+			plugins: {
+				"shaon@avivsinai-marketplace": [
+					{
+						scope: "user",
+						installPath: path.join(privateHome, "plugins", "cache", "avivsinai-marketplace", "shaon", "0.8.3"),
+						version: "0.8.3",
+						installedAt: "2026-04-20T00:00:00.000Z",
+						lastUpdated: "2026-04-20T00:00:00.000Z",
+					},
+				],
+			},
+		});
+		writeJson(path.join(socialHome, "settings.json"), {
+			enabledPlugins: {
+				"shaon@avivsinai-marketplace": false,
+			},
+		});
+		writeJson(path.join(socialHome, "plugins", "installed_plugins.json"), {
+			version: 2,
+			plugins: {
+				"shaon@avivsinai-marketplace": [
+					{
+						scope: "user",
+						installPath: path.join(socialHome, "plugins", "cache", "avivsinai-marketplace", "shaon", "0.8.3"),
+						version: "0.8.3",
+						installedAt: "2026-04-20T00:00:00.000Z",
+						lastUpdated: "2026-04-20T00:00:00.000Z",
+					},
+				],
+			},
+		});
+
+		const listed = listManagedPlugins({
+			persona: "both",
+			env: {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: privateHome,
+				TELCLAUDE_SOCIAL_CLAUDE_HOME: socialHome,
+			},
+		});
+
+		expect(listed).toEqual([
+			{
+				persona: "private",
+				claudeHome: privateHome,
+				plugins: [
+					{
+						enabled: true,
+						installed: true,
+						pluginId: "shaon@avivsinai-marketplace",
+						versions: ["0.8.3"],
+					},
+				],
+			},
+			{
+				persona: "social",
+				claudeHome: socialHome,
+				plugins: [
+					{
+						enabled: false,
+						installed: true,
+						pluginId: "shaon@avivsinai-marketplace",
+						versions: ["0.8.3"],
+					},
+				],
+			},
+		]);
+	});
+
+	it("fails loudly when profile metadata is corrupted", () => {
+		fs.mkdirSync(path.join(privateHome, "plugins"), { recursive: true });
+		fs.writeFileSync(path.join(privateHome, "settings.json"), "{ invalid", "utf8");
+
+		expect(() =>
+			listManagedPlugins({
+				persona: "private",
+				env: {
+					TELCLAUDE_PRIVATE_CLAUDE_HOME: privateHome,
+				},
+			}),
+		).toThrow("Failed to read Claude plugin metadata");
+	});
+
+	it("uninstalls the plugin from each requested persona", () => {
+		writeJson(path.join(privateHome, "settings.json"), {
+			enabledPlugins: {
+				"shaon@avivsinai-marketplace": true,
+			},
+		});
+		writeJson(path.join(privateHome, "plugins", "installed_plugins.json"), {
+			version: 2,
+			plugins: {
+				"shaon@avivsinai-marketplace": [{ version: "0.8.3" }],
+			},
+		});
+
+		const { runner } = createRunner({
+			"claude plugin --help": {
+				stdout:
+					"Commands:\n  install [options] <plugin>\n  list [options]\n  marketplace\n  update [options] <plugin>\n  uninstall [options] <plugin>\n  enable [options] <plugin>\n  disable [options] [plugin]\n",
+			},
+			"claude plugin marketplace --help": {
+				stdout: "Commands:\n  add <source>\n  update [name]\n",
+			},
+			"claude plugin uninstall shaon@avivsinai-marketplace": {
+				stdout: "uninstalled\n",
+			},
+		});
+
+		const result = uninstallManagedPlugin("shaon@avivsinai-marketplace", {
+			persona: "private",
+			env: {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: privateHome,
+			},
+			runner,
+		});
+
+		expect(result.targets[0]?.actions).toEqual(["plugin:uninstall"]);
+	});
+});


### PR DESCRIPTION
Add an official Claude plugin management path to telclaude.

This keeps standalone telclaude skills on the shared draft/promote catalog, but moves real Claude plugins onto the lifecycle they actually belong to: persona-scoped Claude profiles using Claude's own install, update, and uninstall commands.

The relay now mounts the real private and social profile volumes so operator commands act on the same Linux runtime state the agents use on the NUC instead of guessing from the local host environment. That preserves the intended boundary: private and social can share standalone skills while keeping plugin state profile-local.

I also split the operator docs and `/skills import` guidance so marketplace plugins and standalone skill folders stop being treated as the same thing, and added regression coverage for persona targeting, marketplace capability detection, and corrupted profile metadata.