### PR TITLE
fix(social): Separate manual access from heartbeats

### DIFF
--- a/src/commands/cron.ts
+++ b/src/commands/cron.ts
@@ -155,7 +155,7 @@ function formatAction(action: CronAction): string {
 	if (action.serviceId) {
 		return `social heartbeat (${action.serviceId})`;
 	}
-	return "social heartbeat (all enabled)";
+	return "social heartbeat (all automatic-enabled)";
 }
 
 function formatDeliveryTarget(target: CronDeliveryTarget): string {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -38,6 +38,7 @@ import {
 	handleSocialHeartbeat,
 	startSocialScheduler,
 } from "../social/index.js";
+import { getEnabledSocialServices, isAutomaticHeartbeatEnabled } from "../social/service-config.js";
 import { getServiceRevision, getServiceVersion } from "../system-metadata.js";
 import { monitorTelegramProvider } from "../telegram/auto-reply.js";
 import { handlePrivateHeartbeat } from "../telegram/heartbeat.js";
@@ -243,9 +244,14 @@ export function registerRelayCommand(program: Command): void {
 					console.log("  Cron scheduler: disabled in config");
 				}
 
-				const enabledServices = cfg.socialServices.filter((s) => s.enabled);
+				const enabledServices = getEnabledSocialServices(cfg);
 				if (enabledServices.length > 0) {
 					for (const svc of enabledServices) {
+						if (!isAutomaticHeartbeatEnabled(svc)) {
+							console.log(`  Social service ${svc.id}: enabled (automatic heartbeat disabled)`);
+							continue;
+						}
+
 						const coveredByCron =
 							cronEnabled &&
 							(cronCoverage.allSocial || cronCoverage.socialServiceIds.includes(svc.id));

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -64,7 +64,11 @@ const TELEGRAM_NUDGES_DEFAULTS = {
 	digestIntervalHours: 24,
 } as const;
 const SDK_DEFAULTS = { betas: [] as "context-1m-2025-08-07"[] };
-const SOCIAL_SERVICE_DEFAULTS = { enabled: false, heartbeatIntervalHours: 4 } as const;
+const SOCIAL_SERVICE_DEFAULTS = {
+	enabled: false,
+	heartbeatEnabled: true,
+	heartbeatIntervalHours: 4,
+} as const;
 const CRON_DEFAULTS = { enabled: true, pollIntervalSeconds: 15, timeoutSeconds: 900 } as const;
 const DASHBOARD_DEFAULTS = { enabled: false, port: 3005 } as const;
 
@@ -442,6 +446,8 @@ const SocialServiceConfigSchema = z.object({
 	handle: z.string().optional(),
 	/** Display name on the service (e.g. "Claude Ici") */
 	displayName: z.string().optional(),
+	/** Controls automatic heartbeats only. Manual social ask/run still work when enabled=true. */
+	heartbeatEnabled: z.boolean().default(SOCIAL_SERVICE_DEFAULTS.heartbeatEnabled),
 	heartbeatIntervalHours: z
 		.number()
 		.positive()

--- a/src/cron/actions.ts
+++ b/src/cron/actions.ts
@@ -1,6 +1,7 @@
 import type { TelclaudeConfig } from "../config/config.js";
 import { getChildLogger } from "../logging.js";
 import { createSocialClient, handleSocialHeartbeat } from "../social/index.js";
+import { getAutomaticHeartbeatSocialServices } from "../social/service-config.js";
 import { handlePrivateHeartbeat } from "../telegram/heartbeat.js";
 import { executeScheduledAgentPromptAction } from "./agent-action.js";
 import type { CronActionResult, CronJob } from "./types.js";
@@ -42,20 +43,20 @@ export async function executeCronAction(
 		}
 		case "social-heartbeat": {
 			const action = job.action;
-			const enabledServices = cfg.socialServices.filter((service) => service.enabled);
-			if (enabledServices.length === 0) {
+			const automaticServices = getAutomaticHeartbeatSocialServices(cfg);
+			if (automaticServices.length === 0) {
 				return {
 					ok: false,
-					message: "no enabled social services",
+					message: "no social services have automatic heartbeat enabled",
 				};
 			}
 			const targets = action.serviceId
-				? enabledServices.filter((service) => service.id === action.serviceId)
-				: enabledServices;
+				? automaticServices.filter((service) => service.id === action.serviceId)
+				: automaticServices;
 			if (targets.length === 0) {
 				return {
 					ok: false,
-					message: `service '${action.serviceId}' is not enabled`,
+					message: `service '${action.serviceId}' does not have automatic heartbeat enabled`,
 				};
 			}
 

--- a/src/social/service-config.ts
+++ b/src/social/service-config.ts
@@ -1,0 +1,19 @@
+import { loadConfig, type TelclaudeConfig } from "../config/config.js";
+
+export type SocialServiceConfig = NonNullable<TelclaudeConfig["socialServices"]>[number];
+
+export function getEnabledSocialServices(
+	cfg: TelclaudeConfig = loadConfig(),
+): SocialServiceConfig[] {
+	return cfg.socialServices?.filter((service) => service.enabled) ?? [];
+}
+
+export function isAutomaticHeartbeatEnabled(service: SocialServiceConfig): boolean {
+	return service.heartbeatEnabled ?? true;
+}
+
+export function getAutomaticHeartbeatSocialServices(
+	cfg: TelclaudeConfig = loadConfig(),
+): SocialServiceConfig[] {
+	return getEnabledSocialServices(cfg).filter(isAutomaticHeartbeatEnabled);
+}

--- a/src/telegram/auto-reply.ts
+++ b/src/telegram/auto-reply.ts
@@ -69,6 +69,7 @@ import { createTOTPSession, invalidateTOTPSessionForChat } from "../security/tot
 import type { SecurityClassification } from "../security/types.js";
 import { initializeGitCredentials } from "../services/git-credentials.js";
 import { clearOpenAICache, initializeOpenAIKey } from "../services/openai-client.js";
+import { getEnabledSocialServices } from "../social/service-config.js";
 import { cleanupExpired, getDb } from "../storage/db.js";
 import { formatReactionContext, getRecentReactions } from "../storage/reactions.js";
 import { sendSkillsMenuCard, sendSocialMenuCard, sendStatusCard } from "./cards/create-helpers.js";
@@ -668,7 +669,7 @@ async function dispatchTelegramControlCommand(
 				});
 				return true;
 			}
-			const enabledServices = cfg.socialServices?.filter((service) => service.enabled) ?? [];
+			const enabledServices = getEnabledSocialServices(cfg);
 			if (enabledServices.length === 0) {
 				await msg.reply("No social services are enabled.");
 				return true;

--- a/src/telegram/cards/menu-state.ts
+++ b/src/telegram/cards/menu-state.ts
@@ -1,17 +1,13 @@
 import { listActiveSkills, listDraftSkills } from "../../commands/skills-promote.js";
 import { loadConfig, type TelclaudeConfig } from "../../config/config.js";
 import { isAdmin } from "../../security/linking.js";
+import { getEnabledSocialServices } from "../../social/service-config.js";
 import { loadPendingQueueEntries } from "./renderers/pending-queue.js";
 import type { SkillsMenuCardState, SocialMenuCardState } from "./types.js";
 import { CardKind } from "./types.js";
 
-export type SocialServiceConfig = NonNullable<TelclaudeConfig["socialServices"]>[number];
-
-export function getEnabledSocialServices(
-	cfg: TelclaudeConfig = loadConfig(),
-): SocialServiceConfig[] {
-	return cfg.socialServices?.filter((service) => service.enabled) ?? [];
-}
+export type { SocialServiceConfig } from "../../social/service-config.js";
+export { getEnabledSocialServices } from "../../social/service-config.js";
 
 export function buildSkillsMenuState(chatId: number, sessionKey?: string): SkillsMenuCardState {
 	return {

--- a/tests/config/sdk-config.test.ts
+++ b/tests/config/sdk-config.test.ts
@@ -69,6 +69,19 @@ describe("sdk config defaults", () => {
 });
 
 describe("config split (TELCLAUDE_PRIVATE_CONFIG)", () => {
+	it("defaults social service heartbeatEnabled to true", () => {
+		setConfigPath(configPath());
+		fs.writeFileSync(
+			configPath(),
+			JSON.stringify({
+				socialServices: [{ id: "xtwitter", type: "xtwitter", enabled: true }],
+			}),
+		);
+
+		const cfg = loadConfig();
+		expect(cfg.socialServices[0].heartbeatEnabled).toBe(true);
+	});
+
 	it("deep-merges private config on top of policy config", () => {
 		setConfigPath(configPath());
 

--- a/tests/cron/actions.test.ts
+++ b/tests/cron/actions.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createSocialClientMock = vi.hoisted(() => vi.fn());
+const handleSocialHeartbeatMock = vi.hoisted(() => vi.fn());
+const handlePrivateHeartbeatMock = vi.hoisted(() => vi.fn());
+const executeScheduledAgentPromptActionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/social/index.js", () => ({
+	createSocialClient: createSocialClientMock,
+	handleSocialHeartbeat: handleSocialHeartbeatMock,
+}));
+
+vi.mock("../../src/telegram/heartbeat.js", () => ({
+	handlePrivateHeartbeat: handlePrivateHeartbeatMock,
+}));
+
+vi.mock("../../src/cron/agent-action.js", () => ({
+	executeScheduledAgentPromptAction: executeScheduledAgentPromptActionMock,
+}));
+
+import { executeCronAction } from "../../src/cron/actions.js";
+
+describe("executeCronAction social heartbeat", () => {
+	beforeEach(() => {
+		createSocialClientMock.mockReset();
+		handleSocialHeartbeatMock.mockReset();
+		handlePrivateHeartbeatMock.mockReset();
+		executeScheduledAgentPromptActionMock.mockReset();
+	});
+
+	it("skips services with automatic heartbeat disabled", async () => {
+		const result = await executeCronAction(
+			{ id: "job-1", action: { kind: "social-heartbeat", serviceId: "xtwitter" } } as any,
+			{
+				socialServices: [
+					{ id: "xtwitter", type: "xtwitter", enabled: true, heartbeatEnabled: false },
+				],
+			} as any,
+		);
+
+		expect(result.ok).toBe(false);
+		expect(result.message).toContain("automatic heartbeat");
+		expect(createSocialClientMock).not.toHaveBeenCalled();
+		expect(handleSocialHeartbeatMock).not.toHaveBeenCalled();
+	});
+});

--- a/tests/social/service-config.test.ts
+++ b/tests/social/service-config.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	getAutomaticHeartbeatSocialServices,
+	getEnabledSocialServices,
+	isAutomaticHeartbeatEnabled,
+} from "../../src/social/service-config.js";
+
+describe("social service config selectors", () => {
+	it("keeps manual availability separate from automatic heartbeat eligibility", () => {
+		const cfg = {
+			socialServices: [
+				{ id: "xtwitter", enabled: true, heartbeatEnabled: false },
+				{ id: "moltbook", enabled: true, heartbeatEnabled: true },
+				{ id: "disabled", enabled: false, heartbeatEnabled: true },
+			],
+		} as any;
+
+		expect(getEnabledSocialServices(cfg).map((service) => service.id)).toEqual([
+			"xtwitter",
+			"moltbook",
+		]);
+		expect(getAutomaticHeartbeatSocialServices(cfg).map((service) => service.id)).toEqual([
+			"moltbook",
+		]);
+	});
+
+	it("treats omitted heartbeatEnabled as enabled by default", () => {
+		expect(isAutomaticHeartbeatEnabled({ id: "xtwitter", enabled: true } as any)).toBe(true);
+	});
+});

--- a/tests/telegram/social-ask-wizard.test.ts
+++ b/tests/telegram/social-ask-wizard.test.ts
@@ -99,4 +99,20 @@ describe("social ask wizard", () => {
 		).toBe(true);
 		await waitFor(() => !hasActiveSocialAskWizard({ actorId: 101, chatId: 777, threadId: 9 }));
 	});
+
+	it("allows manual ask when automatic heartbeat is disabled", () => {
+		const api = makeApi();
+		const cfg = {
+			socialServices: [{ id: "xtwitter", enabled: true, heartbeatEnabled: false }],
+		} as any;
+
+		const result = startSocialAskWizard(api as any, {
+			actorId: 101,
+			chatId: 777,
+			threadId: 9,
+			cfg,
+		});
+
+		expect(result.callbackText).toBe("Reply with a question for xtwitter");
+	});
 });


### PR DESCRIPTION
Keep manual social access available while letting operators disable automatic social activity per service.

`socialServices.enabled` stays the manual availability switch for `/social ask`, menu visibility, and manual run-now actions. The new `socialServices.heartbeatEnabled` flag gates automatic social heartbeats only, and both the relay interval scheduler and cron-driven social-heartbeat action now respect it.

This is the owning-layer fix for william: `xtwitter` can be re-enabled for manual operator use without bringing back the periodic autonomous scheduler that was timing out and alerting.

The change adds a small selector module for social service eligibility, defaults the new flag to `true`, and adds coverage for config defaults, manual social ask with heartbeats disabled, selector behavior, and cron rejection when a service is manual-only.