### PR TITLE
feat(operator): Add control-plane cockpit and social workbench

### DIFF
--- a/assets/dashboard-ui/app.js
+++ b/assets/dashboard-ui/app.js
@@ -1,29 +1,49 @@
 // Dashboard UI — vanilla JS, no frameworks. Served same-origin from /.
-// Keep this file small and dependency-free; it runs against the localhost API.
+// Keep this dependency-free; the server owns all sensitive filtering.
 
 const $ = (sel) => document.querySelector(sel);
+const $$ = (sel) => Array.from(document.querySelectorAll(sel));
 
 const state = {
 	authed: false,
+	activeTab: "sessions",
 };
+
+function node(tag, className, text) {
+	const el = document.createElement(tag);
+	if (className) el.className = className;
+	if (text !== undefined && text !== null) el.textContent = String(text);
+	return el;
+}
+
+function clear(el) {
+	el.replaceChildren();
+}
+
+function setText(sel, value) {
+	const el = $(sel);
+	if (el) el.textContent = value;
+}
 
 function setAuthed(v) {
 	state.authed = v;
 	$("#login-card").hidden = v;
 	$("#main-panels").hidden = !v;
 	$("#logout-btn").hidden = !v;
+	$("#refresh-btn").hidden = !v;
 	$("#session-indicator").textContent = v ? "signed in" : "not signed in";
 	$("#session-indicator").classList.toggle("pill-ok", v);
 	$("#session-indicator").classList.toggle("pill-muted", !v);
 }
 
-// --- API helpers ----------------------------------------------------------
-
 async function api(path, opts = {}) {
 	const res = await fetch(path, {
 		method: opts.method ?? "GET",
 		credentials: "same-origin",
-		headers: { accept: "application/json", ...(opts.body ? { "content-type": "application/json" } : {}) },
+		headers: {
+			accept: "application/json",
+			...(opts.body ? { "content-type": "application/json" } : {}),
+		},
 		body: opts.body ? JSON.stringify(opts.body) : undefined,
 	});
 	let body;
@@ -34,12 +54,498 @@ async function api(path, opts = {}) {
 	}
 	if (res.status === 401) {
 		setAuthed(false);
-		return { ok: false, error: "authentication required", status: 401 };
+		return { ok: false, error: "authentication required", status: 401, body };
 	}
 	return { ok: res.ok, status: res.status, body };
 }
 
-// --- Auth -----------------------------------------------------------------
+function pillClassFor(status) {
+	if (["ok", "healthy", "success", "completed", "active", "enabled"].includes(status)) {
+		return "pill pill-ok";
+	}
+	if (
+		["degraded", "warn", "warning", "unknown", "idle", "queued", "running", "blocked"].includes(
+			status,
+		)
+	) {
+		return "pill pill-warn";
+	}
+	if (
+		["unhealthy", "unreachable", "auth_expired", "error", "failed", "timeout", "stale"].includes(
+			status,
+		)
+	) {
+		return "pill pill-bad";
+	}
+	return "pill pill-muted";
+}
+
+function fmtTs(v) {
+	if (v == null) return "-";
+	const d = typeof v === "number" ? new Date(v) : new Date(String(v));
+	if (Number.isNaN(d.getTime())) return "-";
+	return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function fmtDuration(ms) {
+	if (ms == null) return "-";
+	if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
+	const sec = Math.round(ms / 1000);
+	if (sec < 60) return `${sec}s`;
+	const min = Math.round(sec / 60);
+	if (min < 60) return `${min}m`;
+	return `${Math.round(min / 60)}h`;
+}
+
+function appendPill(parent, status, label = status) {
+	const pill = node("span", pillClassFor(status), label);
+	parent.append(pill);
+	return pill;
+}
+
+function renderEmpty(parent, text, tag = "li") {
+	const item = node(tag, "muted", text);
+	parent.append(item);
+}
+
+function renderTable(tbody, rows, renderCells, emptyText, colSpan) {
+	clear(tbody);
+	if (!rows || rows.length === 0) {
+		const tr = node("tr");
+		const td = node("td", "muted", emptyText);
+		td.colSpan = colSpan;
+		tr.append(td);
+		tbody.append(tr);
+		return;
+	}
+	for (const row of rows) {
+		const tr = node("tr");
+		for (const cell of renderCells(row)) {
+			const td = node("td");
+			if (cell instanceof Node) td.append(cell);
+			else td.textContent = cell == null ? "-" : String(cell);
+			tr.append(td);
+		}
+		tbody.append(tr);
+	}
+}
+
+function activateTab(tab) {
+	state.activeTab = tab;
+	for (const btn of $$(".tab-btn")) {
+		const active = btn.dataset.tab === tab;
+		btn.setAttribute("aria-selected", String(active));
+		btn.classList.toggle("is-active", active);
+	}
+	for (const panel of $$(".tab-panel")) {
+		panel.hidden = panel.dataset.panel !== tab;
+	}
+	if (state.authed) refreshActiveTab();
+}
+
+async function renderHealth() {
+	const res = await api("/api/health");
+	if (!res.ok) return;
+	const snap = res.body?.snapshot;
+	if (!snap) return;
+	const overall = $("#overall-health");
+	overall.textContent = `${snap.overallStatus} · ${snap.issueCount} issue(s)`;
+	overall.className = pillClassFor(snap.overallStatus);
+	setText("#health-collected", `updated ${fmtTs(snap.collectedAtMs)}`);
+
+	const list = $("#health-items");
+	clear(list);
+	for (const item of snap.items ?? []) {
+		const li = node("li", "item");
+		const left = node("span", "item-label", item.label);
+		const right = node("span", "item-row");
+		appendPill(right, item.status);
+		const detail = node("span", "item-detail", item.detail ?? "");
+		right.append(detail);
+		if (item.remediationCommand) {
+			right.append(node("code", "command-chip", item.remediationCommand));
+		}
+		li.append(left, right);
+		list.append(li);
+	}
+	if (!snap.items?.length) renderEmpty(list, "(no health signals)");
+}
+
+async function renderSessions() {
+	const res = await api("/api/operator/sessions-runs?limit=50");
+	if (!res.ok) return;
+	const sessions = res.body?.sessions ?? [];
+	const runs = res.body?.runs ?? [];
+	setText("#sessions-summary", `${sessions.length} sessions · ${runs.length} recent runs`);
+	renderTable(
+		$("#sessions-table tbody"),
+		sessions,
+		(row) => [
+			row.source,
+			row.persona,
+			row.model ?? "-",
+			(() => {
+				const wrap = node("span");
+				appendPill(wrap, row.status);
+				return wrap;
+			})(),
+			fmtTs(row.updatedAtMs),
+			row.sessionRef,
+			row.errorSummary ?? "-",
+		],
+		"(no tracked sessions)",
+		7,
+	);
+	renderTable(
+		$("#runs-table tbody"),
+		runs,
+		(row) => [
+			row.id,
+			row.source,
+			row.persona,
+			row.model ?? "-",
+			(() => {
+				const wrap = node("span");
+				appendPill(wrap, row.status);
+				return wrap;
+			})(),
+			fmtTs(row.startedAtMs),
+			fmtTs(row.finishedAtMs),
+			fmtDuration(row.durationMs),
+			row.errorSummary ?? "-",
+		],
+		"(no recent runs)",
+		9,
+	);
+}
+
+async function renderLogs() {
+	const level = $("#log-level").value;
+	const component = $("#log-component").value.trim();
+	const params = new URLSearchParams({ limit: "100" });
+	if (level !== "all") params.set("level", level);
+	if (component) params.set("component", component);
+	const [logsRes, providerRes] = await Promise.all([
+		api(`/api/operator/logs?${params.toString()}`),
+		api("/api/operator/provider-health"),
+	]);
+	if (logsRes.ok) {
+		const logs = logsRes.body?.entries ?? [];
+		setText("#logs-summary", `${logs.length} log entries`);
+		const list = $("#logs-list");
+		clear(list);
+		for (const entry of logs) {
+			const li = node("li", "log-line");
+			const meta = node("span", "log-meta", `${fmtTs(entry.timestamp)} ${entry.component}`);
+			const levelPill = node("span", pillClassFor(entry.level), entry.level);
+			const msg = node("span", "log-message", entry.message);
+			li.append(meta, levelPill, msg);
+			list.append(li);
+		}
+		if (!logs.length) renderEmpty(list, "(no matching logs)");
+	}
+	if (providerRes.ok) {
+		const providers = providerRes.body?.providers ?? [];
+		setText("#providers-summary", `${providers.length} providers`);
+		const list = $("#provider-health-list");
+		clear(list);
+		for (const provider of providers) {
+			const li = node("li", "item");
+			li.append(node("span", "item-label", provider.id));
+			const right = node("span", "item-row");
+			appendPill(right, provider.status);
+			right.append(node("span", "item-detail", `${provider.failureCount} issue(s)`));
+			li.append(right);
+			list.append(li);
+		}
+		if (!providers.length) renderEmpty(list, "(no providers configured)");
+
+		const transitions = $("#provider-transitions-list");
+		clear(transitions);
+		for (const entry of providerRes.body?.transitions ?? []) {
+			const li = node("li", "item");
+			li.append(node("span", "item-label", `${fmtTs(entry.timestamp)} · ${entry.provider ?? "provider"}`));
+			const right = node("span", "item-row");
+			appendPill(right, entry.level);
+			right.append(node("span", "item-detail", entry.message));
+			li.append(right);
+			transitions.append(li);
+		}
+		if (!providerRes.body?.transitions?.length) renderEmpty(transitions, "(no recent transitions)");
+	}
+}
+
+async function renderJobs() {
+	const status = $("#job-status").value;
+	const params = new URLSearchParams({ limit: "50" });
+	if (status !== "all") params.set("status", status);
+	const res = await api(`/api/operator/background-jobs?${params.toString()}`);
+	if (!res.ok) return;
+	const jobs = res.body?.jobs ?? [];
+	setText("#jobs-summary", `${jobs.length} background jobs`);
+	renderTable(
+		$("#jobs-table tbody"),
+		jobs,
+		(row) => [
+			row.shortId,
+			row.title,
+			(() => {
+				const wrap = node("span");
+				appendPill(wrap, row.status);
+				return wrap;
+			})(),
+			row.payloadKind,
+			row.tier,
+			fmtTs(row.createdAtMs),
+			fmtTs(row.startedAtMs),
+			row.errorSummary ?? "-",
+			(() => {
+				const wrap = node("span");
+				if (row.canCancel) {
+					const btn = node("button", "btn-small", "Cancel");
+					btn.type = "button";
+					btn.dataset.cancelJob = row.shortId;
+					wrap.append(btn);
+				} else {
+					wrap.textContent = "-";
+				}
+				return wrap;
+			})(),
+		],
+		"(no background jobs)",
+		9,
+	);
+}
+
+async function cancelJob(shortId) {
+	const res = await api(`/api/operator/background-jobs/${encodeURIComponent(shortId)}/cancel`, {
+		method: "POST",
+	});
+	if (!res.ok) {
+		setText("#jobs-error", res.body?.error ?? "cancel failed");
+		return;
+	}
+	setText("#jobs-error", res.body?.transitioned ? `cancelled ${shortId}` : "job was already terminal");
+	await renderJobs();
+}
+
+async function renderCron() {
+	const res = await api("/api/operator/cron");
+	if (!res.ok) return;
+	const jobs = res.body?.jobs ?? [];
+	const summary = res.body?.summary;
+	setText(
+		"#cron-summary",
+		summary
+			? `${summary.enabledJobs}/${summary.totalJobs} enabled · ${summary.runningJobs} running · next ${fmtTs(summary.nextRunAtMs)}`
+			: `${jobs.length} jobs`,
+	);
+	renderTable(
+		$("#cron-table tbody"),
+		jobs,
+		(row) => [
+			row.id,
+			row.name,
+			(() => {
+				const wrap = node("span");
+				appendPill(wrap, row.running ? "running" : row.enabled ? "enabled" : "disabled");
+				return wrap;
+			})(),
+			row.schedule,
+			row.actionSummary,
+			row.delivery,
+			fmtTs(row.nextRunAtMs),
+			row.lastStatus ?? "-",
+			row.lastErrorSummary ?? "-",
+		],
+		"(no cron jobs)",
+		9,
+	);
+}
+
+async function renderSocial() {
+	const res = await api("/api/operator/social-queue");
+	if (!res.ok) return;
+	const pending = res.body?.pending ?? [];
+	const promoted = res.body?.promoted ?? [];
+	setText(
+		"#social-summary",
+		`${pending.length} pending · ${promoted.length} promoted · next: ${res.body?.nextOperatorAction ?? "-"}`,
+	);
+	renderTable(
+		$("#social-pending-table tbody"),
+		pending,
+		(row) => [row.id, row.source, row.trust, row.status, fmtTs(row.createdAtMs), row.nextAction],
+		"(no pending drafts)",
+		6,
+	);
+	renderTable(
+		$("#social-promoted-table tbody"),
+		promoted,
+		(row) => [row.id, row.source, row.status, fmtTs(row.promotedAtMs), row.nextAction],
+		"(no promoted drafts waiting for heartbeat)",
+		5,
+	);
+	const services = $("#social-services-list");
+	clear(services);
+	for (const svc of res.body?.services ?? []) {
+		const li = node("li", "item");
+		li.append(node("span", "item-label", `${svc.id} · ${svc.type}`));
+		const right = node("span", "item-row");
+		appendPill(right, svc.enabled ? "enabled" : "disabled");
+		right.append(node("span", "item-detail", `heartbeat ${svc.heartbeatEnabled ? "on" : "off"}`));
+		li.append(right);
+		services.append(li);
+	}
+	if (!res.body?.services?.length) renderEmpty(services, "(no social services configured)");
+}
+
+async function renderPersonas() {
+	const [personasRes, skillsRes, approvalsRes] = await Promise.all([
+		api("/api/operator/personas"),
+		api("/api/skills"),
+		api("/api/approvals/allowlist"),
+	]);
+	if (personasRes.ok) {
+		const body = personasRes.body;
+		setText("#personas-summary", `security profile: ${body.securityProfile}`);
+		renderPersonaBox("#private-persona", body.privatePersona);
+		renderPersonaBox("#social-persona", body.socialPersona);
+	}
+	if (skillsRes.ok) {
+		renderChips("#skills-active", skillsRes.body?.active ?? []);
+		renderChips("#skills-drafts", skillsRes.body?.drafts ?? []);
+	}
+	if (approvalsRes.ok) {
+		const entries = approvalsRes.body?.entries ?? [];
+		setText("#approvals-summary", `${entries.length} allowlist entries`);
+		renderTable(
+			$("#approvals-table tbody"),
+			entries,
+			(row) => [
+				row.userId,
+				row.tier,
+				row.toolKey,
+				row.scope,
+				fmtTs(row.grantedAt),
+				row.expiresAt == null ? "(none)" : fmtTs(row.expiresAt),
+			],
+			"(no allowlist entries)",
+			6,
+		);
+	}
+}
+
+function renderPersonaBox(sel, persona) {
+	const box = $(sel);
+	clear(box);
+	if (!persona) {
+		box.append(node("p", "muted", "(unavailable)"));
+		return;
+	}
+	const head = node("div", "persona-head");
+	head.append(node("strong", null, persona.source));
+	appendPill(head, persona.status);
+	box.append(head);
+	const counts = persona.memoryCounts ?? {};
+	box.append(
+		node(
+			"p",
+			"muted",
+			`profile ${counts.profile ?? 0} · interests ${counts.interests ?? 0} · meta ${counts.meta ?? 0}`,
+		),
+	);
+	if (persona.summary) {
+		box.append(node("p", "item-detail", persona.summary));
+	}
+	const facts = node("dl", "persona-facts");
+	const addFact = (label, value) => {
+		if (value == null || value === "") return;
+		facts.append(node("dt", null, label), node("dd", null, String(value)));
+	};
+	addFact("profile", persona.profile?.claudeHome ?? persona.profile?.source);
+	addFact(
+		"agent",
+		persona.agent
+			? `${persona.agent.reachability} · ${persona.agent.source}${
+					persona.agent.endpoint ? ` · ${persona.agent.endpoint}` : ""
+				}`
+			: null,
+	);
+	addFact(
+		"skills",
+		persona.skills
+			? `${persona.skills.policy} · ${persona.skills.effectiveCount ?? 0} effective · ${
+					persona.skills.activeCatalogCount ?? 0
+				} catalog`
+			: null,
+	);
+	addFact(
+		"plugins",
+		persona.plugins
+			? `${persona.plugins.enabledCount ?? 0} enabled · ${persona.plugins.installedCount ?? 0} installed`
+			: null,
+	);
+	addFact("filesystem", persona.filesystem?.summary);
+	addFact("providers", persona.providers?.summary);
+	if (persona.boundaries) {
+		addFact(
+			"boundaries",
+			`social memory in private: ${persona.boundaries.privateProcessesSocialMemory}; social workspace: ${persona.boundaries.socialHasWorkspaceMount}`,
+		);
+	}
+	if (facts.childNodes.length > 0) {
+		box.append(facts);
+	}
+	if (Array.isArray(persona.services)) {
+		const list = node("ul", "stack compact");
+		for (const svc of persona.services) {
+			const li = node("li", "item");
+			li.append(node("span", "item-label", svc.id));
+			const right = node("span", "item-row");
+			appendPill(right, svc.enabled ? "enabled" : "disabled");
+			right.append(node("span", "item-detail", `${svc.allowedSkillsCount} skills`));
+			li.append(right);
+			list.append(li);
+		}
+		box.append(list);
+	}
+}
+
+function renderChips(sel, items) {
+	const list = $(sel);
+	clear(list);
+	if (!items?.length) {
+		const li = node("li", "muted", "(none)");
+		list.append(li);
+		return;
+	}
+	for (const name of items) {
+		list.append(node("li", null, name));
+	}
+}
+
+async function refreshActiveTab() {
+	switch (state.activeTab) {
+		case "sessions":
+			return renderSessions();
+		case "logs":
+			return renderLogs();
+		case "jobs":
+			return renderJobs();
+		case "cron":
+			return renderCron();
+		case "social":
+			return renderSocial();
+		case "personas":
+			return renderPersonas();
+	}
+}
+
+async function refreshAll() {
+	await renderHealth();
+	await refreshActiveTab();
+}
 
 $("#login-form").addEventListener("submit", async (ev) => {
 	ev.preventDefault();
@@ -73,183 +579,26 @@ $("#logout-btn").addEventListener("click", async () => {
 	setAuthed(false);
 });
 
-// --- Panels ---------------------------------------------------------------
+$("#refresh-btn").addEventListener("click", refreshAll);
+$("#log-level").addEventListener("change", renderLogs);
+$("#log-component").addEventListener("change", renderLogs);
+$("#job-status").addEventListener("change", renderJobs);
 
-function pillClassFor(status) {
-	if (status === "ok") return "pill pill-ok";
-	if (status === "degraded" || status === "unknown") return "pill pill-warn";
-	return "pill pill-bad";
-}
+$("#jobs-table").addEventListener("click", (ev) => {
+	const target = ev.target;
+	if (!(target instanceof HTMLElement)) return;
+	const shortId = target.dataset.cancelJob;
+	if (shortId) cancelJob(shortId);
+});
 
-async function renderHealth() {
-	const res = await api("/api/health");
-	if (!res.ok) return;
-	const snap = res.body?.snapshot;
-	if (!snap) return;
-	const overall = $("#overall-health");
-	overall.textContent = `${snap.overallStatus} · ${snap.issueCount} issue(s)`;
-	overall.className = pillClassFor(snap.overallStatus);
-	const list = $("#health-items");
-	list.innerHTML = "";
-	for (const item of snap.items ?? []) {
-		const li = document.createElement("li");
-		li.className = "item";
-		const label = document.createElement("span");
-		label.className = "item-label";
-		label.textContent = item.label;
-		const right = document.createElement("span");
-		const statusPill = document.createElement("span");
-		statusPill.className = pillClassFor(item.status);
-		statusPill.textContent = item.status;
-		const detail = document.createElement("span");
-		detail.className = "item-detail";
-		detail.textContent = item.detail ?? "";
-		right.append(statusPill, " ", detail);
-		li.append(label, right);
-		list.append(li);
-	}
-}
-
-async function renderProviders() {
-	const res = await api("/api/providers");
-	if (!res.ok) return;
-	const { catalog, configured } = res.body ?? {};
-	const summary = $("#providers-summary");
-	const list = $("#providers-list");
-	list.innerHTML = "";
-	const configuredIds = new Set((configured ?? []).map((c) => c.id));
-	summary.textContent = `${configured?.length ?? 0} configured · ${catalog?.length ?? 0} in catalog`;
-	for (const entry of catalog ?? []) {
-		const li = document.createElement("li");
-		li.className = "item";
-		const label = document.createElement("span");
-		label.className = "item-label";
-		label.textContent = `${entry.displayName} (${entry.id})`;
-		const pill = document.createElement("span");
-		pill.className = configuredIds.has(entry.id) ? "pill pill-ok" : "pill pill-muted";
-		pill.textContent = configuredIds.has(entry.id) ? "configured" : "available";
-		li.append(label, pill);
-		list.append(li);
-	}
-}
-
-async function renderSkills() {
-	const res = await api("/api/skills");
-	if (!res.ok) return;
-	const { active, drafts } = res.body ?? {};
-	renderChips("#skills-active", active);
-	renderChips("#skills-drafts", drafts, "(none)");
-}
-
-function renderChips(sel, items, emptyMsg) {
-	const list = document.querySelector(sel);
-	list.innerHTML = "";
-	if (!items || items.length === 0) {
-		const li = document.createElement("li");
-		li.textContent = emptyMsg ?? "(none)";
-		li.classList.add("muted");
-		list.append(li);
-		return;
-	}
-	for (const name of items) {
-		const li = document.createElement("li");
-		li.textContent = name;
-		list.append(li);
-	}
-}
-
-function fmtTs(v) {
-	if (v == null) return "-";
-	const d = typeof v === "number" ? new Date(v) : new Date(String(v));
-	if (Number.isNaN(d.getTime())) return "-";
-	return d.toISOString().replace("T", " ").slice(0, 19);
-}
-
-async function renderApprovals() {
-	const res = await api("/api/approvals/allowlist");
-	if (!res.ok) return;
-	const tbody = document.querySelector("#approvals-table tbody");
-	tbody.innerHTML = "";
-	const entries = res.body?.entries ?? [];
-	if (entries.length === 0) {
-		const tr = document.createElement("tr");
-		const td = document.createElement("td");
-		td.colSpan = 6;
-		td.textContent = "(no allowlist entries)";
-		td.classList.add("muted");
-		tr.append(td);
-		tbody.append(tr);
-		return;
-	}
-	for (const entry of entries) {
-		const tr = document.createElement("tr");
-		for (const cell of [
-			entry.userId,
-			entry.tier,
-			entry.toolKey,
-			entry.scope,
-			fmtTs(entry.grantedAt),
-			entry.expiresAt == null ? "(none)" : fmtTs(entry.expiresAt),
-		]) {
-			const td = document.createElement("td");
-			td.textContent = String(cell);
-			tr.append(td);
-		}
-		tbody.append(tr);
-	}
-}
-
-async function renderAudit() {
-	const res = await api("/api/audit/tail?limit=50");
-	if (!res.ok) return;
-	const list = $("#audit-list");
-	list.innerHTML = "";
-	const entries = res.body?.entries ?? [];
-	if (!res.body?.enabled) {
-		const li = document.createElement("li");
-		li.classList.add("muted");
-		li.textContent = "(audit logging disabled)";
-		list.append(li);
-		return;
-	}
-	if (entries.length === 0) {
-		const li = document.createElement("li");
-		li.classList.add("muted");
-		li.textContent = "(no recent entries)";
-		list.append(li);
-		return;
-	}
-	for (const entry of entries.slice().reverse()) {
-		const li = document.createElement("li");
-		li.className = "item";
-		const label = document.createElement("span");
-		label.className = "item-label";
-		label.textContent = `${fmtTs(entry.timestamp)} · ${entry.telegramUserId}`;
-		const right = document.createElement("span");
-		const pill = document.createElement("span");
-		pill.textContent = entry.outcome;
-		pill.className =
-			entry.outcome === "success"
-				? "pill pill-ok"
-				: entry.outcome === "blocked" || entry.outcome === "rate_limited"
-					? "pill pill-warn"
-					: entry.outcome === "error"
-						? "pill pill-bad"
-						: "pill pill-muted";
-		const preview = document.createElement("span");
-		preview.className = "item-detail";
-		const msg = (entry.messagePreview ?? "").slice(0, 80);
-		preview.textContent = msg;
-		right.append(pill, " ", preview);
-		li.append(label, right);
-		list.append(li);
-	}
+for (const btn of $$(".tab-btn")) {
+	btn.addEventListener("click", () => activateTab(btn.dataset.tab));
 }
 
 $("#doctor-run-btn").addEventListener("click", async () => {
 	const btn = $("#doctor-run-btn");
 	const out = $("#doctor-output");
-	out.textContent = "running…";
+	out.textContent = "running...";
 	btn.disabled = true;
 	try {
 		const res = await api("/api/doctor/run", { method: "POST" });
@@ -263,16 +612,7 @@ $("#doctor-run-btn").addEventListener("click", async () => {
 	}
 });
 
-$("#refresh-btn").addEventListener("click", refreshAll);
-
-async function refreshAll() {
-	await Promise.all([renderHealth(), renderProviders(), renderSkills(), renderApprovals(), renderAudit()]);
-}
-
-// --- Bootstrap ------------------------------------------------------------
-
 (async () => {
-	// Probe auth: a health fetch will 401 if we have no cookie.
 	const r = await api("/api/health");
 	if (r.ok) {
 		setAuthed(true);

--- a/assets/dashboard-ui/index.html
+++ b/assets/dashboard-ui/index.html
@@ -9,9 +9,14 @@
 	</head>
 	<body>
 		<header>
-			<h1>telclaude</h1>
-			<span id="session-indicator" class="pill pill-muted">not signed in</span>
-			<button id="logout-btn" type="button" class="btn-link" hidden>sign out</button>
+			<div class="brand">
+				<h1>telclaude</h1>
+				<span id="session-indicator" class="pill pill-muted">not signed in</span>
+			</div>
+			<div class="header-actions">
+				<button id="refresh-btn" type="button" hidden>Refresh</button>
+				<button id="logout-btn" type="button" class="btn-link" hidden>sign out</button>
+			</div>
 		</header>
 
 		<main>
@@ -29,65 +34,237 @@
 			</section>
 
 			<section id="main-panels" hidden>
-				<section class="card">
-					<div class="card-head">
+				<section class="overview-band">
+					<div>
 						<h2>System health</h2>
-						<button id="refresh-btn" type="button">Refresh</button>
+						<p id="health-collected" class="muted">loading...</p>
 					</div>
-					<div id="overall-health" class="pill">loading…</div>
-					<ul id="health-items" class="stack"></ul>
+					<div id="overall-health" class="pill">loading...</div>
+					<button id="doctor-run-btn" type="button">Run doctor</button>
+				</section>
+				<ul id="health-items" class="stack health-strip"></ul>
+				<pre id="doctor-output" class="preblock compact-output"></pre>
+
+				<nav class="tabs" role="tablist" aria-label="Dashboard sections">
+					<button class="tab-btn is-active" type="button" data-tab="sessions" role="tab" aria-selected="true">Sessions/Runs</button>
+					<button class="tab-btn" type="button" data-tab="logs" role="tab" aria-selected="false">Logs</button>
+					<button class="tab-btn" type="button" data-tab="jobs" role="tab" aria-selected="false">Background Jobs</button>
+					<button class="tab-btn" type="button" data-tab="cron" role="tab" aria-selected="false">Cron</button>
+					<button class="tab-btn" type="button" data-tab="social" role="tab" aria-selected="false">Social Queue</button>
+					<button class="tab-btn" type="button" data-tab="personas" role="tab" aria-selected="false">Personas</button>
+				</nav>
+
+				<section class="tab-panel" data-panel="sessions">
+					<div class="section-head">
+						<h2>Sessions/Runs</h2>
+						<p id="sessions-summary" class="muted">loading...</p>
+					</div>
+					<div class="table-wrap">
+						<table id="sessions-table">
+							<thead>
+								<tr>
+									<th scope="col">Source</th>
+									<th scope="col">Persona</th>
+									<th scope="col">Model</th>
+									<th scope="col">Status</th>
+									<th scope="col">Updated</th>
+									<th scope="col">Session</th>
+									<th scope="col">Error</th>
+								</tr>
+							</thead>
+							<tbody></tbody>
+						</table>
+					</div>
+					<div class="table-wrap">
+						<table id="runs-table">
+							<thead>
+								<tr>
+									<th scope="col">Run</th>
+									<th scope="col">Source</th>
+									<th scope="col">Persona</th>
+									<th scope="col">Model</th>
+									<th scope="col">Status</th>
+									<th scope="col">Started</th>
+									<th scope="col">Finished</th>
+									<th scope="col">Duration</th>
+									<th scope="col">Error</th>
+								</tr>
+							</thead>
+							<tbody></tbody>
+						</table>
+					</div>
 				</section>
 
-				<section class="card">
-					<div class="card-head">
-						<h2>Providers</h2>
+				<section class="tab-panel" data-panel="logs" hidden>
+					<div class="section-head">
+						<h2>Logs</h2>
+						<p id="logs-summary" class="muted">loading...</p>
 					</div>
-					<p class="muted" id="providers-summary">loading…</p>
-					<ul id="providers-list" class="stack"></ul>
+					<div class="filters">
+						<label for="log-level">Level</label>
+						<select id="log-level">
+							<option value="all">all</option>
+							<option value="fatal">fatal</option>
+							<option value="error">error</option>
+							<option value="warn">warn</option>
+							<option value="info">info</option>
+							<option value="debug">debug</option>
+						</select>
+						<label for="log-component">Component</label>
+						<input id="log-component" type="text" placeholder="agent-server, cmd-gateway" />
+					</div>
+					<ul id="logs-list" class="log-list"></ul>
+					<div class="two-col">
+						<section>
+							<h3>Provider health</h3>
+							<p id="providers-summary" class="muted">loading...</p>
+							<ul id="provider-health-list" class="stack"></ul>
+						</section>
+						<section>
+							<h3>Recent provider transitions</h3>
+							<ul id="provider-transitions-list" class="stack"></ul>
+						</section>
+					</div>
 				</section>
 
-				<section class="card">
-					<div class="card-head">
-						<h2>Skills</h2>
+				<section class="tab-panel" data-panel="jobs" hidden>
+					<div class="section-head">
+						<h2>Background Jobs</h2>
+						<p id="jobs-summary" class="muted">loading...</p>
 					</div>
-					<h3>Active</h3>
-					<ul id="skills-active" class="chips"></ul>
-					<h3>Drafts</h3>
-					<ul id="skills-drafts" class="chips"></ul>
+					<div class="filters">
+						<label for="job-status">Status</label>
+						<select id="job-status">
+							<option value="all">all</option>
+							<option value="queued">queued</option>
+							<option value="running">running</option>
+							<option value="completed">completed</option>
+							<option value="failed">failed</option>
+							<option value="cancelled">cancelled</option>
+							<option value="interrupted">interrupted</option>
+						</select>
+						<span id="jobs-error" class="muted" aria-live="polite"></span>
+					</div>
+					<div class="table-wrap">
+						<table id="jobs-table">
+							<thead>
+								<tr>
+									<th scope="col">ID</th>
+									<th scope="col">Title</th>
+									<th scope="col">Status</th>
+									<th scope="col">Kind</th>
+									<th scope="col">Tier</th>
+									<th scope="col">Created</th>
+									<th scope="col">Started</th>
+									<th scope="col">Error</th>
+									<th scope="col">Action</th>
+								</tr>
+							</thead>
+							<tbody></tbody>
+						</table>
+					</div>
 				</section>
 
-				<section class="card">
-					<div class="card-head">
-						<h2>Approval allowlist</h2>
+				<section class="tab-panel" data-panel="cron" hidden>
+					<div class="section-head">
+						<h2>Cron</h2>
+						<p id="cron-summary" class="muted">loading...</p>
 					</div>
-					<table id="approvals-table">
-						<thead>
-							<tr>
-								<th scope="col">User</th>
-								<th scope="col">Tier</th>
-								<th scope="col">Tool</th>
-								<th scope="col">Scope</th>
-								<th scope="col">Granted</th>
-								<th scope="col">Expires</th>
-							</tr>
-						</thead>
-						<tbody></tbody>
-					</table>
+					<div class="table-wrap">
+						<table id="cron-table">
+							<thead>
+								<tr>
+									<th scope="col">ID</th>
+									<th scope="col">Name</th>
+									<th scope="col">State</th>
+									<th scope="col">Schedule</th>
+									<th scope="col">Action</th>
+									<th scope="col">Delivery</th>
+									<th scope="col">Next run</th>
+									<th scope="col">Last</th>
+									<th scope="col">Error</th>
+								</tr>
+							</thead>
+							<tbody></tbody>
+						</table>
+					</div>
 				</section>
 
-				<section class="card">
-					<div class="card-head">
-						<h2>Audit tail</h2>
+				<section class="tab-panel" data-panel="social" hidden>
+					<div class="section-head">
+						<h2>Social Queue</h2>
+						<p id="social-summary" class="muted">loading...</p>
 					</div>
-					<ul id="audit-list" class="stack"></ul>
+					<div class="table-wrap">
+						<table id="social-pending-table">
+							<thead>
+								<tr>
+									<th scope="col">ID</th>
+									<th scope="col">Source</th>
+									<th scope="col">Trust</th>
+									<th scope="col">Status</th>
+									<th scope="col">Created</th>
+									<th scope="col">Next action</th>
+								</tr>
+							</thead>
+							<tbody></tbody>
+						</table>
+					</div>
+					<div class="table-wrap">
+						<table id="social-promoted-table">
+							<thead>
+								<tr>
+									<th scope="col">ID</th>
+									<th scope="col">Source</th>
+									<th scope="col">Status</th>
+									<th scope="col">Promoted</th>
+									<th scope="col">Next action</th>
+								</tr>
+							</thead>
+							<tbody></tbody>
+						</table>
+					</div>
+					<h3>Services</h3>
+					<ul id="social-services-list" class="stack"></ul>
 				</section>
 
-				<section class="card">
-					<div class="card-head">
-						<h2>Doctor</h2>
-						<button id="doctor-run-btn" type="button">Run doctor</button>
+				<section class="tab-panel" data-panel="personas" hidden>
+					<div class="section-head">
+						<h2>Personas</h2>
+						<p id="personas-summary" class="muted">loading...</p>
 					</div>
-					<pre id="doctor-output" class="preblock"></pre>
+					<div class="two-col">
+						<section id="private-persona" class="persona-box"></section>
+						<section id="social-persona" class="persona-box"></section>
+					</div>
+					<div class="two-col">
+						<section>
+							<h3>Skills</h3>
+							<h4>Active</h4>
+							<ul id="skills-active" class="chips"></ul>
+							<h4>Drafts</h4>
+							<ul id="skills-drafts" class="chips"></ul>
+						</section>
+						<section>
+							<h3>Approval allowlist</h3>
+							<p id="approvals-summary" class="muted">loading...</p>
+							<div class="table-wrap">
+								<table id="approvals-table">
+									<thead>
+										<tr>
+											<th scope="col">User</th>
+											<th scope="col">Tier</th>
+											<th scope="col">Tool</th>
+											<th scope="col">Scope</th>
+											<th scope="col">Granted</th>
+											<th scope="col">Expires</th>
+										</tr>
+									</thead>
+									<tbody></tbody>
+								</table>
+							</div>
+						</section>
+					</div>
 				</section>
 			</section>
 		</main>

--- a/assets/dashboard-ui/styles.css
+++ b/assets/dashboard-ui/styles.css
@@ -1,27 +1,34 @@
 :root {
 	color-scheme: light dark;
-	--bg: #0f1115;
-	--surface: #171a21;
-	--surface-2: #1f232c;
-	--border: #2a2f3a;
-	--text: #e7eaf0;
-	--muted: #97a0b3;
-	--accent: #7aa2ff;
-	--ok: #38c172;
-	--warn: #e3a008;
-	--bad: #ef4444;
+	--bg: #f4f4f1;
+	--surface: #ffffff;
+	--surface-2: #eeeeea;
+	--surface-3: #e5e5df;
+	--border: #d6d6ce;
+	--text: #20211e;
+	--muted: #6b6d64;
+	--accent: #0f766e;
+	--accent-2: #2563eb;
+	--ok: #15803d;
+	--warn: #b45309;
+	--bad: #dc2626;
 	--mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
 	:root {
-		--bg: #f5f6f8;
-		--surface: #ffffff;
-		--surface-2: #f0f2f6;
-		--border: #dbdfe6;
-		--text: #1b1f28;
-		--muted: #5d6678;
-		--accent: #2b5de0;
+		--bg: #151612;
+		--surface: #1f211c;
+		--surface-2: #282b25;
+		--surface-3: #30342c;
+		--border: #3e4339;
+		--text: #ededdf;
+		--muted: #a5a89b;
+		--accent: #2dd4bf;
+		--accent-2: #93c5fd;
+		--ok: #4ade80;
+		--warn: #fbbf24;
+		--bad: #f87171;
 	}
 }
 
@@ -29,7 +36,8 @@
 	box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
 	margin: 0;
 	padding: 0;
 	background: var(--bg);
@@ -40,62 +48,165 @@ html, body {
 }
 
 header {
+	position: sticky;
+	top: 0;
+	z-index: 10;
 	display: flex;
 	align-items: center;
+	justify-content: space-between;
 	gap: 12px;
-	padding: 14px 20px;
+	padding: 12px 18px;
 	border-bottom: 1px solid var(--border);
-	background: var(--surface);
+	background: color-mix(in srgb, var(--surface) 94%, transparent);
+	backdrop-filter: blur(8px);
 }
 
-header h1 {
+.brand,
+.header-actions,
+.section-head,
+.overview-band,
+.filters,
+.item-row,
+.persona-head {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.brand h1 {
 	margin: 0;
 	font-size: 16px;
-	font-weight: 600;
+	font-weight: 700;
 }
 
 main {
-	max-width: 1100px;
+	max-width: 1280px;
 	margin: 0 auto;
-	padding: 20px;
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
+	padding: 18px;
 }
 
 footer {
 	padding: 16px 20px;
 	text-align: center;
-	color: var(--muted);
 	font-size: 12px;
 }
 
-.card {
+.card,
+.tab-panel,
+.overview-band,
+.health-strip {
 	background: var(--surface);
 	border: 1px solid var(--border);
 	border-radius: 8px;
-	padding: 16px 18px;
 }
 
-.card-head {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	margin-bottom: 10px;
-	gap: 12px;
+.card {
+	max-width: 420px;
+	margin: 50px auto;
+	padding: 18px;
 }
 
-.card h2 {
+.card h2,
+.tab-panel h2,
+.overview-band h2 {
 	margin: 0;
 	font-size: 15px;
 }
 
-.card h3 {
-	margin: 14px 0 6px;
-	font-size: 13px;
+.tab-panel h3,
+.tab-panel h4 {
+	margin: 14px 0 8px;
+	font-size: 12px;
 	color: var(--muted);
 	text-transform: uppercase;
-	letter-spacing: 0.06em;
+}
+
+.tab-panel h4 {
+	margin-top: 10px;
+	font-size: 11px;
+}
+
+.overview-band {
+	justify-content: space-between;
+	padding: 12px 14px;
+}
+
+.overview-band p {
+	margin: 2px 0 0;
+}
+
+.health-strip {
+	margin: 10px 0 14px;
+	padding: 8px;
+}
+
+.compact-output {
+	min-height: 0;
+	max-height: 220px;
+	margin: 0 0 14px;
+}
+
+.tabs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin: 0 0 12px;
+	border-bottom: 1px solid var(--border);
+}
+
+.tab-btn {
+	background: transparent;
+	color: var(--muted);
+	border: 1px solid transparent;
+	border-bottom: none;
+	border-radius: 6px 6px 0 0;
+	padding: 8px 11px;
+}
+
+.tab-btn.is-active {
+	background: var(--surface);
+	color: var(--text);
+	border-color: var(--border);
+}
+
+.tab-panel {
+	padding: 14px;
+}
+
+.section-head {
+	justify-content: space-between;
+	margin-bottom: 10px;
+}
+
+.two-col {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	gap: 14px;
+	margin-top: 14px;
+}
+
+.persona-box {
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	padding: 12px;
+	background: var(--surface-2);
+}
+
+.persona-facts {
+	display: grid;
+	grid-template-columns: max-content minmax(0, 1fr);
+	gap: 6px 10px;
+	margin: 10px 0;
+	font-size: 12px;
+}
+
+.persona-facts dt {
+	color: var(--muted);
+}
+
+.persona-facts dd {
+	margin: 0;
+	overflow-wrap: anywhere;
 }
 
 .muted {
@@ -107,22 +218,30 @@ footer {
 	margin-top: 8px;
 }
 
-input, button {
+input,
+button,
+select {
 	font-family: inherit;
 	font-size: inherit;
 }
 
-input {
+input,
+select {
 	background: var(--surface-2);
 	color: var(--text);
 	border: 1px solid var(--border);
 	border-radius: 6px;
-	padding: 8px 10px;
+	padding: 7px 9px;
+}
+
+form input {
 	width: 100%;
 	margin-bottom: 10px;
 }
 
-input:focus {
+input:focus,
+select:focus,
+button:focus {
 	outline: 2px solid var(--accent);
 	outline-offset: 1px;
 }
@@ -134,17 +253,21 @@ label {
 	color: var(--muted);
 }
 
+.filters label {
+	margin: 0;
+}
+
 button {
 	background: var(--accent);
-	color: white;
+	color: #ffffff;
 	border: none;
 	border-radius: 6px;
-	padding: 8px 14px;
+	padding: 7px 12px;
 	cursor: pointer;
 }
 
 button:hover {
-	filter: brightness(1.08);
+	filter: brightness(1.06);
 }
 
 button:disabled {
@@ -158,43 +281,76 @@ button:disabled {
 	padding: 4px 6px;
 }
 
+.btn-small {
+	padding: 4px 8px;
+	font-size: 12px;
+	background: var(--surface-3);
+	color: var(--text);
+	border: 1px solid var(--border);
+}
+
 .pill {
 	display: inline-block;
 	padding: 2px 8px;
 	border-radius: 999px;
 	font-size: 12px;
+	white-space: nowrap;
 	background: var(--surface-2);
 	border: 1px solid var(--border);
 }
 
-.pill-muted { color: var(--muted); }
-.pill-ok    { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, transparent); }
-.pill-warn  { background: color-mix(in srgb, var(--warn) 22%, transparent); color: var(--warn); border-color: color-mix(in srgb, var(--warn) 50%, transparent); }
-.pill-bad   { background: color-mix(in srgb, var(--bad) 20%, transparent); color: var(--bad); border-color: color-mix(in srgb, var(--bad) 50%, transparent); }
+.pill-muted {
+	color: var(--muted);
+}
 
-.stack {
+.pill-ok {
+	background: color-mix(in srgb, var(--ok) 14%, transparent);
+	color: var(--ok);
+	border-color: color-mix(in srgb, var(--ok) 42%, transparent);
+}
+
+.pill-warn {
+	background: color-mix(in srgb, var(--warn) 16%, transparent);
+	color: var(--warn);
+	border-color: color-mix(in srgb, var(--warn) 45%, transparent);
+}
+
+.pill-bad {
+	background: color-mix(in srgb, var(--bad) 15%, transparent);
+	color: var(--bad);
+	border-color: color-mix(in srgb, var(--bad) 45%, transparent);
+}
+
+.stack,
+.chips,
+.log-list {
 	list-style: none;
 	padding: 0;
 	margin: 0;
+}
+
+.stack {
 	display: flex;
 	flex-direction: column;
 	gap: 6px;
 }
 
+.stack.compact {
+	gap: 4px;
+}
+
 .chips {
-	list-style: none;
-	padding: 0;
-	margin: 4px 0 0;
 	display: flex;
 	flex-wrap: wrap;
 	gap: 6px;
 }
 
-.chips li {
+.chips li,
+.command-chip {
 	background: var(--surface-2);
 	border: 1px solid var(--border);
 	border-radius: 999px;
-	padding: 3px 10px;
+	padding: 3px 9px;
 	font-size: 12px;
 	font-family: var(--mono);
 }
@@ -204,39 +360,101 @@ button:disabled {
 	justify-content: space-between;
 	align-items: baseline;
 	gap: 10px;
-	padding: 6px 10px;
+	padding: 6px 8px;
 	background: var(--surface-2);
 	border: 1px solid var(--border);
 	border-radius: 6px;
 }
 
 .item-label {
-	font-weight: 500;
+	font-weight: 600;
+	min-width: 0;
+	overflow-wrap: anywhere;
 }
 
 .item-detail {
 	color: var(--muted);
 	font-family: var(--mono);
 	font-size: 12px;
+	overflow-wrap: anywhere;
+}
+
+.table-wrap {
+	width: 100%;
+	overflow: auto;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	margin-top: 10px;
 }
 
 table {
 	width: 100%;
 	border-collapse: collapse;
 	font-size: 12px;
+	background: var(--surface);
 }
 
-th, td {
-	padding: 6px 10px;
+th,
+td {
+	padding: 7px 9px;
 	text-align: left;
 	border-bottom: 1px solid var(--border);
+	vertical-align: top;
+	white-space: nowrap;
+}
+
+td {
+	color: var(--text);
+}
+
+td:nth-child(2),
+td:last-child {
+	white-space: normal;
+	min-width: 120px;
 }
 
 th {
+	position: sticky;
+	top: 0;
+	z-index: 1;
 	color: var(--muted);
+	background: var(--surface-2);
 	text-transform: uppercase;
-	letter-spacing: 0.06em;
 	font-size: 11px;
+}
+
+.log-list {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	margin-top: 10px;
+	max-height: 420px;
+	overflow: auto;
+}
+
+.log-line {
+	display: grid;
+	grid-template-columns: 210px 68px minmax(0, 1fr);
+	align-items: baseline;
+	gap: 8px;
+	padding: 6px 8px;
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	background: var(--surface-2);
+}
+
+.log-meta,
+.log-message {
+	font-family: var(--mono);
+	font-size: 12px;
+}
+
+.log-meta {
+	color: var(--muted);
+}
+
+.log-message {
+	overflow-wrap: anywhere;
 }
 
 .preblock {
@@ -248,13 +466,35 @@ th {
 	font-size: 12px;
 	white-space: pre-wrap;
 	word-break: break-word;
-	max-height: 420px;
 	overflow: auto;
 }
 
-@media (max-width: 600px) {
-	main { padding: 14px; }
-	header { padding: 10px 14px; }
-	.card { padding: 12px 14px; }
-	table { font-size: 11px; }
+@media (max-width: 760px) {
+	header {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	main {
+		padding: 12px;
+	}
+
+	.overview-band,
+	.section-head,
+	.filters {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.two-col {
+		grid-template-columns: 1fr;
+	}
+
+	.log-line {
+		grid-template-columns: 1fr;
+	}
+
+	.card {
+		margin: 24px auto;
+	}
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,16 @@
     "node": ">=20.0.0"
   },
   "packageManager": "pnpm@9.15.0",
+  "pnpm": {
+    "overrides": {
+      "fastify": "5.8.5",
+      "minimatch": "9.0.7",
+      "picomatch@<2.3.2": "2.3.2",
+      "picomatch@>=4.0.0 <4.0.4": "4.0.4",
+      "rollup": "4.59.0",
+      "vite": "7.3.2"
+    }
+  },
   "os": [
     "darwin",
     "linux"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fastify: 5.8.5
+  minimatch: 9.0.7
+  picomatch@<2.3.2: 2.3.2
+  picomatch@>=4.0.0 <4.0.4: 4.0.4
+  rollup: 4.59.0
+  vite: 7.3.2
+
 importers:
 
   .:
@@ -45,8 +53,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       fastify:
-        specifier: ^5.8.4
-        version: 5.8.4
+        specifier: 5.8.5
+        version: 5.8.5
       googleapis:
         specifier: ^171.4.0
         version: 171.4.0
@@ -286,34 +294,16 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -322,34 +312,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -358,22 +330,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -382,22 +342,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -406,22 +354,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -430,22 +366,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -454,22 +378,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
@@ -478,34 +390,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -514,22 +408,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -538,23 +420,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
@@ -562,34 +432,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -880,113 +732,128 @@ packages:
   '@pondwader/socks5-server@1.0.10':
     resolution: {integrity: sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==}
 
-  '@rollup/rollup-android-arm-eabi@4.53.3':
-    resolution: {integrity: sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==}
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.53.3':
-    resolution: {integrity: sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==}
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.53.3':
-    resolution: {integrity: sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==}
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.53.3':
-    resolution: {integrity: sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==}
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.53.3':
-    resolution: {integrity: sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==}
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.53.3':
-    resolution: {integrity: sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==}
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
-    resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
-    resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.3':
-    resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.53.3':
-    resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.3':
-    resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
-    resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
-    resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.53.3':
-    resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.3':
-    resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.53.3':
-    resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.53.3':
-    resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openharmony-arm64@4.53.3':
-    resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
-    resolution: {integrity: sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==}
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.3':
-    resolution: {integrity: sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==}
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.53.3':
-    resolution: {integrity: sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==}
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.53.3':
-    resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
 
@@ -1043,7 +910,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: 7.3.2
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1124,8 +991,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1156,8 +1024,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1423,11 +1292,6 @@ packages:
   es-toolkit@1.45.1:
     resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
@@ -1516,8 +1380,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fastify@5.8.4:
-    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1529,7 +1393,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2007,8 +1871,8 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.7:
+    resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
@@ -2157,12 +2021,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pino-abstract-transport@3.0.0:
@@ -2185,10 +2049,6 @@ packages:
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -2302,8 +2162,8 @@ packages:
   robot3@0.4.1:
     resolution: {integrity: sha512-hzjy826lrxzx8eRgv80idkf8ua1JAepRc9Efdtj03N3KNJuznQCPlyCJ7gnUmDFwZCLQjxy567mQVKmdv2BsXQ==}
 
-  rollup@4.53.3:
-    resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2613,8 +2473,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.2.4:
-    resolution: {integrity: sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2901,157 +2761,79 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
-    optional: true
-
   '@esbuild/android-arm@0.27.2':
-    optional: true
-
-  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
-  '@esbuild/linux-x64@0.25.12':
-    optional: true
-
   '@esbuild/linux-x64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
   '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -3347,70 +3129,79 @@ snapshots:
 
   '@pondwader/socks5-server@1.0.10': {}
 
-  '@rollup/rollup-android-arm-eabi@4.53.3':
+  '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.53.3':
+  '@rollup/rollup-android-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.53.3':
+  '@rollup/rollup-darwin-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.53.3':
+  '@rollup/rollup-darwin-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.53.3':
+  '@rollup/rollup-freebsd-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.53.3':
+  '@rollup/rollup-freebsd-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.3':
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.53.3':
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.3':
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.53.3':
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.3':
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.53.3':
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.53.3':
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.53.3':
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
+  '@rollup/rollup-linux-x64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.3':
+  '@rollup/rollup-openbsd-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.53.3':
+  '@rollup/rollup-openharmony-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.53.3':
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
   '@steipete/summarize-core@0.13.0(@noble/hashes@2.0.1)':
@@ -3485,13 +3276,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.2.4(@types/node@25.6.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@25.6.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.4(@types/node@25.6.0)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@25.6.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3570,7 +3361,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
 
@@ -3613,9 +3404,9 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@2.0.2:
+  brace-expansion@5.0.5:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -3854,35 +3645,6 @@ snapshots:
 
   es-toolkit@1.45.1: {}
 
-  esbuild@0.25.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
-
   esbuild@0.27.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.2
@@ -4011,7 +3773,7 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastify@5.8.4:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -4037,9 +3799,9 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -4138,7 +3900,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.7
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -4713,7 +4475,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.54.0: {}
 
@@ -4723,9 +4485,9 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  minimatch@9.0.5:
+  minimatch@9.0.7:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -4837,9 +4599,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pino-abstract-transport@3.0.0:
     dependencies:
@@ -4880,12 +4642,6 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5026,32 +4782,35 @@ snapshots:
 
   robot3@0.4.1: {}
 
-  rollup@4.53.3:
+  rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.53.3
-      '@rollup/rollup-android-arm64': 4.53.3
-      '@rollup/rollup-darwin-arm64': 4.53.3
-      '@rollup/rollup-darwin-x64': 4.53.3
-      '@rollup/rollup-freebsd-arm64': 4.53.3
-      '@rollup/rollup-freebsd-x64': 4.53.3
-      '@rollup/rollup-linux-arm-gnueabihf': 4.53.3
-      '@rollup/rollup-linux-arm-musleabihf': 4.53.3
-      '@rollup/rollup-linux-arm64-gnu': 4.53.3
-      '@rollup/rollup-linux-arm64-musl': 4.53.3
-      '@rollup/rollup-linux-loong64-gnu': 4.53.3
-      '@rollup/rollup-linux-ppc64-gnu': 4.53.3
-      '@rollup/rollup-linux-riscv64-gnu': 4.53.3
-      '@rollup/rollup-linux-riscv64-musl': 4.53.3
-      '@rollup/rollup-linux-s390x-gnu': 4.53.3
-      '@rollup/rollup-linux-x64-gnu': 4.53.3
-      '@rollup/rollup-linux-x64-musl': 4.53.3
-      '@rollup/rollup-openharmony-arm64': 4.53.3
-      '@rollup/rollup-win32-arm64-msvc': 4.53.3
-      '@rollup/rollup-win32-ia32-msvc': 4.53.3
-      '@rollup/rollup-win32-x64-gnu': 4.53.3
-      '@rollup/rollup-win32-x64-msvc': 4.53.3
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -5267,7 +5026,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.5.0
-      minimatch: 9.0.5
+      minimatch: 9.0.7
 
   thread-stream@4.0.0:
     dependencies:
@@ -5279,8 +5038,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -5402,7 +5161,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.2.4(@types/node@25.6.0)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@25.6.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5417,13 +5176,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.2.4(@types/node@25.6.0)(tsx@4.21.0):
+  vite@7.3.2(@types/node@25.6.0)(tsx@4.21.0):
     dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.6.0
@@ -5434,7 +5193,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.4(@types/node@25.6.0)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@25.6.0)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5445,14 +5204,14 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.2.4(@types/node@25.6.0)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@25.6.0)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@25.6.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/src/commands/integration-test.ts
+++ b/src/commands/integration-test.ts
@@ -19,6 +19,22 @@ import type { PermissionTier } from "../config/config.js";
 import { getMediaOutboxDirSync } from "../media/store.js";
 import { executeQueryStream } from "../sdk/client.js";
 import { getOpenAIKey } from "../services/openai-client.js";
+import {
+	assertProviderReplayFixture,
+	assertSocialReplayFixture,
+	type ProviderProbeResult,
+	runMoltbookSocialProbe,
+	runProviderProbe,
+	type SocialProbeResult,
+} from "../testing/integration-harness.js";
+import {
+	buildFixtureEnvelope,
+	type IntegrationHarnessMode,
+	integrationFixturePath,
+	readFixtureFile,
+	resolveHarnessMode,
+	writeFixtureFile,
+} from "../testing/live-replay.js";
 
 type IntegrationTestOptions = {
 	image?: boolean;
@@ -27,9 +43,24 @@ type IntegrationTestOptions = {
 	network?: boolean;
 	voice?: boolean;
 	agents?: boolean;
+	harness?: boolean;
+	providers?: boolean;
+	social?: boolean;
+	controlPlane?: boolean;
+	dashboard?: boolean;
+	live?: boolean;
+	captureFixtures?: boolean;
+	fixtureDir?: string;
 	all?: boolean;
 	verbose?: boolean;
 	timeout?: string;
+};
+
+type IntegrationTestResult = {
+	name: string;
+	passed: boolean;
+	message: string;
+	duration?: number;
 };
 
 export function registerIntegrationTestCommand(program: Command): void {
@@ -42,22 +73,46 @@ export function registerIntegrationTestCommand(program: Command): void {
 		.option("--network", "Test sandbox network proxy configuration")
 		.option("--voice", "Test voice message response (TTS skill)")
 		.option("--agents", "Test direct agent transport (real agent, no Telegram)")
+		.option("--harness", "Run live/replay provider, social, and control-plane harness")
+		.option("--providers", "Run provider live/replay harness")
+		.option("--social", "Run social live/replay harness")
+		.option("--control-plane", "Check Telegram/background control-plane replay fixtures")
+		.option("--dashboard", "Check dashboard route replay fixtures")
+		.option("--live", "Run harness probes against live services (requires explicit env vars)")
+		.option("--capture-fixtures", "Capture sanitized harness fixtures from live services")
+		.option("--fixture-dir <path>", "Harness fixture directory", "tests/fixtures/integration")
 		.option("--all", "Run all integration tests")
 		.option("-v, --verbose", "Show detailed output")
 		.option("--timeout <ms>", "Query timeout in ms", "120000")
 		.action(async (opts: IntegrationTestOptions) => {
 			const verbose = program.opts().verbose || opts.verbose;
 			const timeoutMs = Number.parseInt(opts.timeout ?? "120000", 10);
+			const requestedHarness = Boolean(
+				opts.harness ||
+					opts.providers ||
+					opts.social ||
+					opts.controlPlane ||
+					opts.dashboard ||
+					opts.live ||
+					opts.captureFixtures,
+			);
 
 			const runAll =
 				opts.all ||
-				(!opts.image && !opts.echo && !opts.env && !opts.network && !opts.voice && !opts.agents);
+				(!opts.image &&
+					!opts.echo &&
+					!opts.env &&
+					!opts.network &&
+					!opts.voice &&
+					!opts.agents &&
+					!requestedHarness);
 			const runImage = opts.image || runAll;
 			const runEcho = opts.echo || runAll;
 			const runEnv = opts.env || runAll;
 			const runNetwork = opts.network || runAll;
 			const runVoice = opts.voice || runAll;
 			const runAgents = opts.agents || runAll;
+			const runHarness = requestedHarness;
 
 			console.log(chalk.bold("\n🔬 Telclaude Integration Test\n"));
 			console.log("This tests the full SDK path (not just sandbox config).\n");
@@ -65,7 +120,7 @@ export function registerIntegrationTestCommand(program: Command): void {
 			// SDK handles sandbox initialization internally when sandbox.enabled=true
 			// No need to pre-check - SDK will fail with clear error if unavailable
 
-			const results: { name: string; passed: boolean; message: string; duration?: number }[] = [];
+			const results: IntegrationTestResult[] = [];
 
 			if (runEcho) {
 				console.log(chalk.bold("── Echo Test ──"));
@@ -152,6 +207,13 @@ export function registerIntegrationTestCommand(program: Command): void {
 				console.log();
 			}
 
+			if (runHarness) {
+				console.log(chalk.bold("── Live/Replay Harness ──"));
+				const harnessResults = await runLiveReplayHarness(opts, verbose);
+				results.push(...harnessResults);
+				console.log();
+			}
+
 			// Summary
 			const passed = results.filter((r) => r.passed).length;
 			const failed = results.filter((r) => !r.passed).length;
@@ -168,6 +230,257 @@ export function registerIntegrationTestCommand(program: Command): void {
 
 			process.exit(failed > 0 ? 1 : 0);
 		});
+}
+
+function selectedHarnessTargets(opts: IntegrationTestOptions): {
+	providers: boolean;
+	social: boolean;
+	controlPlane: boolean;
+	dashboard: boolean;
+} {
+	const runAllHarness =
+		opts.harness || (!opts.providers && !opts.social && !opts.controlPlane && !opts.dashboard);
+	return {
+		providers: Boolean(opts.providers || runAllHarness),
+		social: Boolean(opts.social || runAllHarness),
+		controlPlane: Boolean(opts.controlPlane || runAllHarness),
+		dashboard: Boolean(opts.dashboard || runAllHarness),
+	};
+}
+
+function logHarnessResult(result: IntegrationTestResult): void {
+	const icon = result.passed ? chalk.green("✓") : chalk.red("✗");
+	const message = result.message === "OK" ? "" : `: ${result.message}`;
+	console.log(`  ${icon} ${result.name}${message}`);
+}
+
+function parseJsonObjectEnv(name: string): Record<string, unknown> | undefined {
+	const raw = process.env[name];
+	if (!raw) return undefined;
+	const parsed = JSON.parse(raw) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`${name} must be a JSON object.`);
+	}
+	return parsed as Record<string, unknown>;
+}
+
+function fixtureModeLabel(mode: IntegrationHarnessMode): string {
+	switch (mode) {
+		case "capture":
+			return "capture";
+		case "live":
+			return "live";
+		case "replay":
+			return "replay";
+	}
+}
+
+async function runProviderHarness(
+	mode: IntegrationHarnessMode,
+	fixtureDir: string,
+): Promise<IntegrationTestResult> {
+	const startTime = Date.now();
+	const fixturePath = integrationFixturePath(fixtureDir, "provider-basic");
+
+	try {
+		if (mode === "replay") {
+			const fixture = await readFixtureFile<ProviderProbeResult>(fixturePath);
+			assertProviderReplayFixture(fixture.data);
+			return {
+				name: "Provider replay fixture",
+				passed: true,
+				message: "OK",
+				duration: Date.now() - startTime,
+			};
+		}
+
+		const baseUrl = process.env.TELCLAUDE_INTEGRATION_PROVIDER_URL;
+		if (!baseUrl) {
+			return {
+				name: "Provider live probe",
+				passed: false,
+				message: "Set TELCLAUDE_INTEGRATION_PROVIDER_URL before using --live.",
+			};
+		}
+
+		const providerId = process.env.TELCLAUDE_INTEGRATION_PROVIDER_ID ?? "integration-provider";
+		const service = process.env.TELCLAUDE_INTEGRATION_PROVIDER_SERVICE;
+		const action = process.env.TELCLAUDE_INTEGRATION_PROVIDER_ACTION;
+		const readAction = service && action ? { service, action } : undefined;
+		const readParams = parseJsonObjectEnv("TELCLAUDE_INTEGRATION_PROVIDER_PARAMS");
+		const result = await runProviderProbe({
+			providerId,
+			baseUrl,
+			readAction,
+			readParams,
+		});
+		assertProviderReplayFixture(result);
+
+		if (mode === "capture") {
+			await writeFixtureFile(
+				fixturePath,
+				buildFixtureEnvelope("provider-basic", result, { mode: "capture" }),
+			);
+		}
+
+		return {
+			name: `Provider ${fixtureModeLabel(mode)} probe`,
+			passed: true,
+			message: mode === "capture" ? `Captured ${fixturePath}` : "OK",
+			duration: Date.now() - startTime,
+		};
+	} catch (error) {
+		return {
+			name: `Provider ${fixtureModeLabel(mode)} probe`,
+			passed: false,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+function liveSocialMutationEnabled(): boolean {
+	return (
+		process.env.TELCLAUDE_INTEGRATION_SOCIAL_MUTATE === "1" &&
+		process.env.TELCLAUDE_INTEGRATION_SOCIAL_TEST_ACCOUNT === "1"
+	);
+}
+
+async function runSocialHarness(
+	mode: IntegrationHarnessMode,
+	fixtureDir: string,
+): Promise<IntegrationTestResult> {
+	const startTime = Date.now();
+	const fixturePath = integrationFixturePath(fixtureDir, "social-moltbook-basic");
+
+	try {
+		if (mode === "replay") {
+			const fixture = await readFixtureFile<SocialProbeResult>(fixturePath);
+			assertSocialReplayFixture(fixture.data);
+			return {
+				name: "Social replay fixture",
+				passed: true,
+				message: "OK",
+				duration: Date.now() - startTime,
+			};
+		}
+
+		const baseUrl =
+			process.env.TELCLAUDE_INTEGRATION_SOCIAL_BASE_URL ?? process.env.MOLTBOOK_API_BASE;
+		const apiKey = process.env.TELCLAUDE_INTEGRATION_SOCIAL_API_KEY ?? process.env.MOLTBOOK_API_KEY;
+		if (!baseUrl || !apiKey) {
+			return {
+				name: "Social live probe",
+				passed: false,
+				message:
+					"Set TELCLAUDE_INTEGRATION_SOCIAL_BASE_URL and TELCLAUDE_INTEGRATION_SOCIAL_API_KEY before using --live.",
+			};
+		}
+
+		const result = await runMoltbookSocialProbe({
+			baseUrl,
+			apiKey,
+			allowPublicMutation: liveSocialMutationEnabled(),
+			postContent: process.env.TELCLAUDE_INTEGRATION_SOCIAL_POST_TEXT,
+		});
+		const failed = result.checks.filter((check) => check.status === "failed");
+		if (failed.length > 0) {
+			throw new Error(failed.map((check) => `${check.name}: ${check.failureKind}`).join(", "));
+		}
+
+		if (mode === "capture") {
+			await writeFixtureFile(
+				fixturePath,
+				buildFixtureEnvelope("social-moltbook-basic", result, { mode: "capture" }),
+			);
+		}
+
+		return {
+			name: `Social ${fixtureModeLabel(mode)} probe`,
+			passed: true,
+			message: mode === "capture" ? `Captured ${fixturePath}` : "OK",
+			duration: Date.now() - startTime,
+		};
+	} catch (error) {
+		return {
+			name: `Social ${fixtureModeLabel(mode)} probe`,
+			passed: false,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+async function runReplayFixturePresence(
+	fixtureDir: string,
+	fixtureName: string,
+	requiredKeys: string[],
+): Promise<IntegrationTestResult> {
+	const startTime = Date.now();
+	try {
+		const fixture = await readFixtureFile<Record<string, unknown>>(
+			integrationFixturePath(fixtureDir, fixtureName),
+		);
+		for (const key of requiredKeys) {
+			if (!(key in fixture.data)) {
+				throw new Error(`Missing ${key} in ${fixtureName}.json`);
+			}
+		}
+		return {
+			name: `${fixtureName} replay fixture`,
+			passed: true,
+			message: "OK",
+			duration: Date.now() - startTime,
+		};
+	} catch (error) {
+		return {
+			name: `${fixtureName} replay fixture`,
+			passed: false,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+async function runLiveReplayHarness(
+	opts: IntegrationTestOptions,
+	verbose: boolean,
+): Promise<IntegrationTestResult[]> {
+	const mode = resolveHarnessMode({
+		live: opts.live,
+		captureFixtures: opts.captureFixtures,
+	});
+	const fixtureDir = path.resolve(opts.fixtureDir ?? "tests/fixtures/integration");
+	const targets = selectedHarnessTargets(opts);
+	const results: IntegrationTestResult[] = [];
+
+	if (verbose) {
+		console.log(chalk.gray(`  Harness mode: ${fixtureModeLabel(mode)}`));
+		console.log(chalk.gray(`  Fixtures: ${fixtureDir}`));
+	}
+
+	if (targets.providers) {
+		const result = await runProviderHarness(mode, fixtureDir);
+		logHarnessResult(result);
+		results.push(result);
+	}
+	if (targets.social) {
+		const result = await runSocialHarness(mode, fixtureDir);
+		logHarnessResult(result);
+		results.push(result);
+	}
+	if (targets.controlPlane) {
+		const result = await runReplayFixturePresence(fixtureDir, "telegram-control-plane", [
+			"cardCallbacks",
+			"backgroundJobs",
+		]);
+		logHarnessResult(result);
+		results.push(result);
+	}
+	if (targets.dashboard) {
+		const result = await runReplayFixturePresence(fixtureDir, "dashboard-routes", ["routes"]);
+		logHarnessResult(result);
+		results.push(result);
+	}
+
+	return results;
 }
 
 /**

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -8,6 +8,11 @@ import { getChildLogger } from "../logging.js";
 import type { SandboxMode } from "../sandbox/mode.js";
 import { getSandboxMode } from "../sandbox/mode.js";
 import { createAuditLogger } from "../security/audit.js";
+import {
+	collectPersonaStatus,
+	formatPersonaStatusSnapshot,
+	type PersonaStatusSnapshot,
+} from "../status/personas.js";
 import { buildRuntimeSnapshot } from "../system-metadata.js";
 import { formatDuration, formatUptime } from "./cli-utils.js";
 
@@ -52,6 +57,7 @@ export type TelclaudeStatus = {
 		socialServices: number;
 		enabledSocialServices: number;
 	};
+	personas: PersonaStatusSnapshot;
 	runtime: {
 		version: string;
 		revision: string;
@@ -120,6 +126,10 @@ export async function collectTelclaudeStatus(): Promise<TelclaudeStatus> {
 		socialServices: cfg?.socialServices?.length ?? 0,
 		enabledSocialServices: (cfg?.socialServices ?? []).filter((svc) => svc.enabled).length,
 	};
+	const personas = await collectPersonaStatus({
+		...(cfg ? { config: cfg } : {}),
+		cwd: process.cwd(),
+	});
 
 	const runtime = buildRuntimeSnapshot(STATUS_STARTED_AT);
 	const sessions = Object.entries(getAllSessions())
@@ -166,6 +176,7 @@ export async function collectTelclaudeStatus(): Promise<TelclaudeStatus> {
 			: null,
 		audit: auditStats,
 		services: serviceCounts,
+		personas,
 		runtime: {
 			version: runtime.version,
 			revision: runtime.revision,
@@ -206,6 +217,8 @@ export function formatTelclaudeStatus(status: TelclaudeStatus, telegram = false)
 			"Services:",
 			`  External Providers: ${status.services.externalProviders}`,
 			`  Social Services: ${status.services.enabledSocialServices}/${status.services.socialServices}`,
+			"",
+			formatPersonaStatusSnapshot(status.personas, { telegram: true }),
 			"",
 			"Operations:",
 			`  Sessions: ${status.operations.sessions.total} total (${status.operations.sessions.staleOver24h} stale >24h)`,
@@ -262,6 +275,8 @@ export function formatTelclaudeStatus(status: TelclaudeStatus, telegram = false)
 	lines.push(
 		`  Social Services: ${status.services.enabledSocialServices}/${status.services.socialServices}`,
 	);
+	lines.push("");
+	lines.push(formatPersonaStatusSnapshot(status.personas));
 	lines.push("");
 	lines.push("Operations:");
 	lines.push(

--- a/src/dashboard/routes/health.ts
+++ b/src/dashboard/routes/health.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { getChildLogger } from "../../logging.js";
+import { getRemediation } from "../../telegram/remediation-commands.js";
 import { collectSystemHealth } from "../../telegram/status-overview.js";
 
 const logger = getChildLogger({ module: "dashboard-health" });
@@ -8,7 +9,22 @@ export async function registerHealthRoute(server: FastifyInstance): Promise<void
 	server.get("/api/health", async (_request, reply) => {
 		try {
 			const snapshot = await collectSystemHealth();
-			return reply.send({ ok: true, snapshot });
+			const enriched = {
+				...snapshot,
+				items: snapshot.items.map((item) => {
+					const remediation = item.remediation ? getRemediation(item.remediation) : undefined;
+					return {
+						...item,
+						...(remediation
+							? {
+									remediationCommand: remediation.command,
+									remediationTitle: remediation.title,
+								}
+							: {}),
+					};
+				}),
+			};
+			return reply.send({ ok: true, snapshot: enriched });
 		} catch (err) {
 			logger.warn({ error: String(err) }, "collectSystemHealth failed");
 			return reply.status(500).send({

--- a/src/dashboard/routes/operator.ts
+++ b/src/dashboard/routes/operator.ts
@@ -1,0 +1,741 @@
+import fs from "node:fs";
+import type { FastifyInstance } from "fastify";
+import { cancelJob, getJobByShortId, listJobs } from "../../background/index.js";
+import type { BackgroundJob, BackgroundJobStatus } from "../../background/types.js";
+import { collectSessionRows, type SessionListRow } from "../../commands/sessions.js";
+import { loadConfig, type TelclaudeConfig } from "../../config/config.js";
+import {
+	getCronCoverage,
+	getCronStatusSummary,
+	listCronJobs,
+	listCronRuns,
+} from "../../cron/store.js";
+import type { CronAction, CronDeliveryTarget, CronJob, CronSchedule } from "../../cron/types.js";
+import { getChildLogger, getResolvedLoggerSettings } from "../../logging.js";
+import { getEntries } from "../../memory/store.js";
+import type { MemoryCategory, MemoryEntry, MemorySource } from "../../memory/types.js";
+import {
+	type ConnectorHealth,
+	checkProviderHealth,
+	type HealthAlert,
+	type HealthCheckResult,
+} from "../../providers/provider-health.js";
+import { createAuditLogger } from "../../security/audit.js";
+import { redactSecrets } from "../../security/output-filter.js";
+import type { AuditEntry } from "../../security/types.js";
+import { collectPersonaStatus, type PersonaStatus } from "../../status/personas.js";
+
+const logger = getChildLogger({ module: "dashboard-operator" });
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const LOG_TAIL_BYTES = 512 * 1024;
+const STRING_LIMIT = 180;
+
+const BACKGROUND_STATUSES: readonly BackgroundJobStatus[] = [
+	"queued",
+	"running",
+	"completed",
+	"failed",
+	"cancelled",
+	"interrupted",
+];
+
+const LOG_LEVELS = new Map<number, string>([
+	[10, "trace"],
+	[20, "debug"],
+	[30, "info"],
+	[40, "warn"],
+	[50, "error"],
+	[60, "fatal"],
+]);
+
+const LOG_LEVEL_VALUES = new Map<string, number>(
+	[...LOG_LEVELS.entries()].map(([value, name]) => [name, value]),
+);
+
+const SAFE_LOG_CONTEXT_KEYS = new Set([
+	"action",
+	"attempt",
+	"chatId",
+	"connector",
+	"health",
+	"jobId",
+	"level",
+	"module",
+	"poolKey",
+	"provider",
+	"providerId",
+	"requestId",
+	"scope",
+	"service",
+	"serviceId",
+	"shortId",
+	"state",
+	"status",
+	"tier",
+	"userId",
+]);
+
+type QueryMap = Record<string, string | undefined>;
+
+type DashboardLogEntry = {
+	timestamp: string | null;
+	level: string;
+	component: string;
+	message: string;
+	context: Record<string, string | number | boolean | null>;
+};
+
+function parseLimit(raw: string | undefined, fallback = DEFAULT_LIMIT): number {
+	if (!raw) return fallback;
+	const n = Number.parseInt(raw, 10);
+	if (!Number.isFinite(n) || n <= 0) return fallback;
+	return Math.min(n, MAX_LIMIT);
+}
+
+function clampText(value: string | null | undefined, limit = STRING_LIMIT): string | null {
+	if (!value) return null;
+	const redacted = redactSecrets(value).replace(/\s+/g, " ").trim();
+	if (!redacted) return null;
+	return redacted.length <= limit ? redacted : `${redacted.slice(0, limit - 3)}...`;
+}
+
+function compactRef(value: string): string {
+	if (value.length <= 16) return value;
+	return `${value.slice(0, 6)}...${value.slice(-6)}`;
+}
+
+function statusFromAge(ageMs: number): "active" | "idle" | "stale" {
+	if (ageMs <= 30 * 60_000) return "active";
+	if (ageMs <= 24 * 60 * 60_000) return "idle";
+	return "stale";
+}
+
+function sessionPersona(_row: SessionListRow): "private" {
+	return "private";
+}
+
+function summarizeSession(row: SessionListRow) {
+	return {
+		key: row.key,
+		source: row.kind,
+		persona: sessionPersona(row),
+		model: null,
+		status: statusFromAge(row.ageMs),
+		updatedAtMs: row.updatedAt,
+		ageMs: row.ageMs,
+		systemSent: row.systemSent,
+		sessionRef: compactRef(row.sessionId),
+		errorSummary: null,
+	};
+}
+
+function runStatusFromOutcome(outcome: AuditEntry["outcome"]) {
+	switch (outcome) {
+		case "success":
+			return "completed";
+		case "blocked":
+			return "blocked";
+		case "timeout":
+			return "timeout";
+		case "rate_limited":
+			return "rate_limited";
+		case "error":
+			return "error";
+	}
+}
+
+function summarizeAuditRun(entry: AuditEntry) {
+	const finishedAtMs = entry.timestamp.getTime();
+	const durationMs = entry.executionTimeMs ?? null;
+	const startedAtMs = durationMs === null ? null : Math.max(0, finishedAtMs - durationMs);
+	return {
+		id: entry.requestId,
+		source: "telegram",
+		persona: "private",
+		model: null,
+		status: runStatusFromOutcome(entry.outcome),
+		startedAtMs,
+		finishedAtMs,
+		durationMs,
+		errorSummary: clampText(
+			entry.errorType ?? (entry.outcome === "success" ? null : entry.outcome),
+		),
+		tier: entry.permissionTier,
+	};
+}
+
+function parseStatuses(raw: string | undefined): BackgroundJobStatus[] | undefined {
+	if (!raw) return undefined;
+	const requested = raw
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+	if (requested.length === 0) return undefined;
+	const valid = requested.filter((status): status is BackgroundJobStatus =>
+		BACKGROUND_STATUSES.includes(status as BackgroundJobStatus),
+	);
+	return valid.length > 0 ? valid : undefined;
+}
+
+function summarizeBackgroundJob(job: BackgroundJob) {
+	return {
+		id: job.id,
+		shortId: job.shortId,
+		title: clampText(job.title) ?? "(untitled)",
+		description: clampText(job.description),
+		status: job.status,
+		tier: job.tier,
+		userId: clampText(job.userId, 80),
+		chatId: job.chatId,
+		threadId: job.threadId,
+		payloadKind: job.payload.kind,
+		createdAtMs: job.createdAtMs,
+		startedAtMs: job.startedAtMs,
+		completedAtMs: job.completedAtMs,
+		cancelledAtMs: job.cancelledAtMs,
+		errorSummary: clampText(job.error ?? job.result?.message ?? null),
+		canCancel: job.status === "queued" || job.status === "running",
+	};
+}
+
+function formatSchedule(schedule: CronSchedule): string {
+	switch (schedule.kind) {
+		case "at":
+			return `at ${schedule.at}`;
+		case "every":
+			return `every ${Math.round(schedule.everyMs / 60_000)}m`;
+		case "cron":
+			return `cron ${schedule.expr}`;
+	}
+}
+
+function summarizeAction(action: CronAction): {
+	actionKind: CronAction["kind"];
+	actionSummary: string;
+} {
+	switch (action.kind) {
+		case "social-heartbeat":
+			return {
+				actionKind: action.kind,
+				actionSummary: action.serviceId
+					? `social heartbeat (${action.serviceId})`
+					: "social heartbeat (all)",
+			};
+		case "private-heartbeat":
+			return { actionKind: action.kind, actionSummary: "private heartbeat" };
+		case "agent-prompt":
+			return { actionKind: action.kind, actionSummary: "agent prompt (redacted)" };
+	}
+}
+
+function summarizeDelivery(target: CronDeliveryTarget): string {
+	switch (target.kind) {
+		case "home":
+			return "home";
+		case "origin":
+			return target.chatId ? "origin chat" : "origin";
+		case "chat":
+			return "chat";
+	}
+}
+
+function summarizeCronJob(job: CronJob) {
+	const action = summarizeAction(job.action);
+	return {
+		id: job.id,
+		name: clampText(job.name) ?? "(unnamed)",
+		enabled: job.enabled,
+		running: job.running,
+		ownerId: clampText(job.ownerId, 80),
+		delivery: summarizeDelivery(job.deliveryTarget),
+		schedule: formatSchedule(job.schedule),
+		...action,
+		nextRunAtMs: job.nextRunAtMs,
+		lastRunAtMs: job.lastRunAtMs,
+		lastStatus: job.lastStatus,
+		lastErrorSummary: clampText(job.lastError),
+		createdAtMs: job.createdAtMs,
+		updatedAtMs: job.updatedAtMs,
+		recentRuns: listCronRuns(job.id, 3).map((run) => ({
+			jobId: run.jobId,
+			startedAtMs: run.startedAtMs,
+			finishedAtMs: run.finishedAtMs,
+			status: run.status,
+			message: clampText(run.message),
+		})),
+	};
+}
+
+function queueStatus(entry: MemoryEntry): "awaiting_promotion" | "awaiting_heartbeat" | "posted" {
+	if (entry._provenance.postedAt) return "posted";
+	if (entry._provenance.trust === "trusted" && entry._provenance.promotedAt) {
+		return "awaiting_heartbeat";
+	}
+	return "awaiting_promotion";
+}
+
+function summarizeQueueEntry(entry: MemoryEntry) {
+	return {
+		id: entry.id,
+		source: entry._provenance.source,
+		trust: entry._provenance.trust,
+		status: queueStatus(entry),
+		createdAtMs: entry._provenance.createdAt,
+		promotedAtMs: entry._provenance.promotedAt ?? null,
+		postedAtMs: entry._provenance.postedAt ?? null,
+		metadataKind:
+			entry.metadata && typeof entry.metadata.action === "string" ? entry.metadata.action : null,
+		nextAction:
+			entry._provenance.trust === "trusted"
+				? "wait for heartbeat or run /social run"
+				: `/social promote ${entry.id}`,
+	};
+}
+
+function getMemoryEntries(query: {
+	categories: MemoryCategory[];
+	trust: Array<MemoryEntry["_provenance"]["trust"]>;
+	sources: MemorySource[];
+	promoted?: boolean;
+	posted?: boolean;
+	limit?: number;
+	order?: "asc" | "desc";
+}): MemoryEntry[] {
+	try {
+		return getEntries(query);
+	} catch (err) {
+		logger.warn({ error: String(err) }, "dashboard memory query failed");
+		return [];
+	}
+}
+
+function countIdentityEntries(
+	source: MemorySource,
+): Record<"profile" | "interests" | "meta", number> {
+	const entries = getMemoryEntries({
+		categories: ["profile", "interests", "meta"],
+		trust: ["trusted"],
+		sources: [source],
+		limit: 200,
+	});
+	return {
+		profile: entries.filter((entry) => entry.category === "profile").length,
+		interests: entries.filter((entry) => entry.category === "interests").length,
+		meta: entries.filter((entry) => entry.category === "meta").length,
+	};
+}
+
+function summarizeSocialService(service: NonNullable<TelclaudeConfig["socialServices"]>[number]) {
+	return {
+		id: service.id,
+		type: service.type,
+		enabled: service.enabled,
+		hasHandle: Boolean(service.handle),
+		displayName: clampText(service.displayName, 80),
+		heartbeatEnabled: service.heartbeatEnabled,
+		heartbeatIntervalHours: service.heartbeatIntervalHours,
+		notifyOnHeartbeat: service.notifyOnHeartbeat,
+		enableSkills: service.enableSkills,
+		allowedSkillsCount: service.allowedSkills?.length ?? 0,
+		hasAgentUrl: Boolean(service.agentUrl),
+	};
+}
+
+function summarizePersonaForDashboard(
+	status: PersonaStatus,
+	memoryCounts: Record<"profile" | "interests" | "meta", number>,
+	services: ReturnType<typeof summarizeSocialService>[] = [],
+) {
+	return {
+		status: status.health,
+		source: status.memory.source,
+		summary: status.summary,
+		memoryCounts,
+		profile: {
+			configured: status.profile.configured,
+			claudeHome: status.profile.claudeHome,
+			source: status.profile.source,
+		},
+		agent: {
+			configured: status.agent.configured,
+			source: status.agent.source,
+			endpoint: status.agent.endpoint,
+			reachability: status.agent.reachability,
+			checkedAt: status.agent.checkedAt,
+			error: status.agent.error,
+		},
+		skills: {
+			policy: status.skills.policy,
+			effectiveCount: status.skills.effective.length,
+			activeCatalogCount: status.skills.activeCatalog.length,
+			allowedCount: status.skills.allowed.length,
+			failClosed: status.skills.failClosed,
+		},
+		plugins: {
+			configured: status.plugins.configured,
+			enabledCount: status.plugins.enabled.length,
+			installedCount: status.plugins.installed.length,
+			error: status.plugins.error,
+		},
+		filesystem: status.filesystem,
+		providers: {
+			summary: status.providers.summary,
+			providerIds: status.providers.providerIds,
+			serviceIds: status.providers.serviceIds,
+			privateEndpointCount: status.providers.privateEndpointCount,
+			directProviderFetch: status.providers.directProviderFetch,
+			relayProxied: status.providers.relayProxied,
+		},
+		operations: status.operations,
+		boundaries: status.boundaries,
+		...(services.length ? { services } : {}),
+	};
+}
+
+function primitiveContextValue(value: unknown): string | number | boolean | null | undefined {
+	if (value === null) return null;
+	if (typeof value === "string") return clampText(value, 120);
+	if (typeof value === "number" || typeof value === "boolean") return value;
+	return undefined;
+}
+
+function parsePinoLine(line: string): DashboardLogEntry | null {
+	try {
+		const parsed = JSON.parse(line) as Record<string, unknown>;
+		const levelNumber = typeof parsed.level === "number" ? parsed.level : null;
+		const level =
+			levelNumber === null
+				? typeof parsed.level === "string"
+					? parsed.level
+					: "info"
+				: (LOG_LEVELS.get(levelNumber) ?? "info");
+		const component =
+			typeof parsed.module === "string" && parsed.module.trim() ? parsed.module.trim() : "unknown";
+		const message = clampText(typeof parsed.msg === "string" ? parsed.msg : "", 240) ?? "";
+		const context: Record<string, string | number | boolean | null> = {};
+		for (const [key, value] of Object.entries(parsed)) {
+			if (!SAFE_LOG_CONTEXT_KEYS.has(key) || key === "module" || key === "level") continue;
+			const safe = primitiveContextValue(value);
+			if (safe !== undefined) context[key] = safe;
+		}
+		return {
+			timestamp: typeof parsed.time === "string" ? parsed.time : null,
+			level,
+			component,
+			message,
+			context,
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function readTail(filePath: string, maxBytes = LOG_TAIL_BYTES): Promise<string> {
+	const handle = await fs.promises.open(filePath, "r");
+	try {
+		const stat = await handle.stat();
+		const start = Math.max(0, stat.size - maxBytes);
+		const length = stat.size - start;
+		const buf = Buffer.alloc(length);
+		await handle.read(buf, 0, length, start);
+		const text = buf.toString("utf8");
+		if (start === 0) return text;
+		const firstNewline = text.indexOf("\n");
+		return firstNewline >= 0 ? text.slice(firstNewline + 1) : text;
+	} finally {
+		await handle.close();
+	}
+}
+
+async function readLogEntries(options: {
+	limit: number;
+	component?: string;
+	level?: string;
+	minLevel?: string;
+}): Promise<DashboardLogEntry[]> {
+	const settings = getResolvedLoggerSettings();
+	let content = "";
+	try {
+		content = await readTail(settings.file);
+	} catch {
+		return [];
+	}
+	const minLevelValue = options.minLevel ? LOG_LEVEL_VALUES.get(options.minLevel) : undefined;
+	const entries = content
+		.split(/\r?\n/)
+		.filter(Boolean)
+		.map(parsePinoLine)
+		.filter((entry): entry is DashboardLogEntry => entry !== null)
+		.filter((entry) => {
+			if (options.component && entry.component !== options.component) return false;
+			if (options.level && entry.level !== options.level) return false;
+			if (minLevelValue !== undefined) {
+				const entryLevel = LOG_LEVEL_VALUES.get(entry.level) ?? 30;
+				if (entryLevel < minLevelValue) return false;
+			}
+			return true;
+		});
+	return entries.slice(-options.limit).reverse();
+}
+
+function summarizeConnector(name: string, connector: ConnectorHealth) {
+	return {
+		name,
+		status: connector.status,
+		lastSuccess: clampText(connector.lastSuccess, 80),
+		lastAttempt: clampText(connector.lastAttempt, 80),
+		failureCount: connector.failureCount ?? 0,
+		driftSignals: connector.driftSignals?.slice(0, 5).map((signal) => clampText(signal, 80) ?? ""),
+	};
+}
+
+function summarizeAlert(alert: HealthAlert) {
+	return {
+		level: alert.level,
+		connector: clampText(alert.connector, 80),
+		since: clampText(alert.since, 80),
+	};
+}
+
+function summarizeProvider(result: HealthCheckResult) {
+	const connectors = Object.entries(result.response?.connectors ?? {}).map(([name, connector]) =>
+		summarizeConnector(name, connector),
+	);
+	const alerts = (result.response?.alerts ?? []).map(summarizeAlert);
+	return {
+		id: result.providerId,
+		reachable: result.reachable,
+		status: result.response?.status ?? (result.reachable ? "unknown" : "unreachable"),
+		errorSummary: clampText(result.error),
+		failureCount:
+			(result.reachable ? 0 : 1) +
+			alerts.length +
+			connectors.filter((connector) => connector.status !== "ok").length,
+		connectors,
+		alerts,
+	};
+}
+
+async function readProviderTransitions(limit = 20) {
+	const entries = await readLogEntries({
+		limit: Math.min(limit * 4, MAX_LIMIT),
+		component: "provider-health",
+	});
+	return entries
+		.filter((entry) => /provider (healthy|not healthy|health check failed)/i.test(entry.message))
+		.slice(0, limit)
+		.map((entry) => ({
+			timestamp: entry.timestamp,
+			level: entry.level,
+			provider: entry.context.provider ?? entry.context.providerId ?? null,
+			status: entry.context.status ?? null,
+			message: entry.message,
+		}));
+}
+
+export async function registerOperatorRoutes(server: FastifyInstance): Promise<void> {
+	server.get("/api/operator/sessions-runs", async (request, reply) => {
+		try {
+			const query = request.query as QueryMap;
+			const limit = parseLimit(query.limit);
+			const cfg = loadConfig();
+			const sessions = collectSessionRows({ limit }).map(summarizeSession);
+			const auditLogger = createAuditLogger({
+				enabled: cfg.security?.audit?.enabled !== false,
+				logFile: cfg.security?.audit?.logFile,
+			});
+			const runs = (await auditLogger.readRecent(limit)).map(summarizeAuditRun).reverse();
+			return reply.send({ ok: true, sessions, runs });
+		} catch (err) {
+			logger.warn({ error: String(err) }, "operator sessions-runs failed");
+			return reply.status(500).send({ ok: false, error: "failed to load session summaries" });
+		}
+	});
+
+	server.get("/api/operator/logs", async (request, reply) => {
+		const query = request.query as QueryMap;
+		const component = query.component?.trim() || undefined;
+		const level = query.level?.trim() || undefined;
+		const minLevel = query.minLevel?.trim() || undefined;
+		const limit = parseLimit(query.limit, 100);
+		const entries = await readLogEntries({ limit, component, level, minLevel });
+		return reply.send({
+			ok: true,
+			filters: {
+				component: component ?? null,
+				level: level ?? null,
+				minLevel: minLevel ?? null,
+				limit,
+			},
+			entries,
+		});
+	});
+
+	server.get("/api/operator/background-jobs", async (request, reply) => {
+		try {
+			const query = request.query as QueryMap;
+			const limit = parseLimit(query.limit);
+			const statuses = parseStatuses(query.status);
+			const jobs = listJobs({ limit, ...(statuses ? { statuses } : {}) }).map(
+				summarizeBackgroundJob,
+			);
+			return reply.send({ ok: true, jobs });
+		} catch (err) {
+			logger.warn({ error: String(err) }, "operator background jobs failed");
+			return reply.status(500).send({ ok: false, error: "failed to load background jobs" });
+		}
+	});
+
+	server.post("/api/operator/background-jobs/:shortId/cancel", async (request, reply) => {
+		try {
+			const params = request.params as { shortId?: string };
+			const shortId = params.shortId?.trim();
+			if (!shortId) {
+				return reply.status(400).send({ ok: false, error: "missing job id" });
+			}
+			const existing = getJobByShortId(shortId);
+			if (!existing) {
+				return reply.status(404).send({ ok: false, error: "background job not found" });
+			}
+			const { transitioned, job } = cancelJob(existing.id);
+			return reply.send({
+				ok: true,
+				transitioned,
+				job: job ? summarizeBackgroundJob(job) : null,
+			});
+		} catch (err) {
+			logger.warn({ error: String(err) }, "operator background cancel failed");
+			return reply.status(500).send({ ok: false, error: "failed to cancel background job" });
+		}
+	});
+
+	server.get("/api/operator/cron", async (_request, reply) => {
+		try {
+			const cfg = loadConfig();
+			const jobs = listCronJobs({ includeDisabled: true }).map(summarizeCronJob);
+			return reply.send({
+				ok: true,
+				config: {
+					enabled: cfg.cron.enabled,
+					pollIntervalSeconds: cfg.cron.pollIntervalSeconds,
+					timeoutSeconds: cfg.cron.timeoutSeconds,
+				},
+				summary: getCronStatusSummary(),
+				coverage: getCronCoverage(),
+				jobs,
+			});
+		} catch (err) {
+			logger.warn({ error: String(err) }, "operator cron failed");
+			return reply.status(500).send({ ok: false, error: "failed to load cron jobs" });
+		}
+	});
+
+	server.get("/api/operator/social-queue", async (_request, reply) => {
+		try {
+			const cfg = loadConfig();
+			const pending = [
+				...getMemoryEntries({
+					categories: ["posts"],
+					trust: ["quarantined"],
+					sources: ["telegram"],
+					posted: false,
+					limit: 20,
+					order: "desc",
+				}),
+				...getMemoryEntries({
+					categories: ["posts"],
+					trust: ["untrusted"],
+					sources: ["social"],
+					posted: false,
+					limit: 20,
+					order: "desc",
+				}),
+			]
+				.sort((a, b) => b._provenance.createdAt - a._provenance.createdAt)
+				.slice(0, 20)
+				.map(summarizeQueueEntry);
+			const promoted = getMemoryEntries({
+				categories: ["posts"],
+				trust: ["trusted"],
+				sources: ["telegram", "social"],
+				promoted: true,
+				posted: false,
+				limit: 20,
+				order: "asc",
+			}).map(summarizeQueueEntry);
+			const services = (cfg.socialServices ?? []).map(summarizeSocialService);
+			const nextOperatorAction =
+				pending.length > 0
+					? "/social queue"
+					: promoted.length > 0
+						? "/social run"
+						: services.some((svc) => svc.enabled)
+							? "monitor"
+							: "configure socialServices";
+			return reply.send({
+				ok: true,
+				summary: {
+					pending: pending.length,
+					promoted: promoted.length,
+					enabledServices: services.filter((svc) => svc.enabled).length,
+				},
+				nextOperatorAction,
+				services,
+				pending,
+				promoted,
+			});
+		} catch (err) {
+			logger.warn({ error: String(err) }, "operator social queue failed");
+			return reply.status(500).send({ ok: false, error: "failed to load social queue" });
+		}
+	});
+
+	server.get("/api/operator/personas", async (_request, reply) => {
+		try {
+			const cfg = loadConfig();
+			const services = (cfg.socialServices ?? []).map(summarizeSocialService);
+			const personaSnapshot = await collectPersonaStatus({ config: cfg, probeAgents: false });
+			return reply.send({
+				ok: true,
+				securityProfile: cfg.security?.profile ?? "simple",
+				personaSnapshot,
+				privatePersona: {
+					...summarizePersonaForDashboard(
+						personaSnapshot.personas.private,
+						countIdentityEntries("telegram"),
+					),
+					heartbeatEnabled: cfg.telegram.heartbeat?.enabled ?? false,
+					heartbeatIntervalHours: cfg.telegram.heartbeat?.intervalHours ?? null,
+				},
+				socialPersona: summarizePersonaForDashboard(
+					personaSnapshot.personas.social,
+					countIdentityEntries("social"),
+					services,
+				),
+			});
+		} catch (err) {
+			logger.warn({ error: String(err) }, "operator personas failed");
+			return reply.status(500).send({ ok: false, error: "failed to load persona status" });
+		}
+	});
+
+	server.get("/api/operator/provider-health", async (_request, reply) => {
+		try {
+			const cfg = loadConfig();
+			const results = await Promise.all(
+				(cfg.providers ?? []).map((provider) => checkProviderHealth(provider.id, provider.baseUrl)),
+			);
+			const providers = results.map(summarizeProvider);
+			return reply.send({
+				ok: true,
+				providers,
+				transitions: await readProviderTransitions(),
+			});
+		} catch (err) {
+			logger.warn({ error: String(err) }, "operator provider health failed");
+			return reply.status(500).send({ ok: false, error: "failed to load provider health" });
+		}
+	});
+}

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -26,6 +26,7 @@ import { registerAuditRoute } from "./routes/audit.js";
 import { registerAuthRoutes } from "./routes/auth.js";
 import { registerDoctorRoute } from "./routes/doctor.js";
 import { registerHealthRoute } from "./routes/health.js";
+import { registerOperatorRoutes } from "./routes/operator.js";
 import { registerProvidersRoute } from "./routes/providers.js";
 import { registerSkillsRoute } from "./routes/skills.js";
 import { DASHBOARD_COOKIE_NAME, DashboardSessionStore } from "./sessions.js";
@@ -161,6 +162,7 @@ export async function buildDashboardServer(
 	await registerApprovalsRoute(server);
 	await registerAuditRoute(server);
 	await registerDoctorRoute(server);
+	await registerOperatorRoutes(server);
 
 	// ─── Static UI (shipped under assets/dashboard-ui/) ─────────────────────
 	const uiDir = path.resolve(__dirname, "..", "..", "assets", "dashboard-ui");

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ registerAgentCommand(program);
 registerStatusCommand(program);
 registerSendCommand(program);
 registerSessionsCommand(program);
+registerIntegrationTestCommand(program);
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Command groups (namespaced subcommands)

--- a/src/social/activity-log.ts
+++ b/src/social/activity-log.ts
@@ -12,7 +12,18 @@ import { getDb } from "../storage/db.js";
 const logger = getChildLogger({ module: "activity-log" });
 
 export type ActivityLogEntry = {
-	type: "notification" | "reply" | "post" | "autonomous";
+	type:
+		| "notification"
+		| "reply"
+		| "post"
+		| "autonomous"
+		| "drafted"
+		| "approved"
+		| "manual_action_needed"
+		| "posting_failed"
+		| "posted_via_api"
+		| "marked_posted"
+		| "dismissed";
 	timestamp: number;
 	serviceId: string;
 };

--- a/src/social/handler.ts
+++ b/src/social/handler.ts
@@ -19,7 +19,12 @@ import {
 import type { SocialServiceClient } from "./client.js";
 import { formatSocialContextForPrompt } from "./context.js";
 import { buildSocialIdentityPreamble } from "./identity.js";
-import { parseSocialQuoteProposalMetadata } from "./proposal-metadata.js";
+import {
+	getSocialDraft,
+	parseSocialQuoteProposalMetadata,
+	socialDraftMetadataForNewProposal,
+	updateSocialDraftText,
+} from "./proposal-metadata.js";
 import type {
 	SocialHandlerResult,
 	SocialNotification,
@@ -797,6 +802,95 @@ function extractJsonFromText(text: string): unknown {
 	return null;
 }
 
+function parseRefinedDraftOutput(raw: unknown): string | null {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		return null;
+	}
+	const obj = raw as Record<string, unknown>;
+	return typeof obj.content === "string" && obj.content.trim() ? obj.content.trim() : null;
+}
+
+export type RefineSocialDraftResult = { ok: true; content: string } | { ok: false; reason: string };
+
+export async function refineSocialDraftText(params: {
+	id: string;
+	instruction: string;
+	actor: string;
+	serviceId?: string;
+	allowedSkills?: string[];
+}): Promise<RefineSocialDraftResult> {
+	const draft = getSocialDraft(params.id);
+	if (!draft) {
+		return { ok: false, reason: "Draft not found" };
+	}
+	const instruction = params.instruction.trim();
+	if (!instruction) {
+		return { ok: false, reason: "Refinement instruction cannot be empty" };
+	}
+
+	const serviceId = params.serviceId ?? draft.metadata?.serviceId ?? "social";
+	let agentUrl: string;
+	try {
+		agentUrl = resolveAgentUrl(serviceId);
+	} catch (err) {
+		return { ok: false, reason: String(err) };
+	}
+
+	const bundle = buildSocialPromptBundle(
+		[
+			"[DRAFT REFINE REQUEST - TRUSTED OPERATOR]",
+			"Refine the draft below according to the operator instruction.",
+			"Return only one JSON object with a content string. Do not post publicly.",
+			"",
+			"[OPERATOR INSTRUCTION]",
+			sanitizeInlineContent(instruction),
+			"[END OPERATOR INSTRUCTION]",
+			"",
+			wrapExternalContent(draft.content, {
+				source: "social-context",
+				serviceId,
+				foldHomoglyphs: true,
+				includeRiskAssessment: true,
+			}),
+			"",
+			'Output format: {"content":"refined draft text"}',
+		].join("\n"),
+		serviceId,
+	);
+
+	const stream = executeRemoteQuery(bundle.prompt, {
+		agentUrl,
+		scope: "social",
+		cwd: resolveAgentWorkdir(serviceId),
+		tier: "SOCIAL",
+		poolKey: `${serviceId}:draft-refine:${draft.id}`,
+		userId: `social:${serviceId}:operator`,
+		enableSkills: true,
+		allowedSkills: params.allowedSkills,
+		systemPromptAppend: bundle.systemPromptAppend,
+		timeoutMs: Math.max(getDefaultTimeoutMs(serviceId), 300_000),
+	});
+	const queryResult = await collectResponseText(stream);
+	if (!queryResult.success) {
+		return { ok: false, reason: queryResult.error ?? "Draft refine query failed" };
+	}
+
+	const refined =
+		parseRefinedDraftOutput(queryResult.structuredOutput) ??
+		parseRefinedDraftOutput(extractJsonFromText(queryResult.text));
+	if (!refined) {
+		return { ok: false, reason: "Social persona did not return refined draft text" };
+	}
+
+	const updateResult = updateSocialDraftText({
+		id: draft.id,
+		text: refined,
+		actor: params.actor,
+		refined: true,
+	});
+	return updateResult.ok ? { ok: true, content: refined } : updateResult;
+}
+
 function parseAutonomousAction(structuredOutput: unknown): AutonomousAction | null {
 	if (
 		!structuredOutput ||
@@ -898,6 +992,7 @@ function truncateMetadataText(text: string, maxLength = 160): string {
 }
 
 function createSocialPostProposal(
+	serviceId: string,
 	action: "propose_post" | "quote",
 	content: string,
 	metadata?: Record<string, unknown>,
@@ -909,7 +1004,13 @@ function createSocialPostProposal(
 				id: `${prefix}-${crypto.randomUUID().slice(0, 12)}`,
 				category: "posts",
 				content,
-				...(metadata ? { metadata } : {}),
+				metadata: {
+					...socialDraftMetadataForNewProposal({
+						serviceId,
+						action: action === "quote" ? "quote" : "post",
+					}),
+					...(metadata ?? {}),
+				},
 			},
 		],
 		SOCIAL_MEMORY_SOURCE,
@@ -1496,7 +1597,7 @@ async function handleAutonomousActivity(
 	}
 
 	if (parsed.action === "propose_post") {
-		const entry = createSocialPostProposal("propose_post", parsed.content);
+		const entry = createSocialPostProposal(serviceId, "propose_post", parsed.content);
 		logger.info({ serviceId, entryId: entry.id }, "autonomous post proposal created");
 		return { acted: true, summary: `queued post proposal ${entry.id}` };
 	}
@@ -1624,7 +1725,7 @@ async function handleAutonomousActivity(
 	}
 
 	if (actionWithTarget.action === "quote") {
-		const entry = createSocialPostProposal("quote", actionWithTarget.body, {
+		const entry = createSocialPostProposal(serviceId, "quote", actionWithTarget.body, {
 			action: "quote",
 			targetPostId: target.id,
 			...(getTimelineAuthorLabel(target) ? { targetAuthor: getTimelineAuthorLabel(target) } : {}),

--- a/src/social/proposal-metadata.ts
+++ b/src/social/proposal-metadata.ts
@@ -1,3 +1,9 @@
+import type { MemorySource, TrustLevel } from "../memory/types.js";
+import { filterOutput } from "../security/output-filter.js";
+import { getDb } from "../storage/db.js";
+import { logSocialActivity } from "./activity-log.js";
+import type { SocialDraftStatus } from "./types.js";
+
 export type SocialQuoteProposalMetadata = {
 	action: "quote";
 	targetPostId: string;
@@ -5,14 +11,503 @@ export type SocialQuoteProposalMetadata = {
 	targetExcerpt?: string;
 };
 
+export type SocialDraftMetadata = {
+	action?: "post" | "quote" | "thread";
+	targetPostId?: string;
+	targetAuthor?: string;
+	targetExcerpt?: string;
+	draftState?: SocialDraftStatus;
+	draftWorkflow?: "workbench";
+	serviceId?: string;
+	targetUrl?: string;
+	manualActionReason?: string;
+	lastError?: string;
+	postedPostId?: string;
+	editedAt?: number;
+	editedBy?: string;
+	refinedAt?: number;
+	refinedBy?: string;
+	approvedAt?: number;
+	approvedBy?: string;
+	markedPostedAt?: number;
+	markedPostedBy?: string;
+	dismissedAt?: number;
+	dismissedBy?: string;
+};
+
+export type SocialDraftRecord = {
+	id: string;
+	category: string;
+	content: string;
+	metadata?: SocialDraftMetadata;
+	source: MemorySource;
+	trust: TrustLevel;
+	createdAt: number;
+	promotedAt?: number;
+	promotedBy?: string;
+	postedAt?: number;
+	chatId?: string;
+	status: SocialDraftStatus;
+};
+
+type SocialDraftRow = {
+	id: string;
+	category: string;
+	content: string;
+	metadata: string | null;
+	source: string;
+	trust: string;
+	created_at: number;
+	promoted_at: number | null;
+	promoted_by: string | null;
+	posted_at: number | null;
+	chat_id: string | null;
+};
+
+const SOCIAL_DRAFT_STATUSES: SocialDraftStatus[] = [
+	"queued",
+	"drafted",
+	"needs_review",
+	"manual_action_needed",
+	"posted_via_api",
+	"marked_posted",
+	"dismissed",
+	"failed",
+];
+
+const ACTIVE_DRAFT_STATUSES: SocialDraftStatus[] = [
+	"queued",
+	"drafted",
+	"needs_review",
+	"manual_action_needed",
+	"failed",
+];
+
+const MAX_DRAFT_TEXT_LENGTH = 4000;
+
+function isSocialDraftStatus(value: unknown): value is SocialDraftStatus {
+	return typeof value === "string" && SOCIAL_DRAFT_STATUSES.includes(value as SocialDraftStatus);
+}
+
+function parseMetadataObject(raw: unknown): Record<string, unknown> | undefined {
+	if (!raw) return undefined;
+	if (typeof raw === "string") {
+		try {
+			const parsed = JSON.parse(raw) as unknown;
+			return parseMetadataObject(parsed);
+		} catch {
+			return undefined;
+		}
+	}
+	if (typeof raw === "object" && !Array.isArray(raw)) {
+		return raw as Record<string, unknown>;
+	}
+	return undefined;
+}
+
+function normalizeMetadata(metadata: unknown): SocialDraftMetadata {
+	const parsed = parseMetadataObject(metadata);
+	if (!parsed) return {};
+	const normalized: SocialDraftMetadata = {};
+
+	if (parsed.action === "post" || parsed.action === "quote" || parsed.action === "thread") {
+		normalized.action = parsed.action;
+	}
+	if (isSocialDraftStatus(parsed.draftState)) {
+		normalized.draftState = parsed.draftState;
+	}
+	if (parsed.draftWorkflow === "workbench") {
+		normalized.draftWorkflow = "workbench";
+	}
+
+	for (const key of [
+		"targetPostId",
+		"targetAuthor",
+		"targetExcerpt",
+		"serviceId",
+		"targetUrl",
+		"manualActionReason",
+		"lastError",
+		"postedPostId",
+		"editedBy",
+		"refinedBy",
+		"approvedBy",
+		"markedPostedBy",
+		"dismissedBy",
+	] as const) {
+		const value = parsed[key];
+		if (typeof value === "string" && value.trim()) {
+			normalized[key] = value.trim();
+		}
+	}
+
+	for (const key of [
+		"editedAt",
+		"refinedAt",
+		"approvedAt",
+		"markedPostedAt",
+		"dismissedAt",
+	] as const) {
+		const value = parsed[key];
+		if (typeof value === "number" && Number.isFinite(value)) {
+			normalized[key] = value;
+		}
+	}
+
+	return normalized;
+}
+
+function serializeMetadata(metadata: SocialDraftMetadata): string {
+	return JSON.stringify(metadata);
+}
+
+function validateDraftText(text: string): string | null {
+	const trimmed = text.trim();
+	if (!trimmed) {
+		return "Draft text cannot be empty";
+	}
+	if (trimmed.length > MAX_DRAFT_TEXT_LENGTH) {
+		return `Draft text is too long (${MAX_DRAFT_TEXT_LENGTH} characters max)`;
+	}
+	const secretCheck = filterOutput(trimmed);
+	if (secretCheck.blocked) {
+		return "Draft text appears to contain a secret";
+	}
+	return null;
+}
+
+function rowToDraft(row: SocialDraftRow): SocialDraftRecord {
+	const metadata = normalizeMetadata(row.metadata);
+	const base = {
+		metadata,
+		_provenance: {
+			source: row.source as MemorySource,
+			trust: row.trust as TrustLevel,
+			createdAt: row.created_at,
+			...(row.promoted_at ? { promotedAt: row.promoted_at } : {}),
+			...(row.promoted_by ? { promotedBy: row.promoted_by } : {}),
+			...(row.posted_at ? { postedAt: row.posted_at } : {}),
+			...(row.chat_id ? { chatId: row.chat_id } : {}),
+		},
+	};
+
+	return {
+		id: row.id,
+		category: row.category,
+		content: row.content,
+		metadata,
+		source: row.source as MemorySource,
+		trust: row.trust as TrustLevel,
+		createdAt: row.created_at,
+		...(row.promoted_at ? { promotedAt: row.promoted_at } : {}),
+		...(row.promoted_by ? { promotedBy: row.promoted_by } : {}),
+		...(row.posted_at ? { postedAt: row.posted_at } : {}),
+		...(row.chat_id ? { chatId: row.chat_id } : {}),
+		status: resolveSocialDraftStatus(base),
+	};
+}
+
+function ensureDraftCanMutate(record: SocialDraftRecord): string | null {
+	if (record.category !== "posts") {
+		return "Only post drafts can be changed";
+	}
+	if (record.source !== "telegram" && record.source !== "social") {
+		return "Only telegram or social drafts can be changed";
+	}
+	if (record.status === "posted_via_api" || record.status === "marked_posted") {
+		return "Posted drafts cannot be changed";
+	}
+	if (record.status === "dismissed") {
+		return "Dismissed drafts cannot be changed";
+	}
+	return null;
+}
+
+function patchDraftMetadata(
+	id: string,
+	patch: SocialDraftMetadata,
+	options: { content?: string; postedAt?: number | null } = {},
+): SocialDraftRecord | null {
+	const current = getSocialDraft(id);
+	if (!current) return null;
+
+	const nextMetadata = {
+		...(current.metadata ?? {}),
+		...patch,
+	};
+	const db = getDb();
+	db.prepare(
+		`UPDATE memory_entries
+		 SET metadata = ?, content = COALESCE(?, content), posted_at = COALESCE(?, posted_at)
+		 WHERE id = ?`,
+	).run(serializeMetadata(nextMetadata), options.content ?? null, options.postedAt ?? null, id);
+	return getSocialDraft(id);
+}
+
+export function parseSocialDraftMetadata(metadata: unknown): SocialDraftMetadata {
+	return normalizeMetadata(metadata);
+}
+
+export function isActiveSocialDraftStatus(status: SocialDraftStatus): boolean {
+	return ACTIVE_DRAFT_STATUSES.includes(status);
+}
+
+export function resolveSocialDraftStatus(entry: {
+	metadata?: unknown;
+	_provenance?: { trust?: string; promotedAt?: number; postedAt?: number };
+}): SocialDraftStatus {
+	const metadata = normalizeMetadata(entry.metadata);
+	if (metadata.draftState) {
+		return metadata.draftState;
+	}
+	if (entry._provenance?.postedAt) {
+		return "posted_via_api";
+	}
+	if (entry._provenance?.trust === "trusted" && entry._provenance.promotedAt) {
+		return "queued";
+	}
+	return "drafted";
+}
+
+export function socialDraftMetadataForNewProposal(params: {
+	serviceId: string;
+	action?: "post" | "quote" | "thread";
+	targetPostId?: string;
+	targetAuthor?: string;
+	targetExcerpt?: string;
+	targetUrl?: string;
+}): SocialDraftMetadata {
+	return {
+		draftState: "drafted",
+		draftWorkflow: "workbench",
+		serviceId: params.serviceId,
+		action: params.action ?? "post",
+		...(params.targetPostId ? { targetPostId: params.targetPostId } : {}),
+		...(params.targetAuthor ? { targetAuthor: params.targetAuthor } : {}),
+		...(params.targetExcerpt ? { targetExcerpt: params.targetExcerpt } : {}),
+		...(params.targetUrl ? { targetUrl: params.targetUrl } : {}),
+	};
+}
+
+export function getSocialDraft(id: string): SocialDraftRecord | null {
+	const row = getDb()
+		.prepare(
+			`SELECT id, category, content, metadata, source, trust, created_at, promoted_at, promoted_by, posted_at, chat_id
+			 FROM memory_entries
+			 WHERE id = ?`,
+		)
+		.get(id) as SocialDraftRow | undefined;
+	return row ? rowToDraft(row) : null;
+}
+
+export type SocialDraftMutationResult =
+	| { ok: true; draft: SocialDraftRecord }
+	| { ok: false; reason: string };
+
+export function updateSocialDraftText(params: {
+	id: string;
+	text: string;
+	actor: string;
+	refined?: boolean;
+}): SocialDraftMutationResult {
+	const record = getSocialDraft(params.id);
+	if (!record) return { ok: false, reason: "Draft not found" };
+	const mutationError = ensureDraftCanMutate(record);
+	if (mutationError) return { ok: false, reason: mutationError };
+	const validationError = validateDraftText(params.text);
+	if (validationError) return { ok: false, reason: validationError };
+
+	const now = Date.now();
+	const draft = patchDraftMetadata(
+		params.id,
+		params.refined
+			? {
+					draftState: "needs_review",
+					draftWorkflow: "workbench",
+					refinedAt: now,
+					refinedBy: params.actor,
+					lastError: undefined,
+					manualActionReason: undefined,
+				}
+			: {
+					draftState: "needs_review",
+					draftWorkflow: "workbench",
+					editedAt: now,
+					editedBy: params.actor,
+					lastError: undefined,
+					manualActionReason: undefined,
+				},
+		{ content: params.text.trim() },
+	);
+	return draft ? { ok: true, draft } : { ok: false, reason: "Failed to update draft" };
+}
+
+export function markSocialDraftApproved(params: {
+	id: string;
+	actor: string;
+	serviceId?: string;
+}): SocialDraftMutationResult {
+	const record = getSocialDraft(params.id);
+	if (!record) return { ok: false, reason: "Draft not found" };
+	const mutationError = ensureDraftCanMutate(record);
+	if (mutationError) return { ok: false, reason: mutationError };
+
+	const now = Date.now();
+	const draft = patchDraftMetadata(params.id, {
+		draftState: "queued",
+		draftWorkflow: "workbench",
+		approvedAt: now,
+		approvedBy: params.actor,
+		...(params.serviceId ? { serviceId: params.serviceId } : {}),
+		lastError: undefined,
+		manualActionReason: undefined,
+	});
+	if (draft) {
+		logSocialActivity({
+			type: "approved",
+			timestamp: now,
+			serviceId: draft.metadata?.serviceId ?? params.serviceId ?? "social",
+		});
+		return { ok: true, draft };
+	}
+	return { ok: false, reason: "Failed to approve draft" };
+}
+
+export function markSocialDraftManualActionNeeded(params: {
+	id: string;
+	reason: string;
+	serviceId?: string;
+}): SocialDraftMutationResult {
+	const now = Date.now();
+	const draft = patchDraftMetadata(params.id, {
+		draftState: "manual_action_needed",
+		draftWorkflow: "workbench",
+		manualActionReason: params.reason,
+		lastError: params.reason,
+		...(params.serviceId ? { serviceId: params.serviceId } : {}),
+	});
+	if (draft) {
+		logSocialActivity({
+			type: "manual_action_needed",
+			timestamp: now,
+			serviceId: draft.metadata?.serviceId ?? params.serviceId ?? "social",
+		});
+		return { ok: true, draft };
+	}
+	return { ok: false, reason: "Draft not found" };
+}
+
+export function markSocialDraftPostingFailed(params: {
+	id: string;
+	error: string;
+	serviceId?: string;
+}): SocialDraftMutationResult {
+	const now = Date.now();
+	const draft = patchDraftMetadata(params.id, {
+		draftState: "failed",
+		draftWorkflow: "workbench",
+		lastError: params.error,
+		manualActionReason: undefined,
+		...(params.serviceId ? { serviceId: params.serviceId } : {}),
+	});
+	if (draft) {
+		logSocialActivity({
+			type: "posting_failed",
+			timestamp: now,
+			serviceId: draft.metadata?.serviceId ?? params.serviceId ?? "social",
+		});
+		return { ok: true, draft };
+	}
+	return { ok: false, reason: "Draft not found" };
+}
+
+export function markSocialDraftPostedViaApi(params: {
+	id: string;
+	serviceId?: string;
+	postId?: string;
+}): SocialDraftMutationResult {
+	const now = Date.now();
+	const draft = patchDraftMetadata(
+		params.id,
+		{
+			draftState: "posted_via_api",
+			draftWorkflow: "workbench",
+			...(params.serviceId ? { serviceId: params.serviceId } : {}),
+			...(params.postId ? { postedPostId: params.postId } : {}),
+			lastError: undefined,
+			manualActionReason: undefined,
+		},
+		{ postedAt: now },
+	);
+	if (draft) {
+		logSocialActivity({
+			type: "posted_via_api",
+			timestamp: now,
+			serviceId: draft.metadata?.serviceId ?? params.serviceId ?? "social",
+		});
+		return { ok: true, draft };
+	}
+	return { ok: false, reason: "Draft not found" };
+}
+
+export function markSocialDraftManuallyPosted(params: {
+	id: string;
+	actor: string;
+	serviceId?: string;
+}): SocialDraftMutationResult {
+	const now = Date.now();
+	const draft = patchDraftMetadata(
+		params.id,
+		{
+			draftState: "marked_posted",
+			draftWorkflow: "workbench",
+			markedPostedAt: now,
+			markedPostedBy: params.actor,
+			...(params.serviceId ? { serviceId: params.serviceId } : {}),
+			lastError: undefined,
+			manualActionReason: undefined,
+		},
+		{ postedAt: now },
+	);
+	if (draft) {
+		logSocialActivity({
+			type: "marked_posted",
+			timestamp: now,
+			serviceId: draft.metadata?.serviceId ?? params.serviceId ?? "social",
+		});
+		return { ok: true, draft };
+	}
+	return { ok: false, reason: "Draft not found" };
+}
+
+export function dismissSocialDraft(params: {
+	id: string;
+	actor: string;
+	serviceId?: string;
+}): SocialDraftMutationResult {
+	const now = Date.now();
+	const draft = patchDraftMetadata(params.id, {
+		draftState: "dismissed",
+		draftWorkflow: "workbench",
+		dismissedAt: now,
+		dismissedBy: params.actor,
+		...(params.serviceId ? { serviceId: params.serviceId } : {}),
+	});
+	if (draft) {
+		logSocialActivity({
+			type: "dismissed",
+			timestamp: now,
+			serviceId: draft.metadata?.serviceId ?? params.serviceId ?? "social",
+		});
+		return { ok: true, draft };
+	}
+	return { ok: false, reason: "Draft not found" };
+}
+
 export function parseSocialQuoteProposalMetadata(
 	metadata: unknown,
 ): SocialQuoteProposalMetadata | null {
-	if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-		return null;
-	}
-
-	const candidate = metadata as Record<string, unknown>;
+	const candidate = normalizeMetadata(metadata);
 	if (candidate.action !== "quote" || typeof candidate.targetPostId !== "string") {
 		return null;
 	}

--- a/src/social/types.ts
+++ b/src/social/types.ts
@@ -84,3 +84,13 @@ export type SocialPromptBundle = {
 	prompt: string;
 	systemPromptAppend: string;
 };
+
+export type SocialDraftStatus =
+	| "queued"
+	| "drafted"
+	| "needs_review"
+	| "manual_action_needed"
+	| "posted_via_api"
+	| "marked_posted"
+	| "dismissed"
+	| "failed";

--- a/src/status/personas.ts
+++ b/src/status/personas.ts
@@ -1,0 +1,894 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { listManagedPlugins, type PluginPersona } from "../commands/plugins.js";
+import { getAllSkillRoots } from "../commands/skill-path.js";
+import { loadConfig, type TelclaudeConfig } from "../config/config.js";
+import { listCronJobs } from "../cron/store.js";
+import type { CronJob } from "../cron/types.js";
+import { redactSecretsWithConfig } from "../security/output-filter.js";
+import { getDb } from "../storage/db.js";
+
+export type PersonaKind = "private" | "social";
+export type PersonaHealth = "ok" | "degraded" | "not_configured";
+export type AgentReachability = "reachable" | "unreachable" | "not_configured" | "unknown";
+export type SkillPolicy = "trusted_all_active" | "disabled" | "explicit_allowlist" | "fail_closed";
+
+export type PersonaAgentStatus = {
+	configured: boolean;
+	source: string;
+	endpoint: string | null;
+	reachability: AgentReachability;
+	checkedAt: string | null;
+	error: string | null;
+};
+
+export type PersonaProfileStatus = {
+	configured: boolean;
+	claudeHome: string | null;
+	source: string;
+};
+
+export type PersonaPluginStatus = {
+	configured: boolean;
+	enabled: string[];
+	installed: string[];
+	error: string | null;
+};
+
+export type PersonaSkillStatus = {
+	policy: SkillPolicy;
+	activeCatalog: string[];
+	effective: string[];
+	allowed: string[];
+	failClosed: boolean;
+	servicePolicies: Array<{
+		serviceId: string;
+		enabled: boolean;
+		enableSkills: boolean;
+		policy: SkillPolicy;
+		allowed: string[];
+		failClosed: boolean;
+	}>;
+};
+
+export type PersonaMemoryStatus = {
+	source: "telegram" | "social";
+	summary: string;
+	contentsExposed: false;
+};
+
+export type PersonaFilesystemStatus = {
+	workspace: "mounted" | "not_mounted";
+	summary: string;
+	mounts: string[];
+};
+
+export type PersonaProviderAccessStatus = {
+	summary: string;
+	providerIds: string[];
+	serviceIds: string[];
+	privateEndpointCount: number;
+	directProviderFetch: "blocked" | "not_applicable";
+	relayProxied: boolean;
+};
+
+export type PersonaOperationsStatus = {
+	lastHeartbeatAt: string | null;
+	lastSocialRunAt: string | null;
+	lastError: string | null;
+};
+
+export type PersonaStatus = {
+	persona: PersonaKind;
+	health: PersonaHealth;
+	summary: string;
+	profile: PersonaProfileStatus;
+	agent: PersonaAgentStatus;
+	modelProvider: {
+		claudeSdkModel: string;
+		sdkBetas: string[];
+		anthropicProxy: "configured" | "not_configured";
+		credentialProxy: "configured" | "not_configured";
+	};
+	skills: PersonaSkillStatus;
+	plugins: PersonaPluginStatus;
+	memory: PersonaMemoryStatus;
+	filesystem: PersonaFilesystemStatus;
+	providers: PersonaProviderAccessStatus;
+	operations: PersonaOperationsStatus;
+	boundaries: {
+		privateProcessesSocialMemory: false;
+		socialHasWorkspaceMount: boolean;
+		profileCloning: false;
+	};
+	services?: Array<{
+		id: string;
+		type: string;
+		enabled: boolean;
+		heartbeatEnabled: boolean;
+		agentConfigured: boolean;
+		agentSource: string;
+		enableSkills: boolean;
+		allowedSkills: string[];
+		skillFailClosed: boolean;
+	}>;
+};
+
+export type PersonaStatusSnapshot = {
+	collectedAt: string;
+	overallHealth: PersonaHealth;
+	issueCount: number;
+	personas: {
+		private: PersonaStatus;
+		social: PersonaStatus;
+	};
+};
+
+export type PersonaStatusBuildInput = {
+	config: TelclaudeConfig;
+	env?: NodeJS.ProcessEnv;
+	cwd?: string;
+	nowMs?: number;
+	activeSkillNames?: string[];
+	privatePlugins?: PersonaPluginStatus;
+	socialPlugins?: PersonaPluginStatus;
+	cronJobs?: CronJob[];
+	latestSocialActivityAtMs?: number | null;
+	agentReachability?: Partial<Record<PersonaKind, PersonaAgentStatus>>;
+};
+
+export type PersonaStatusCollectOptions = {
+	config?: TelclaudeConfig;
+	env?: NodeJS.ProcessEnv;
+	cwd?: string;
+	nowMs?: number;
+	probeAgents?: boolean;
+	probeTimeoutMs?: number;
+};
+
+type ProfileResolution = {
+	configured: boolean;
+	claudeHome: string | null;
+	source: string;
+};
+
+type AgentResolution = {
+	configured: boolean;
+	source: string;
+	url: string | null;
+};
+
+const DEFAULT_PRIVATE_AGENT_WORKDIR = "/workspace";
+const DEFAULT_SOCIAL_AGENT_WORKDIR = "/social/sandbox";
+
+function normalizeDir(raw: string): string {
+	return raw.replace(/[/\\]+$/, "");
+}
+
+function resolvePath(raw: string): string {
+	return normalizeDir(path.resolve(raw));
+}
+
+function resolvePrivateClaudeHome(env: NodeJS.ProcessEnv = process.env): ProfileResolution {
+	if (env.TELCLAUDE_PRIVATE_CLAUDE_HOME) {
+		return {
+			configured: true,
+			claudeHome: resolvePath(env.TELCLAUDE_PRIVATE_CLAUDE_HOME),
+			source: "TELCLAUDE_PRIVATE_CLAUDE_HOME",
+		};
+	}
+	if (env.CLAUDE_CONFIG_DIR) {
+		return {
+			configured: true,
+			claudeHome: resolvePath(env.CLAUDE_CONFIG_DIR),
+			source: "CLAUDE_CONFIG_DIR",
+		};
+	}
+	if (env.TELCLAUDE_CLAUDE_HOME) {
+		return {
+			configured: true,
+			claudeHome: resolvePath(env.TELCLAUDE_CLAUDE_HOME),
+			source: "TELCLAUDE_CLAUDE_HOME",
+		};
+	}
+	return {
+		configured: true,
+		claudeHome: normalizeDir(path.join(os.homedir(), ".claude")),
+		source: "default ~/.claude",
+	};
+}
+
+function resolveSocialClaudeHome(env: NodeJS.ProcessEnv = process.env): ProfileResolution {
+	if (!env.TELCLAUDE_SOCIAL_CLAUDE_HOME) {
+		return {
+			configured: false,
+			claudeHome: null,
+			source: "TELCLAUDE_SOCIAL_CLAUDE_HOME missing",
+		};
+	}
+	return {
+		configured: true,
+		claudeHome: resolvePath(env.TELCLAUDE_SOCIAL_CLAUDE_HOME),
+		source: "TELCLAUDE_SOCIAL_CLAUDE_HOME",
+	};
+}
+
+function serviceEnvKey(serviceId: string, suffix: string): string {
+	return `TELCLAUDE_${serviceId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_${suffix}`;
+}
+
+function resolvePrivateAgent(env: NodeJS.ProcessEnv = process.env): AgentResolution {
+	const url = env.TELCLAUDE_AGENT_URL ?? null;
+	return {
+		configured: Boolean(url),
+		source: url ? "TELCLAUDE_AGENT_URL" : "not configured",
+		url,
+	};
+}
+
+function resolveSocialAgentForService(
+	service: TelclaudeConfig["socialServices"][number],
+	env: NodeJS.ProcessEnv = process.env,
+): AgentResolution {
+	if (service.agentUrl) {
+		return { configured: true, source: "service config", url: service.agentUrl };
+	}
+	const perServiceKey = serviceEnvKey(service.id, "AGENT_URL");
+	if (env[perServiceKey]) {
+		return { configured: true, source: perServiceKey, url: env[perServiceKey] ?? null };
+	}
+	if (env.TELCLAUDE_SOCIAL_AGENT_URL) {
+		return {
+			configured: true,
+			source: "TELCLAUDE_SOCIAL_AGENT_URL",
+			url: env.TELCLAUDE_SOCIAL_AGENT_URL,
+		};
+	}
+	if (env.TELCLAUDE_AGENT_URL) {
+		return {
+			configured: true,
+			source: "TELCLAUDE_AGENT_URL fallback",
+			url: env.TELCLAUDE_AGENT_URL,
+		};
+	}
+	return { configured: false, source: "not configured", url: null };
+}
+
+function resolveSocialAgent(
+	config: TelclaudeConfig,
+	env: NodeJS.ProcessEnv = process.env,
+): AgentResolution {
+	const service = config.socialServices.find((entry) => entry.enabled) ?? config.socialServices[0];
+	if (service) {
+		return resolveSocialAgentForService(service, env);
+	}
+	if (env.TELCLAUDE_SOCIAL_AGENT_URL) {
+		return {
+			configured: true,
+			source: "TELCLAUDE_SOCIAL_AGENT_URL",
+			url: env.TELCLAUDE_SOCIAL_AGENT_URL,
+		};
+	}
+	return { configured: false, source: "not configured", url: null };
+}
+
+function summarizeEndpoint(url: string | null, config: TelclaudeConfig): string | null {
+	if (!url) return null;
+	try {
+		return new URL(url).origin;
+	} catch {
+		return redactSecretsWithConfig(url, config.security?.secretFilter);
+	}
+}
+
+function defaultAgentStatus(
+	resolution: AgentResolution,
+	config: TelclaudeConfig,
+): PersonaAgentStatus {
+	return {
+		configured: resolution.configured,
+		source: resolution.source,
+		endpoint: summarizeEndpoint(resolution.url, config),
+		reachability: resolution.configured ? "unknown" : "not_configured",
+		checkedAt: null,
+		error: null,
+	};
+}
+
+async function probeAgent(
+	resolution: AgentResolution,
+	nowMs: number,
+	timeoutMs: number,
+	config: TelclaudeConfig,
+): Promise<PersonaAgentStatus> {
+	if (!resolution.url) {
+		return defaultAgentStatus(resolution, config);
+	}
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const healthUrl = new URL("/health", resolution.url);
+		const response = await fetch(healthUrl, { signal: controller.signal });
+		return {
+			configured: true,
+			source: resolution.source,
+			endpoint: summarizeEndpoint(resolution.url, config),
+			reachability: response.ok ? "reachable" : "unreachable",
+			checkedAt: new Date(nowMs).toISOString(),
+			error: response.ok ? null : `health returned HTTP ${response.status}`,
+		};
+	} catch (err) {
+		return {
+			configured: true,
+			source: resolution.source,
+			endpoint: summarizeEndpoint(resolution.url, config),
+			reachability: "unreachable",
+			checkedAt: new Date(nowMs).toISOString(),
+			error: redactStatusText(String(err), config),
+		};
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function isSkillDirEntry(root: string, entry: fs.Dirent): boolean {
+	if (entry.name.startsWith(".")) return false;
+	if (entry.isDirectory()) return true;
+	if (!entry.isSymbolicLink()) return false;
+	try {
+		return fs.statSync(path.join(root, entry.name)).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function listActiveSkillNames(cwd: string): string[] {
+	const seen = new Set<string>();
+	for (const root of getAllSkillRoots(cwd)) {
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(root, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			if (isSkillDirEntry(root, entry) && fs.existsSync(path.join(root, entry.name, "SKILL.md"))) {
+				seen.add(entry.name);
+			}
+		}
+	}
+	return [...seen].sort((left, right) => left.localeCompare(right));
+}
+
+function collectPluginsForPersona(
+	persona: PluginPersona,
+	env: NodeJS.ProcessEnv,
+	config: TelclaudeConfig,
+): PersonaPluginStatus {
+	try {
+		const [entry] = listManagedPlugins({ persona, env });
+		if (!entry) {
+			return {
+				configured: false,
+				enabled: [],
+				installed: [],
+				error: `${persona} plugin profile not found`,
+			};
+		}
+		return {
+			configured: true,
+			enabled: entry.plugins
+				.filter((plugin) => plugin.enabled)
+				.map((plugin) => plugin.pluginId)
+				.sort((left, right) => left.localeCompare(right)),
+			installed: entry.plugins
+				.filter((plugin) => plugin.installed)
+				.map((plugin) => plugin.pluginId)
+				.sort((left, right) => left.localeCompare(right)),
+			error: null,
+		};
+	} catch (err) {
+		return {
+			configured: false,
+			enabled: [],
+			installed: [],
+			error: redactStatusText(err instanceof Error ? err.message : String(err), config),
+		};
+	}
+}
+
+function collectLatestSocialActivityAtMs(): number | null {
+	try {
+		const row = getDb()
+			.prepare("SELECT MAX(timestamp) AS last_run_at FROM social_activity_log")
+			.get() as { last_run_at: number | null } | undefined;
+		return row?.last_run_at ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function redactStatusText(text: string | null | undefined, config: TelclaudeConfig): string | null {
+	if (!text) return null;
+	return redactSecretsWithConfig(text, config.security?.secretFilter);
+}
+
+function isoOrNull(ms: number | null | undefined): string | null {
+	return typeof ms === "number" && Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+function latestCronJob(jobs: CronJob[], predicate: (job: CronJob) => boolean): CronJob | null {
+	return (
+		jobs
+			.filter(predicate)
+			.filter((job) => typeof job.lastRunAtMs === "number")
+			.sort((left, right) => (right.lastRunAtMs ?? 0) - (left.lastRunAtMs ?? 0))[0] ?? null
+	);
+}
+
+function latestCronError(
+	jobs: CronJob[],
+	predicate: (job: CronJob) => boolean,
+	config: TelclaudeConfig,
+): string | null {
+	const latest =
+		jobs
+			.filter(predicate)
+			.filter((job) => job.lastStatus === "error" && Boolean(job.lastError))
+			.sort((left, right) => (right.lastRunAtMs ?? 0) - (left.lastRunAtMs ?? 0))[0] ?? null;
+	return redactStatusText(latest?.lastError, config);
+}
+
+function providerAccessForPersona(
+	persona: PersonaKind,
+	config: TelclaudeConfig,
+): PersonaProviderAccessStatus {
+	const providerIds = config.providers.map((provider) => provider.id).sort();
+	const serviceIds = Array.from(
+		new Set(config.providers.flatMap((provider) => provider.services)),
+	).sort((left, right) => left.localeCompare(right));
+	const privateEndpointCount = config.security?.network?.privateEndpoints?.length ?? 0;
+	return {
+		summary:
+			providerIds.length === 0
+				? "no external providers configured"
+				: `${providerIds.length} provider(s), ${serviceIds.length} service id(s), relay metadata only`,
+		providerIds,
+		serviceIds,
+		privateEndpointCount,
+		directProviderFetch: persona === "private" ? "blocked" : "not_applicable",
+		relayProxied: providerIds.length > 0,
+	};
+}
+
+function buildPrivateSkills(activeCatalog: string[]): PersonaSkillStatus {
+	return {
+		policy: "trusted_all_active",
+		activeCatalog,
+		effective: activeCatalog,
+		allowed: [],
+		failClosed: false,
+		servicePolicies: [],
+	};
+}
+
+function socialServiceSkillPolicy(service: TelclaudeConfig["socialServices"][number]): {
+	policy: SkillPolicy;
+	allowed: string[];
+	failClosed: boolean;
+} {
+	if (!service.enableSkills) {
+		return { policy: "disabled", allowed: [], failClosed: false };
+	}
+	if (!service.allowedSkills) {
+		return { policy: "fail_closed", allowed: [], failClosed: true };
+	}
+	return {
+		policy: "explicit_allowlist",
+		allowed: [...service.allowedSkills].sort((left, right) => left.localeCompare(right)),
+		failClosed: false,
+	};
+}
+
+function buildSocialSkills(
+	config: TelclaudeConfig,
+	activeCatalog: string[],
+	socialProfileConfigured: boolean,
+): PersonaSkillStatus {
+	const servicePolicies = config.socialServices.map((service) => {
+		const policy = socialServiceSkillPolicy(service);
+		return {
+			serviceId: service.id,
+			enabled: service.enabled,
+			enableSkills: service.enableSkills,
+			...policy,
+		};
+	});
+	const allowed = Array.from(new Set(servicePolicies.flatMap((policy) => policy.allowed))).sort(
+		(left, right) => left.localeCompare(right),
+	);
+	const failClosed =
+		!socialProfileConfigured || servicePolicies.some((policy) => policy.failClosed);
+	const anySkillsEnabled = servicePolicies.some((policy) => policy.enableSkills);
+	const policy: SkillPolicy = failClosed
+		? "fail_closed"
+		: anySkillsEnabled
+			? "explicit_allowlist"
+			: "disabled";
+
+	return {
+		policy,
+		activeCatalog,
+		effective: policy === "explicit_allowlist" ? allowed : [],
+		allowed,
+		failClosed,
+		servicePolicies,
+	};
+}
+
+function buildModelProviderStatus(config: TelclaudeConfig, env: NodeJS.ProcessEnv) {
+	return {
+		claudeSdkModel: "SDK default",
+		sdkBetas: config.sdk?.betas ?? [],
+		anthropicProxy:
+			env.ANTHROPIC_BASE_URL || env.ANTHROPIC_AUTH_TOKEN ? "configured" : "not_configured",
+		credentialProxy: env.TELCLAUDE_CREDENTIAL_PROXY_URL ? "configured" : "not_configured",
+	} as PersonaStatus["modelProvider"];
+}
+
+function buildPrivateFilesystem(env: NodeJS.ProcessEnv, cwd: string): PersonaFilesystemStatus {
+	const workspace =
+		env.TELCLAUDE_AGENT_WORKDIR ?? (env.WORKSPACE_PATH ? DEFAULT_PRIVATE_AGENT_WORKDIR : cwd);
+	const mounts = [
+		`workspace:${workspace}:rw`,
+		env.TELCLAUDE_MEDIA_INBOX_DIR ? "media-inbox:configured" : "media-inbox:default/unknown",
+		env.TELCLAUDE_MEDIA_OUTBOX_DIR ? "media-outbox:configured" : "media-outbox:default/unknown",
+	];
+	return {
+		workspace: "mounted",
+		summary: "workspace and media volumes available to private persona",
+		mounts,
+	};
+}
+
+function buildSocialFilesystem(env: NodeJS.ProcessEnv): PersonaFilesystemStatus {
+	const sandbox = env.TELCLAUDE_SOCIAL_AGENT_WORKDIR ?? DEFAULT_SOCIAL_AGENT_WORKDIR;
+	return {
+		workspace: "not_mounted",
+		summary: "no workspace mount; isolated social sandbox only",
+		mounts: [
+			`social-sandbox:${sandbox}:rw`,
+			env.TELCLAUDE_SKILL_CATALOG_DIR
+				? "skill-catalog:configured:ro"
+				: "skill-catalog:default/unknown:ro",
+		],
+	};
+}
+
+function socialServicesStatus(config: TelclaudeConfig, env: NodeJS.ProcessEnv) {
+	return config.socialServices.map((service) => {
+		const agent = resolveSocialAgentForService(service, env);
+		const skillPolicy = socialServiceSkillPolicy(service);
+		return {
+			id: service.id,
+			type: service.type,
+			enabled: service.enabled,
+			heartbeatEnabled: service.heartbeatEnabled,
+			agentConfigured: agent.configured,
+			agentSource: agent.source,
+			enableSkills: service.enableSkills,
+			allowedSkills: skillPolicy.allowed,
+			skillFailClosed: skillPolicy.failClosed,
+		};
+	});
+}
+
+function chooseOverallHealth(
+	privateStatus: PersonaStatus,
+	socialStatus: PersonaStatus,
+): PersonaHealth {
+	if (privateStatus.health === "not_configured" || socialStatus.health === "not_configured") {
+		return "not_configured";
+	}
+	if (privateStatus.health === "degraded" || socialStatus.health === "degraded") {
+		return "degraded";
+	}
+	return "ok";
+}
+
+function countIssues(statuses: PersonaStatus[]): number {
+	return statuses.filter((status) => status.health !== "ok").length;
+}
+
+function summarizePrivate(status: {
+	agent: PersonaAgentStatus;
+	plugins: PersonaPluginStatus;
+}): string {
+	if (status.agent.reachability === "unreachable") return "private agent unreachable";
+	if (status.plugins.error) return "private plugin metadata has errors";
+	return "private persona metadata healthy";
+}
+
+function summarizeSocial(status: {
+	profile: PersonaProfileStatus;
+	agent: PersonaAgentStatus;
+	skills: PersonaSkillStatus;
+	plugins: PersonaPluginStatus;
+}): string {
+	if (!status.profile.configured) return "social profile is not configured; fail-closed";
+	if (status.agent.reachability === "unreachable") return "social agent unreachable";
+	if (status.skills.failClosed) return "social skills are fail-closed";
+	if (status.plugins.error) return "social plugin metadata has errors";
+	return "social persona metadata healthy";
+}
+
+function privateHealth(agent: PersonaAgentStatus, plugins: PersonaPluginStatus): PersonaHealth {
+	if (agent.reachability === "unreachable" || plugins.error) return "degraded";
+	return "ok";
+}
+
+function socialHealth(
+	profile: PersonaProfileStatus,
+	agent: PersonaAgentStatus,
+	skills: PersonaSkillStatus,
+	plugins: PersonaPluginStatus,
+): PersonaHealth {
+	if (!profile.configured) return "not_configured";
+	if (agent.reachability === "unreachable" || skills.failClosed || plugins.error) return "degraded";
+	return "ok";
+}
+
+export function buildPersonaStatusSnapshot(input: PersonaStatusBuildInput): PersonaStatusSnapshot {
+	const env = input.env ?? process.env;
+	const cwd = input.cwd ?? process.cwd();
+	const nowMs = input.nowMs ?? Date.now();
+	const config = input.config;
+	const activeSkillNames = input.activeSkillNames ?? [];
+	const cronJobs = input.cronJobs ?? [];
+	const privateProfile = resolvePrivateClaudeHome(env);
+	const socialProfile = resolveSocialClaudeHome(env);
+
+	const privateAgentResolution = resolvePrivateAgent(env);
+	const socialAgentResolution = resolveSocialAgent(config, env);
+	const privateAgent =
+		input.agentReachability?.private ?? defaultAgentStatus(privateAgentResolution, config);
+	const socialAgent =
+		input.agentReachability?.social ?? defaultAgentStatus(socialAgentResolution, config);
+	const privatePlugins = input.privatePlugins ?? collectPluginsForPersona("private", env, config);
+	const socialPlugins =
+		input.socialPlugins ??
+		(socialProfile.configured
+			? collectPluginsForPersona("social", env, config)
+			: {
+					configured: false,
+					enabled: [],
+					installed: [],
+					error: "TELCLAUDE_SOCIAL_CLAUDE_HOME is not configured",
+				});
+	const privateSkills = buildPrivateSkills(activeSkillNames);
+	const socialSkills = buildSocialSkills(config, activeSkillNames, socialProfile.configured);
+
+	const privateHeartbeat = latestCronJob(
+		cronJobs,
+		(job) => job.action.kind === "private-heartbeat",
+	);
+	const socialHeartbeat = latestCronJob(cronJobs, (job) => job.action.kind === "social-heartbeat");
+	const privateStatusBase = {
+		profile: privateProfile,
+		agent: privateAgent,
+		plugins: privatePlugins,
+	};
+	const socialStatusBase = {
+		profile: socialProfile,
+		agent: socialAgent,
+		skills: socialSkills,
+		plugins: socialPlugins,
+	};
+
+	const privateStatus: PersonaStatus = {
+		persona: "private",
+		health: privateHealth(privateAgent, privatePlugins),
+		summary: summarizePrivate(privateStatusBase),
+		profile: privateProfile,
+		agent: privateAgent,
+		modelProvider: buildModelProviderStatus(config, env),
+		skills: privateSkills,
+		plugins: privatePlugins,
+		memory: {
+			source: "telegram",
+			summary: "telegram semantic memory plus private episodic archive; contents not included",
+			contentsExposed: false,
+		},
+		filesystem: buildPrivateFilesystem(env, cwd),
+		providers: providerAccessForPersona("private", config),
+		operations: {
+			lastHeartbeatAt: isoOrNull(privateHeartbeat?.lastRunAtMs),
+			lastSocialRunAt: null,
+			lastError: latestCronError(
+				cronJobs,
+				(job) => job.action.kind === "private-heartbeat",
+				config,
+			),
+		},
+		boundaries: {
+			privateProcessesSocialMemory: false,
+			socialHasWorkspaceMount: false,
+			profileCloning: false,
+		},
+	};
+
+	const socialFilesystem = buildSocialFilesystem(env);
+	const socialStatus: PersonaStatus = {
+		persona: "social",
+		health: socialHealth(socialProfile, socialAgent, socialSkills, socialPlugins),
+		summary: summarizeSocial(socialStatusBase),
+		profile: socialProfile,
+		agent: socialAgent,
+		modelProvider: buildModelProviderStatus(config, env),
+		skills: socialSkills,
+		plugins: socialPlugins,
+		memory: {
+			source: "social",
+			summary: "public social memory only; contents not included",
+			contentsExposed: false,
+		},
+		filesystem: socialFilesystem,
+		providers: providerAccessForPersona("social", config),
+		operations: {
+			lastHeartbeatAt: isoOrNull(socialHeartbeat?.lastRunAtMs),
+			lastSocialRunAt: isoOrNull(input.latestSocialActivityAtMs),
+			lastError: latestCronError(cronJobs, (job) => job.action.kind === "social-heartbeat", config),
+		},
+		boundaries: {
+			privateProcessesSocialMemory: false,
+			socialHasWorkspaceMount: socialFilesystem.workspace === "mounted",
+			profileCloning: false,
+		},
+		services: socialServicesStatus(config, env),
+	};
+
+	const statuses = [privateStatus, socialStatus];
+	return {
+		collectedAt: new Date(nowMs).toISOString(),
+		overallHealth: chooseOverallHealth(privateStatus, socialStatus),
+		issueCount: countIssues(statuses),
+		personas: {
+			private: privateStatus,
+			social: socialStatus,
+		},
+	};
+}
+
+export async function collectPersonaStatus(
+	options: PersonaStatusCollectOptions = {},
+): Promise<PersonaStatusSnapshot> {
+	const config = options.config ?? loadConfig();
+	const env = options.env ?? process.env;
+	const cwd = options.cwd ?? process.cwd();
+	const nowMs = options.nowMs ?? Date.now();
+	const privateAgentResolution = resolvePrivateAgent(env);
+	const socialAgentResolution = resolveSocialAgent(config, env);
+	let agentReachability: Partial<Record<PersonaKind, PersonaAgentStatus>> | undefined;
+
+	if (options.probeAgents !== false) {
+		const timeoutMs = options.probeTimeoutMs ?? 1500;
+		const [privateAgent, socialAgent] = await Promise.all([
+			probeAgent(privateAgentResolution, nowMs, timeoutMs, config),
+			probeAgent(socialAgentResolution, nowMs, timeoutMs, config),
+		]);
+		agentReachability = { private: privateAgent, social: socialAgent };
+	}
+
+	let cronJobs: CronJob[] = [];
+	try {
+		cronJobs = listCronJobs({ includeDisabled: true });
+	} catch {
+		cronJobs = [];
+	}
+
+	return buildPersonaStatusSnapshot({
+		config,
+		env,
+		cwd,
+		nowMs,
+		activeSkillNames: listActiveSkillNames(cwd),
+		cronJobs,
+		latestSocialActivityAtMs: collectLatestSocialActivityAtMs(),
+		agentReachability,
+	});
+}
+
+function formatList(values: string[], emptyLabel: string, limit = 8): string {
+	if (values.length === 0) return emptyLabel;
+	const shown = values.slice(0, limit).join(", ");
+	const remaining = values.length - limit;
+	return remaining > 0 ? `${shown}, +${remaining} more` : shown;
+}
+
+function formatAgent(agent: PersonaAgentStatus): string {
+	const suffix = agent.error ? `; error=${agent.error}` : "";
+	const endpoint = agent.endpoint ? `; endpoint=${agent.endpoint}` : "";
+	return `${agent.reachability} via ${agent.source}${endpoint}${suffix}`;
+}
+
+function formatProfile(profile: PersonaProfileStatus): string {
+	return profile.claudeHome ? `${profile.claudeHome} (${profile.source})` : profile.source;
+}
+
+function formatOperations(ops: PersonaOperationsStatus): string {
+	const parts = [
+		`heartbeat=${ops.lastHeartbeatAt ?? "never"}`,
+		...(ops.lastSocialRunAt ? [`social-run=${ops.lastSocialRunAt}`] : []),
+		...(ops.lastError ? [`last-error=${ops.lastError}`] : []),
+	];
+	return parts.join("; ");
+}
+
+function formatPersona(status: PersonaStatus): string[] {
+	const indent = "  ";
+	const lines = [
+		`${status.persona}: ${status.health} (${status.summary})`,
+		`${indent}Claude home: ${formatProfile(status.profile)}`,
+		`${indent}Agent: ${formatAgent(status.agent)}`,
+		`${indent}Model/provider: model=${status.modelProvider.claudeSdkModel}; betas=${
+			status.modelProvider.sdkBetas.length ? status.modelProvider.sdkBetas.join(",") : "none"
+		}; anthropicProxy=${status.modelProvider.anthropicProxy}; credentialProxy=${
+			status.modelProvider.credentialProxy
+		}`,
+		`${indent}Memory: source=${status.memory.source}; contents=hidden; ${status.memory.summary}`,
+		`${indent}Filesystem: ${status.filesystem.summary}; mounts=${formatList(
+			status.filesystem.mounts,
+			"none",
+		)}`,
+		`${indent}Skills: policy=${status.skills.policy}; effective=${formatList(
+			status.skills.effective,
+			"none",
+		)}; catalog=${status.skills.activeCatalog.length}`,
+		`${indent}Plugins: enabled=${formatList(status.plugins.enabled, "none")}; installed=${
+			status.plugins.installed.length
+		}${status.plugins.error ? `; error=${status.plugins.error}` : ""}`,
+		`${indent}Providers: ${status.providers.summary}; ids=${formatList(
+			status.providers.providerIds,
+			"none",
+		)}; directFetch=${status.providers.directProviderFetch}`,
+		`${indent}Operations: ${formatOperations(status.operations)}`,
+		`${indent}Boundaries: privateProcessesSocialMemory=${
+			status.boundaries.privateProcessesSocialMemory
+		}; socialHasWorkspaceMount=${status.boundaries.socialHasWorkspaceMount}; profileCloning=${
+			status.boundaries.profileCloning
+		}`,
+	];
+	if (status.services && status.services.length > 0) {
+		lines.push(
+			`${indent}Services: ${status.services
+				.map((service) => {
+					const skillState = service.skillFailClosed
+						? "skills=fail-closed"
+						: service.enableSkills
+							? `skills=${service.allowedSkills.length}`
+							: "skills=disabled";
+					return `${service.id}:${service.enabled ? "enabled" : "disabled"}:${skillState}:agent=${
+						service.agentConfigured ? service.agentSource : "not configured"
+					}`;
+				})
+				.join("; ")}`,
+		);
+	}
+	return lines;
+}
+
+export function formatPersonaStatusSnapshot(
+	snapshot: PersonaStatusSnapshot,
+	_options: { telegram?: boolean } = {},
+): string {
+	const lines = [
+		`Personas: ${snapshot.overallHealth} (${snapshot.issueCount} issue${
+			snapshot.issueCount === 1 ? "" : "s"
+		})`,
+		...formatPersona(snapshot.personas.private),
+		...formatPersona(snapshot.personas.social),
+	];
+	return lines.join("\n");
+}

--- a/src/telegram/auto-reply.ts
+++ b/src/telegram/auto-reply.ts
@@ -95,6 +95,7 @@ import {
 	setHomeTargetCommand,
 	startSkillsNewWizard,
 	startSocialAskWizard,
+	stopActiveWorkCommand,
 } from "./control-command-actions.js";
 import {
 	formatTelegramCommandCatalog,
@@ -857,6 +858,14 @@ async function dispatchTelegramControlCommand(
 			await setHomeTargetCommand(bot.api, {
 				chatId: msg.chatId,
 				threadId: msg.messageThreadId,
+			});
+			return true;
+		}
+		case "stop": {
+			await stopActiveWorkCommand(bot.api, {
+				chatId: msg.chatId,
+				threadId: msg.messageThreadId,
+				shortId: match.args[0]?.trim(),
 			});
 			return true;
 		}

--- a/src/telegram/cards/callback-controller.ts
+++ b/src/telegram/cards/callback-controller.ts
@@ -12,6 +12,9 @@ import { type CardInstance, type CardKind, type CardRenderer, parseCardAction } 
 
 const logger = getChildLogger({ module: "telegram-card-callbacks" });
 const CALLBACK_ACK_TIMEOUT_MS = 1_500;
+const CARD_NOT_FOUND_MESSAGE = "Card not found. Run the command again.";
+const CARD_EXPIRED_MESSAGE = "Card expired. Run the command again.";
+const CARD_OUTDATED_MESSAGE = "Card outdated. Use the latest card.";
 
 const CARD_KIND_TO_TIER: Record<CardKind, PermissionTier> = {
 	Approval: "FULL_ACCESS",
@@ -184,7 +187,7 @@ export async function handleCallback(
 
 	const card = getCardByShortId(token.shortId);
 	if (!card) {
-		await ctx.answerCallbackQuery({ text: "Card not found", show_alert: true });
+		await ctx.answerCallbackQuery({ text: CARD_NOT_FOUND_MESSAGE, show_alert: true });
 		await logCallbackAudit(options.auditLogger, {
 			shortId: token.shortId,
 			action: token.action,
@@ -285,7 +288,7 @@ export async function handleCallback(
 		const expiredCard =
 			card.status === "expired" ? card : (markCardExpired(card) ?? getCard(card.cardId) ?? card);
 		await renderCardMessage(ctx, expiredCard, renderer);
-		await ctx.answerCallbackQuery({ text: "Card expired", show_alert: true });
+		await ctx.answerCallbackQuery({ text: CARD_EXPIRED_MESSAGE, show_alert: true });
 		await logCallbackAudit(options.auditLogger, {
 			card: expiredCard,
 			shortId: token.shortId,
@@ -301,7 +304,7 @@ export async function handleCallback(
 
 	if (card.status === "superseded") {
 		await renderCardMessage(ctx, card, renderer);
-		await ctx.answerCallbackQuery({ text: "Card outdated", show_alert: true });
+		await ctx.answerCallbackQuery({ text: CARD_OUTDATED_MESSAGE, show_alert: true });
 		await logCallbackAudit(options.auditLogger, {
 			card,
 			shortId: token.shortId,
@@ -317,7 +320,7 @@ export async function handleCallback(
 
 	if (card.revision !== token.revision) {
 		await renderCardMessage(ctx, card, renderer);
-		await ctx.answerCallbackQuery({ text: "Card outdated", show_alert: true });
+		await ctx.answerCallbackQuery({ text: CARD_OUTDATED_MESSAGE, show_alert: true });
 		await logCallbackAudit(options.auditLogger, {
 			card,
 			shortId: token.shortId,
@@ -338,7 +341,7 @@ export async function handleCallback(
 		const currentCard = getCard(card.cardId) ?? card;
 		const handleRevisionConflict = async (latestCard: CardInstance): Promise<void> => {
 			await renderCardMessage(ctx, latestCard, renderer);
-			await responder.answer({ text: "Card outdated", show_alert: true });
+			await responder.answer({ text: CARD_OUTDATED_MESSAGE, show_alert: true });
 			await logCallbackAudit(options.auditLogger, {
 				card: latestCard,
 				shortId: token.shortId,
@@ -369,7 +372,7 @@ export async function handleCallback(
 
 		if (currentCard.status === "superseded" || currentCard.revision !== card.revision) {
 			await renderCardMessage(ctx, currentCard, renderer);
-			await responder.answer({ text: "Card outdated", show_alert: true });
+			await responder.answer({ text: CARD_OUTDATED_MESSAGE, show_alert: true });
 			await logCallbackAudit(options.auditLogger, {
 				card: currentCard,
 				shortId: token.shortId,
@@ -391,7 +394,7 @@ export async function handleCallback(
 						getCard(currentCard.cardId) ??
 						currentCard);
 			await renderCardMessage(ctx, expiredCard, renderer);
-			await responder.answer({ text: "Card expired", show_alert: true });
+			await responder.answer({ text: CARD_EXPIRED_MESSAGE, show_alert: true });
 			await logCallbackAudit(options.auditLogger, {
 				card: expiredCard,
 				shortId: token.shortId,

--- a/src/telegram/cards/create-helpers.ts
+++ b/src/telegram/cards/create-helpers.ts
@@ -44,6 +44,7 @@ import type {
 	SkillPickerCardState,
 	SkillReviewCardState,
 	SkillsMenuCardState,
+	SocialDraftListEntry,
 	SocialMenuCardState,
 	StatusCardState,
 	SystemHealthCardState,
@@ -318,7 +319,7 @@ export async function sendPendingQueueCard(
 	api: Api,
 	chatId: number,
 	opts: {
-		entries: CardListEntry[];
+		entries: SocialDraftListEntry[];
 		actorScope: CardActorScope;
 		threadId?: number;
 	},

--- a/src/telegram/cards/renderers/background-job.ts
+++ b/src/telegram/cards/renderers/background-job.ts
@@ -37,6 +37,25 @@ function statusIcon(status: BackgroundJobCardState["status"]): string {
 	}
 }
 
+function statusLabel(status: BackgroundJobCardState["status"]): string {
+	switch (status) {
+		case "queued":
+			return "Queued";
+		case "running":
+			return "Running";
+		case "completed":
+			return "Done";
+		case "failed":
+			return "Failed";
+		case "cancelled":
+			return "Cancelled";
+		case "interrupted":
+			return "Interrupted";
+		default:
+			return "Unknown";
+	}
+}
+
 function isTerminalState(status: BackgroundJobCardState["status"]): boolean {
 	return (
 		status === "completed" ||
@@ -58,7 +77,7 @@ export const backgroundJobRenderer: CardRenderer<K> = {
 		const icon = statusIcon(s.status);
 		let text = `${icon} *${esc(s.title)}*`;
 
-		text += `\n\n*Status:* ${esc(s.status)}`;
+		text += `\n\n*Status:* ${esc(statusLabel(s.status))}`;
 		text += `\n*Job:* \`${esc(s.shortId)}\` \\(${esc(s.payloadKind)}\\)`;
 
 		if (s.description) {
@@ -129,7 +148,7 @@ export const backgroundJobRenderer: CardRenderer<K> = {
 						status: isTerminalState(job.status as BackgroundJobCardState["status"])
 							? "consumed"
 							: undefined,
-						callbackText: `Already ${job.status}`,
+						callbackText: `Already ${statusLabel(job.status as BackgroundJobCardState["status"])}`,
 						rerender: true,
 					};
 				}
@@ -171,7 +190,7 @@ export const backgroundJobRenderer: CardRenderer<K> = {
 				return {
 					state: nextState,
 					status: isTerminalState(nextState.status) ? "consumed" : undefined,
-					callbackText: `Status: ${latest.status}`,
+					callbackText: `Status: ${statusLabel(nextState.status)}`,
 					rerender: true,
 				};
 			}
@@ -199,7 +218,7 @@ export const backgroundJobListRenderer: CardRenderer<LK> = {
 		} else {
 			for (const entry of s.entries.slice(0, 10)) {
 				text += `\n${statusIcon(entry.status)} \`${esc(entry.shortId)}\` — ${esc(entry.label)}`;
-				text += `\n  _${esc(entry.status)} · ${esc(formatAge(entry.createdAtMs))}_`;
+				text += `\n  _${esc(statusLabel(entry.status))} · ${esc(formatAge(entry.createdAtMs))}_`;
 			}
 		}
 

--- a/src/telegram/cards/renderers/pending-queue.ts
+++ b/src/telegram/cards/renderers/pending-queue.ts
@@ -1,23 +1,39 @@
-import { deleteEntry, getEntries, promoteEntryTrust } from "../../../memory/store.js";
-import { parseSocialQuoteProposalMetadata } from "../../../social/proposal-metadata.js";
+import { getEntries, promoteEntryTrust } from "../../../memory/store.js";
+import {
+	dismissSocialDraft,
+	getSocialDraft,
+	isActiveSocialDraftStatus,
+	markSocialDraftApproved,
+	markSocialDraftManuallyPosted,
+	parseSocialDraftMetadata,
+	parseSocialQuoteProposalMetadata,
+	resolveSocialDraftStatus,
+	updateSocialDraftText,
+} from "../../../social/proposal-metadata.js";
+import {
+	createWizardPrompter,
+	WizardCancelledError,
+	WizardTimeoutError,
+} from "../../wizard/index.js";
 import type {
 	CardExecutionContext,
 	CardExecutionResult,
 	CardInstance,
 	CardKind,
-	CardListEntry,
 	CardRenderer,
 	CardRenderResult,
 	PendingQueueCardAction,
 	PendingQueueCardState,
+	SocialDraftListEntry,
 } from "../types.js";
 import { btn, esc, keyboard, renderTerminalState } from "./helpers.js";
 
 type K = typeof CardKind.PendingQueue;
 
 const PAGE_SIZE = 4;
+const MAX_DRAFT_TEXT_LENGTH = 4000;
 
-function pageSlice(entries: { id: string; label: string; summary?: string }[], page: number) {
+function pageSlice(entries: SocialDraftListEntry[], page: number) {
 	const start = page * PAGE_SIZE;
 	return entries.slice(start, start + PAGE_SIZE);
 }
@@ -32,44 +48,409 @@ function clampPage(page: number, total: number): number {
 	return Math.min(page, maxPage);
 }
 
+function draftStatusLabel(status: SocialDraftListEntry["status"]): string {
+	switch (status) {
+		case "queued":
+			return "Ready";
+		case "drafted":
+			return "Drafted";
+		case "needs_review":
+			return "Needs review";
+		case "manual_action_needed":
+			return "Manual action";
+		case "posted_via_api":
+			return "Posted via API";
+		case "marked_posted":
+			return "Marked posted";
+		case "dismissed":
+			return "Dismissed";
+		case "failed":
+			return "Failed";
+	}
+}
+
+function draftBadge(status: SocialDraftListEntry["status"]): string {
+	switch (status) {
+		case "queued":
+			return "READY";
+		case "drafted":
+			return "DRAFT";
+		case "needs_review":
+			return "REVIEW";
+		case "manual_action_needed":
+			return "MANUAL";
+		case "failed":
+			return "FAILED";
+		case "posted_via_api":
+			return "POSTED";
+		case "marked_posted":
+			return "POSTED";
+		case "dismissed":
+			return "DISMISSED";
+	}
+}
+
+function formatAgeLabel(createdAt: number): string {
+	const age = Math.max(0, Math.round((Date.now() - createdAt) / 60000));
+	if (age < 60) return `${age}m ago`;
+	return `${Math.round(age / 60)}h ago`;
+}
+
+function previewText(content: string, maxLength: number): string {
+	const collapsed = content.replace(/\s+/g, " ").trim();
+	if (collapsed.length <= maxLength) return collapsed;
+	return `${collapsed.slice(0, maxLength - 3)}...`;
+}
+
+function normalizeUrl(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	try {
+		const url = new URL(value);
+		if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+		return url.toString();
+	} catch {
+		return undefined;
+	}
+}
+
+function entryFromDraftId(id: string): SocialDraftListEntry | null {
+	const draft = getSocialDraft(id);
+	if (!draft) return null;
+	const metadata = parseSocialDraftMetadata(draft.metadata);
+	const status = draft.status;
+	return {
+		id: draft.id,
+		label: `"${previewText(draft.content, 60)}" - ${formatAgeLabel(draft.createdAt)}`,
+		status,
+		source: draft.source,
+		ageLabel: formatAgeLabel(draft.createdAt),
+		draftText: draft.content,
+		...(metadata.serviceId ? { serviceId: metadata.serviceId } : {}),
+		...(metadata.targetPostId ? { targetPostId: metadata.targetPostId } : {}),
+		...(metadata.targetAuthor ? { targetAuthor: metadata.targetAuthor } : {}),
+		...(metadata.targetExcerpt ? { targetExcerpt: metadata.targetExcerpt } : {}),
+		...(normalizeUrl(metadata.targetUrl) ? { targetUrl: normalizeUrl(metadata.targetUrl) } : {}),
+		...(metadata.manualActionReason ? { manualActionReason: metadata.manualActionReason } : {}),
+		...(metadata.lastError ? { lastError: metadata.lastError } : {}),
+		...(metadata.postedPostId ? { postedPostId: metadata.postedPostId } : {}),
+		approved: Boolean(draft.promotedAt && draft.trust === "trusted"),
+		canRetryApi: status === "failed" || status === "manual_action_needed",
+	};
+}
+
+function refreshEntries(chatId: number | string): SocialDraftListEntry[] {
+	return loadPendingQueueEntries(String(chatId));
+}
+
+function replaceEntry(
+	entries: SocialDraftListEntry[],
+	nextEntry: SocialDraftListEntry | null,
+	targetId: string,
+): SocialDraftListEntry[] {
+	if (!nextEntry || !isActiveSocialDraftStatus(nextEntry.status)) {
+		return entries.filter((entry) => entry.id !== targetId);
+	}
+	return entries.map((entry) => (entry.id === targetId ? nextEntry : entry));
+}
+
+function selectedEntry(s: PendingQueueCardState): SocialDraftListEntry | undefined {
+	return s.entries.find((entry) => entry.id === s.selectedEntryId);
+}
+
+function firstVisibleEntry(s: PendingQueueCardState): SocialDraftListEntry | undefined {
+	return pageSlice(s.entries, s.page ?? 0)[0];
+}
+
+function selectedOrFirstVisible(s: PendingQueueCardState): SocialDraftListEntry | undefined {
+	return selectedEntry(s) ?? firstVisibleEntry(s);
+}
+
+function renderList(card: CardInstance<K>, s: PendingQueueCardState): CardRenderResult {
+	const page = s.page ?? 0;
+	const entries = s.entries;
+	const total = s.total ?? entries.length;
+	const pages = totalPages(total);
+	const visible = pageSlice(entries, page);
+
+	let text = `📋 *${esc(s.title)}*\n`;
+
+	if (visible.length === 0) {
+		text += `\n_No pending entries_`;
+	} else {
+		for (let i = 0; i < visible.length; i++) {
+			const entry = visible[i];
+			const marker = i === 0 ? "▶" : "•";
+			text += `\n${marker} *${esc(entry.label)}*`;
+			text += `\n  ${esc(`[${draftBadge(entry.status)}] ${entry.source}${entry.serviceId ? `/${entry.serviceId}` : ""}`)}`;
+			if (entry.summary) {
+				text += `\n  ${esc(entry.summary)}`;
+			}
+		}
+	}
+
+	if (pages > 1) {
+		text += `\n\n_Page ${page + 1}/${pages}_`;
+	}
+
+	const kb = keyboard();
+	if (visible.length > 0) {
+		kb.text("View ▶", btn(card, "view"))
+			.text("Approve ▶", btn(card, "promote"))
+			.row()
+			.text("Dismiss ▶", btn(card, "dismiss"))
+			.text("Refresh", btn(card, "refresh"))
+			.row();
+	}
+
+	if (page > 0) {
+		kb.text("◀ Prev", btn(card, "prev"));
+	}
+	if (page < pages - 1) {
+		kb.text("Next ▶", btn(card, "next"));
+	}
+
+	if (visible.length === 0) {
+		kb.text("Refresh", btn(card, "refresh"));
+	}
+
+	return { text, parseMode: "MarkdownV2", keyboard: kb };
+}
+
+function renderDetail(card: CardInstance<K>, s: PendingQueueCardState): CardRenderResult {
+	const entry = selectedEntry(s);
+	if (!entry) {
+		return renderList(card, { ...s, view: "list", selectedEntryId: undefined });
+	}
+
+	let text = `📝 *${esc(s.title)}*\n\n`;
+	text += `*${esc(draftStatusLabel(entry.status))}* · ${esc(entry.source)} · ${esc(entry.ageLabel)}`;
+	if (entry.serviceId) {
+		text += `\nService: \`${esc(entry.serviceId)}\``;
+	}
+	if (entry.targetPostId || entry.targetAuthor) {
+		text += `\nTarget: ${esc([entry.targetAuthor, entry.targetPostId].filter(Boolean).join(" "))}`;
+	}
+	if (entry.targetExcerpt) {
+		text += `\nSource: ${esc(previewText(entry.targetExcerpt, 140))}`;
+	}
+	if (entry.manualActionReason) {
+		text += `\n\n*Manual action needed:* ${esc(entry.manualActionReason)}`;
+	}
+	if (entry.lastError && entry.lastError !== entry.manualActionReason) {
+		text += `\n\n*Last error:* ${esc(entry.lastError)}`;
+	}
+	if (entry.postedPostId) {
+		text += `\n\nPosted id: \`${esc(entry.postedPostId)}\``;
+	}
+
+	text += `\n\n*Copy-ready text:*\n\`\`\`\n${esc(entry.draftText)}\n\`\`\``;
+
+	const kb = keyboard();
+	kb.text("Edit", btn(card, "edit")).text("Refine", btn(card, "refine")).row();
+	if (entry.status !== "queued") {
+		kb.text("Approve", btn(card, "promote"));
+	}
+	if (entry.canRetryApi) {
+		kb.text("Retry API", btn(card, "retry-api"));
+	}
+	kb.row().text("Mark posted", btn(card, "mark-posted")).text("Dismiss", btn(card, "dismiss"));
+	if (entry.targetUrl) {
+		kb.row().url("Open target", entry.targetUrl);
+	}
+	kb.row().text("Back", btn(card, "back")).text("Refresh", btn(card, "refresh"));
+
+	return { text, parseMode: "MarkdownV2", keyboard: kb };
+}
+
 /**
  * Load pending queue entries from memory store.
  * Shared between the initial `/social queue` command and the card's refresh action.
  */
-export function loadPendingQueueEntries(chatId?: string): CardListEntry[] {
-	const telegramPending = getEntries({
+export function loadPendingQueueEntries(chatId?: string): SocialDraftListEntry[] {
+	const entries = getEntries({
 		categories: ["posts"],
-		trust: ["quarantined"],
-		sources: ["telegram"],
-		...(chatId ? { chatId } : {}),
-		limit: 20,
+		sources: ["telegram", "social"],
+		posted: false,
+		limit: 100,
 		order: "desc",
 	});
-	const socialPending = getEntries({
-		categories: ["posts"],
-		trust: ["untrusted"],
-		sources: ["social"],
-		limit: 20,
-		order: "desc",
-	});
-	const merged = [...telegramPending, ...socialPending]
-		.sort((a, b) => b._provenance.createdAt - a._provenance.createdAt)
-		.slice(0, 20);
 
-	return merged.map((entry) => {
-		const age = Math.round((Date.now() - entry._provenance.createdAt) / 60000);
-		const ageStr = age < 60 ? `${age}m ago` : `${Math.round(age / 60)}h ago`;
-		const preview = entry.content.length > 60 ? `${entry.content.slice(0, 60)}...` : entry.content;
-		const quoteMetadata = parseSocialQuoteProposalMetadata(entry.metadata);
-		const summary = quoteMetadata
-			? `quote${quoteMetadata.targetAuthor ? ` ${quoteMetadata.targetAuthor}` : ""}${
-					quoteMetadata.targetExcerpt
-						? `: "${quoteMetadata.targetExcerpt.slice(0, 40)}${quoteMetadata.targetExcerpt.length > 40 ? "..." : ""}"`
-						: ""
-				}`
-			: undefined;
-		return { id: entry.id, label: `"${preview}" — ${ageStr}`, summary };
+	return entries
+		.filter((entry) => {
+			const source = entry._provenance.source;
+			if (source === "telegram" && chatId && entry._provenance.chatId !== chatId) {
+				return false;
+			}
+			if (source === "telegram" && entry._provenance.trust !== "quarantined") {
+				return Boolean(entry._provenance.promotedAt);
+			}
+			if (source === "social" && entry._provenance.trust !== "untrusted") {
+				return Boolean(entry._provenance.promotedAt);
+			}
+			return true;
+		})
+		.map((entry) => {
+			const status = resolveSocialDraftStatus(entry);
+			const metadata = parseSocialDraftMetadata(entry.metadata);
+			const quoteMetadata = parseSocialQuoteProposalMetadata(entry.metadata);
+			const summary = quoteMetadata
+				? `quote${quoteMetadata.targetAuthor ? ` ${quoteMetadata.targetAuthor}` : ""}${
+						quoteMetadata.targetExcerpt ? `: "${previewText(quoteMetadata.targetExcerpt, 40)}"` : ""
+					}`
+				: metadata.action === "thread"
+					? "thread draft"
+					: undefined;
+			return {
+				id: entry.id,
+				label: `"${previewText(entry.content, 60)}" - ${formatAgeLabel(entry._provenance.createdAt)}`,
+				...(summary ? { summary } : {}),
+				status,
+				source: entry._provenance.source,
+				ageLabel: formatAgeLabel(entry._provenance.createdAt),
+				draftText: entry.content,
+				...(metadata.serviceId ? { serviceId: metadata.serviceId } : {}),
+				...(metadata.targetPostId ? { targetPostId: metadata.targetPostId } : {}),
+				...(metadata.targetAuthor ? { targetAuthor: metadata.targetAuthor } : {}),
+				...(metadata.targetExcerpt ? { targetExcerpt: metadata.targetExcerpt } : {}),
+				...(normalizeUrl(metadata.targetUrl)
+					? { targetUrl: normalizeUrl(metadata.targetUrl) }
+					: {}),
+				...(metadata.manualActionReason ? { manualActionReason: metadata.manualActionReason } : {}),
+				...(metadata.lastError ? { lastError: metadata.lastError } : {}),
+				...(metadata.postedPostId ? { postedPostId: metadata.postedPostId } : {}),
+				approved: Boolean(entry._provenance.promotedAt && entry._provenance.trust === "trusted"),
+				canRetryApi: status === "failed" || status === "manual_action_needed",
+			};
+		})
+		.filter((entry) => isActiveSocialDraftStatus(entry.status))
+		.sort((a, b) => {
+			const statusRank = (status: SocialDraftListEntry["status"]) =>
+				status === "manual_action_needed"
+					? 0
+					: status === "failed"
+						? 1
+						: status === "needs_review"
+							? 2
+							: status === "drafted"
+								? 3
+								: 4;
+			return statusRank(a.status) - statusRank(b.status);
+		})
+		.slice(0, 20);
+}
+
+async function runEditDraftFlow(
+	context: CardExecutionContext<K>,
+	entry: SocialDraftListEntry,
+): Promise<void> {
+	const wizard = createWizardPrompter({
+		api: context.ctx.api,
+		actorId: context.ctx.from.id,
+		chatId: context.card.chatId,
+		threadId: context.card.threadId,
 	});
+	try {
+		const text = await wizard.text({
+			message: `Send edited draft text for ${entry.id}:`,
+			placeholder: entry.draftText,
+			validate: (value) => {
+				const trimmed = value.trim();
+				if (!trimmed) return "Draft text cannot be empty.";
+				if (trimmed.length > MAX_DRAFT_TEXT_LENGTH) return "Draft text is too long.";
+				return undefined;
+			},
+		});
+		const actor = `telegram:${context.card.chatId}:${context.ctx.from.id}`;
+		const result = updateSocialDraftText({ id: entry.id, text, actor });
+		await context.ctx.api.sendMessage(
+			context.card.chatId,
+			result.ok
+				? `Draft ${entry.id} updated. Tap Refresh.`
+				: `Draft update failed: ${result.reason}`,
+			context.card.threadId === undefined
+				? {}
+				: {
+						message_thread_id: context.card.threadId,
+					},
+		);
+	} catch (error) {
+		if (error instanceof WizardTimeoutError || error instanceof WizardCancelledError) {
+			return;
+		}
+		await context.ctx.api.sendMessage(
+			context.card.chatId,
+			`Draft edit failed: ${String(error)}`,
+			context.card.threadId === undefined
+				? {}
+				: {
+						message_thread_id: context.card.threadId,
+					},
+		);
+	} finally {
+		await wizard.dismiss().catch(() => {});
+	}
+}
+
+async function runRefineDraftFlow(
+	context: CardExecutionContext<K>,
+	entry: SocialDraftListEntry,
+): Promise<void> {
+	const wizard = createWizardPrompter({
+		api: context.ctx.api,
+		actorId: context.ctx.from.id,
+		chatId: context.card.chatId,
+		threadId: context.card.threadId,
+	});
+	try {
+		const instruction = await wizard.text({
+			message: `Send refinement instruction for ${entry.id}:`,
+			placeholder: "make it sharper, shorter, more concrete",
+			validate: (value) => (value.trim() ? undefined : "Instruction cannot be empty."),
+		});
+		await context.ctx.api.sendMessage(
+			context.card.chatId,
+			`Refining ${entry.id}...`,
+			context.card.threadId === undefined
+				? {}
+				: {
+						message_thread_id: context.card.threadId,
+					},
+		);
+		const { refineSocialDraftText } = await import("../../../social/handler.js");
+		const actor = `telegram:${context.card.chatId}:${context.ctx.from.id}`;
+		const result = await refineSocialDraftText({
+			id: entry.id,
+			instruction: instruction.trim(),
+			actor,
+			serviceId: entry.serviceId,
+		});
+		await context.ctx.api.sendMessage(
+			context.card.chatId,
+			result.ok
+				? `Draft ${entry.id} refined. Tap Refresh.`
+				: `Draft refine failed: ${result.reason}`,
+			context.card.threadId === undefined
+				? {}
+				: {
+						message_thread_id: context.card.threadId,
+					},
+		);
+	} catch (error) {
+		if (error instanceof WizardTimeoutError || error instanceof WizardCancelledError) {
+			return;
+		}
+		await context.ctx.api.sendMessage(
+			context.card.chatId,
+			`Draft refine failed: ${String(error)}`,
+			context.card.threadId === undefined
+				? {}
+				: {
+						message_thread_id: context.card.threadId,
+					},
+		);
+	} finally {
+		await wizard.dismiss().catch(() => {});
+	}
 }
 
 export const pendingQueueRenderer: CardRenderer<K> = {
@@ -79,54 +460,7 @@ export const pendingQueueRenderer: CardRenderer<K> = {
 		const terminal = renderTerminalState(card, s.title);
 		if (terminal) return terminal;
 
-		const page = s.page ?? 0;
-		const entries = s.entries;
-		const total = s.total ?? entries.length;
-		const pages = totalPages(total);
-		const visible = pageSlice(entries, page);
-
-		let text = `\uD83D\uDCCB *${esc(s.title)}*\n`;
-
-		if (visible.length === 0) {
-			text += `\n_No pending entries_`;
-		} else {
-			for (let i = 0; i < visible.length; i++) {
-				const entry = visible[i];
-				const marker = i === 0 ? "\u25B6" : "\u2022";
-				text += `\n${marker} *${esc(entry.label)}*`;
-				if (entry.summary) {
-					text += `\n  ${esc(entry.summary)}`;
-				}
-			}
-		}
-
-		if (pages > 1) {
-			text += `\n\n_Page ${page + 1}/${pages}_`;
-		}
-
-		const kb = keyboard();
-
-		// Action buttons act on ▶ marked entry (first on page)
-		if (visible.length > 0) {
-			kb.text("\u2B06 Promote \u25B6", btn(card, "promote")).text(
-				"\uD83D\uDDD1 Dismiss \u25B6",
-				btn(card, "dismiss"),
-			);
-			kb.row();
-		}
-
-		// Pagination buttons
-		if (page > 0) {
-			kb.text("\u25C0 Prev", btn(card, "prev"));
-		}
-		if (page < pages - 1) {
-			kb.text("Next \u25B6", btn(card, "next"));
-		}
-
-		// Refresh always available
-		kb.row().text("\uD83D\uDD04 Refresh", btn(card, "refresh"));
-
-		return { text, parseMode: "MarkdownV2", keyboard: kb };
+		return s.view === "detail" ? renderDetail(card, s) : renderList(card, s);
 	},
 
 	reduce(card: CardInstance<K>, action: PendingQueueCardAction): PendingQueueCardState {
@@ -136,18 +470,34 @@ export const pendingQueueRenderer: CardRenderer<K> = {
 		const currentPage = s.page ?? 0;
 
 		switch (action.type) {
-			case "next":
-				return { ...s, page: Math.min(currentPage + 1, pages - 1), selectedEntryId: undefined };
-			case "prev":
-				return { ...s, page: Math.max(currentPage - 1, 0), selectedEntryId: undefined };
-			case "promote": {
-				// Select first visible entry if none selected
+			case "view": {
 				const visible = pageSlice(s.entries, currentPage);
-				return { ...s, selectedEntryId: visible[0]?.id };
+				return { ...s, view: "detail", selectedEntryId: visible[0]?.id };
 			}
-			case "dismiss": {
-				const visible = pageSlice(s.entries, currentPage);
-				return { ...s, selectedEntryId: visible[0]?.id };
+			case "back":
+				return { ...s, view: "list", selectedEntryId: undefined };
+			case "next":
+				return {
+					...s,
+					view: "list",
+					page: Math.min(currentPage + 1, pages - 1),
+					selectedEntryId: undefined,
+				};
+			case "prev":
+				return {
+					...s,
+					view: "list",
+					page: Math.max(currentPage - 1, 0),
+					selectedEntryId: undefined,
+				};
+			case "promote":
+			case "dismiss":
+			case "edit":
+			case "refine":
+			case "mark-posted":
+			case "retry-api": {
+				const target = selectedOrFirstVisible(s);
+				return { ...s, selectedEntryId: target?.id };
 			}
 			case "refresh":
 				return s;
@@ -158,47 +508,85 @@ export const pendingQueueRenderer: CardRenderer<K> = {
 		const { action, card, ctx } = context;
 		const s = card.state;
 		const currentPage = s.page ?? 0;
-		const visible = pageSlice(s.entries, currentPage);
-		const targetId = s.selectedEntryId ?? visible[0]?.id;
-		const promotedBy = `telegram:${card.chatId}:${ctx.from.id}`;
+		const target = selectedOrFirstVisible(s);
+		const actor = `telegram:${card.chatId}:${ctx.from.id}`;
 
 		switch (action.type) {
+			case "view": {
+				const visible = pageSlice(s.entries, currentPage);
+				if (!visible[0]) {
+					return { callbackText: "No draft to view", callbackAlert: true };
+				}
+				return {
+					state: { ...s, view: "detail", selectedEntryId: visible[0].id },
+					callbackText: "Opened draft",
+					rerender: true,
+				};
+			}
+
+			case "back":
+				return {
+					state: { ...s, view: "list", selectedEntryId: undefined },
+					callbackText: "Back to queue",
+					rerender: true,
+				};
+
 			case "promote": {
-				if (!targetId) {
-					return { callbackText: "No entry to promote", callbackAlert: true };
+				if (!target) {
+					return { callbackText: "No draft to approve", callbackAlert: true };
 				}
-				const result = promoteEntryTrust(targetId, promotedBy);
-				if (!result.ok) {
-					return { callbackText: result.reason, callbackAlert: true };
+
+				const current = getSocialDraft(target.id);
+				if (!current) {
+					return { callbackText: "Draft not found", callbackAlert: true };
 				}
-				const remaining = s.entries.filter((e) => e.id !== targetId);
-				const newTotal = (s.total ?? s.entries.length) - 1;
+				if (!(current.trust === "trusted" && current.promotedAt)) {
+					const promoteResult = promoteEntryTrust(target.id, actor);
+					if (!promoteResult.ok) {
+						return { callbackText: promoteResult.reason, callbackAlert: true };
+					}
+				}
+
+				const approved = markSocialDraftApproved({
+					id: target.id,
+					actor,
+					serviceId: target.serviceId,
+				});
+				if (!approved.ok) {
+					return { callbackText: approved.reason, callbackAlert: true };
+				}
+				const nextEntry = entryFromDraftId(target.id);
+				const nextEntries = replaceEntry(s.entries, nextEntry, target.id);
 				return {
 					state: {
 						...s,
-						entries: remaining,
-						total: newTotal,
-						page: clampPage(currentPage, newTotal),
-						selectedEntryId: undefined,
+						entries: nextEntries,
+						total: nextEntries.length,
+						page: clampPage(currentPage, nextEntries.length),
+						view: s.view === "detail" ? "detail" : "list",
+						selectedEntryId: nextEntry?.id,
 					},
-					callbackText: "Promoted",
+					callbackText: "Approved",
 					rerender: true,
 				};
 			}
 
 			case "dismiss": {
-				if (!targetId) {
-					return { callbackText: "No entry to dismiss", callbackAlert: true };
+				if (!target) {
+					return { callbackText: "No draft to dismiss", callbackAlert: true };
 				}
-				deleteEntry(targetId);
-				const remaining = s.entries.filter((e) => e.id !== targetId);
-				const newTotal = (s.total ?? s.entries.length) - 1;
+				const result = dismissSocialDraft({ id: target.id, actor, serviceId: target.serviceId });
+				if (!result.ok) {
+					return { callbackText: result.reason, callbackAlert: true };
+				}
+				const nextEntries = s.entries.filter((entry) => entry.id !== target.id);
 				return {
 					state: {
 						...s,
-						entries: remaining,
-						total: newTotal,
-						page: clampPage(currentPage, newTotal),
+						entries: nextEntries,
+						total: nextEntries.length,
+						page: clampPage(currentPage, nextEntries.length),
+						view: "list",
 						selectedEntryId: undefined,
 					},
 					callbackText: "Dismissed",
@@ -206,10 +594,101 @@ export const pendingQueueRenderer: CardRenderer<K> = {
 				};
 			}
 
+			case "mark-posted": {
+				if (!target) {
+					return { callbackText: "No draft to mark posted", callbackAlert: true };
+				}
+				const result = markSocialDraftManuallyPosted({
+					id: target.id,
+					actor,
+					serviceId: target.serviceId,
+				});
+				if (!result.ok) {
+					return { callbackText: result.reason, callbackAlert: true };
+				}
+				const nextEntries = s.entries.filter((entry) => entry.id !== target.id);
+				return {
+					state: {
+						...s,
+						entries: nextEntries,
+						total: nextEntries.length,
+						page: clampPage(currentPage, nextEntries.length),
+						view: "list",
+						selectedEntryId: undefined,
+					},
+					callbackText: "Marked posted",
+					rerender: true,
+				};
+			}
+
+			case "edit": {
+				if (!target) {
+					return { callbackText: "No draft to edit", callbackAlert: true };
+				}
+				return {
+					state: { ...s, selectedEntryId: target.id },
+					callbackText: "Reply with edited text",
+					rerender: false,
+					afterCommit: () => runEditDraftFlow(context, target),
+				};
+			}
+
+			case "refine": {
+				if (!target) {
+					return { callbackText: "No draft to refine", callbackAlert: true };
+				}
+				return {
+					state: { ...s, selectedEntryId: target.id },
+					callbackText: "Reply with refinement instruction",
+					rerender: false,
+					afterCommit: () => runRefineDraftFlow(context, target),
+				};
+			}
+
+			case "retry-api":
+				if (!target) {
+					return { callbackText: "No draft to retry", callbackAlert: true };
+				}
+				{
+					const current = getSocialDraft(target.id);
+					if (!current) {
+						return { callbackText: "Draft not found", callbackAlert: true };
+					}
+					if (!(current.trust === "trusted" && current.promotedAt)) {
+						const promoteResult = promoteEntryTrust(target.id, actor);
+						if (!promoteResult.ok) {
+							return { callbackText: promoteResult.reason, callbackAlert: true };
+						}
+					}
+					const approved = markSocialDraftApproved({
+						id: target.id,
+						actor,
+						serviceId: target.serviceId,
+					});
+					if (!approved.ok) {
+						return { callbackText: approved.reason, callbackAlert: true };
+					}
+					const nextEntry = entryFromDraftId(target.id);
+					const nextEntries = replaceEntry(s.entries, nextEntry, target.id);
+					return {
+						state: {
+							...s,
+							entries: nextEntries,
+							total: nextEntries.length,
+							page: clampPage(currentPage, nextEntries.length),
+							view: s.view === "detail" ? "detail" : "list",
+							selectedEntryId: nextEntry?.id,
+						},
+						callbackText: "Queued for API retry",
+						rerender: true,
+					};
+				}
+
 			case "next":
 				return {
 					state: {
 						...s,
+						view: "list",
 						page: Math.min(currentPage + 1, totalPages(s.total ?? s.entries.length) - 1),
 						selectedEntryId: undefined,
 					},
@@ -221,6 +700,7 @@ export const pendingQueueRenderer: CardRenderer<K> = {
 				return {
 					state: {
 						...s,
+						view: "list",
 						page: Math.max(currentPage - 1, 0),
 						selectedEntryId: undefined,
 					},
@@ -229,14 +709,19 @@ export const pendingQueueRenderer: CardRenderer<K> = {
 				};
 
 			case "refresh": {
-				const refreshedEntries = loadPendingQueueEntries(String(card.chatId));
+				const refreshedEntries = refreshEntries(card.chatId);
+				const selectedId =
+					s.selectedEntryId && refreshedEntries.some((entry) => entry.id === s.selectedEntryId)
+						? s.selectedEntryId
+						: undefined;
 				return {
 					state: {
 						...s,
 						entries: refreshedEntries,
 						total: refreshedEntries.length,
 						page: 0,
-						selectedEntryId: undefined,
+						view: selectedId && s.view === "detail" ? "detail" : "list",
+						selectedEntryId: selectedId,
 					},
 					callbackText: "Refreshed",
 					rerender: true,

--- a/src/telegram/cards/renderers/provider-list.ts
+++ b/src/telegram/cards/renderers/provider-list.ts
@@ -4,6 +4,7 @@ import {
 	startProviderEditWizard,
 	startProviderRemoveWizard,
 } from "../../control-command-actions.js";
+import { getRemediation, type RemediationKey } from "../../remediation-commands.js";
 import type {
 	CardExecutionContext,
 	CardExecutionResult,
@@ -51,6 +52,21 @@ export function healthIcon(health: ProviderHealthIcon): string {
 function resolveSelected(state: ProviderListCardState): ProviderListEntry | undefined {
 	if (!state.selectedProviderId) return undefined;
 	return state.providers.find((p) => p.id === state.selectedProviderId);
+}
+
+function resolveRemediation(
+	entry: ProviderListEntry,
+): { title: string; command: string; explanation?: string } | undefined {
+	const remediation = entry.remediationKey
+		? getRemediation(entry.remediationKey as RemediationKey)
+		: undefined;
+	const command = entry.setupCommand ?? remediation?.command;
+	if (!command) return undefined;
+	return {
+		title: remediation?.title ?? "Provider setup",
+		command,
+		explanation: remediation?.explanation,
+	};
 }
 
 function renderListView(card: CardInstance<K>): CardRenderResult {
@@ -135,8 +151,13 @@ function renderDetailView(card: CardInstance<K>): CardRenderResult {
 	if (entry.oauthServiceId) {
 		lines.push(`*OAuth:* ${esc(entry.oauthServiceId)}`);
 	}
-	if (entry.setupCommand) {
-		lines.push("", `_Remediation:_ \`${esc(entry.setupCommand)}\``);
+	const remediation = resolveRemediation(entry);
+	if (remediation) {
+		lines.push("", `*Remediation:* ${esc(remediation.title)}`);
+		lines.push(`\`${esc(remediation.command)}\``);
+		if (remediation.explanation) {
+			lines.push(esc(remediation.explanation));
+		}
 	}
 
 	const kb = keyboard();

--- a/src/telegram/cards/types.ts
+++ b/src/telegram/cards/types.ts
@@ -1,4 +1,5 @@
 import type { CallbackQueryContext, Context, InlineKeyboard } from "grammy";
+import type { SocialDraftStatus } from "../../social/types.js";
 
 export enum CardKind {
 	Approval = "Approval",
@@ -30,6 +31,23 @@ export type CardListEntry = {
 	summary?: string;
 };
 
+export type SocialDraftListEntry = CardListEntry & {
+	status: SocialDraftStatus;
+	source: string;
+	ageLabel: string;
+	draftText: string;
+	serviceId?: string;
+	targetPostId?: string;
+	targetAuthor?: string;
+	targetExcerpt?: string;
+	targetUrl?: string;
+	manualActionReason?: string;
+	lastError?: string;
+	postedPostId?: string;
+	approved?: boolean;
+	canRetryApi?: boolean;
+};
+
 export type ApprovalCardState = {
 	kind: CardKind.Approval;
 	title: string;
@@ -59,7 +77,8 @@ export type ApprovalScopeCardState = {
 export type PendingQueueCardState = {
 	kind: CardKind.PendingQueue;
 	title: string;
-	entries: CardListEntry[];
+	entries: SocialDraftListEntry[];
+	view?: "list" | "detail";
 	page?: number;
 	total?: number;
 	selectedEntryId?: string;
@@ -257,6 +276,8 @@ export type ProviderListEntry = {
 	oauthServiceId?: string;
 	/** Setup command path shown in detail view. */
 	setupCommand?: string;
+	/** Central remediation key for health/config/auth failures. */
+	remediationKey?: string;
 	/** Base URL for health tap-through. */
 	baseUrl?: string;
 };
@@ -380,8 +401,14 @@ export type ApprovalScopeCardAction =
 	| { type: "refresh" };
 
 export type PendingQueueCardAction =
+	| { type: "view" }
+	| { type: "back" }
+	| { type: "edit" }
+	| { type: "refine" }
 	| { type: "promote" }
 	| { type: "dismiss" }
+	| { type: "mark-posted" }
+	| { type: "retry-api" }
 	| { type: "next" }
 	| { type: "prev" }
 	| { type: "refresh" };
@@ -538,7 +565,19 @@ const CARD_ACTIONS_BY_KIND = {
 		"deny",
 		"refresh",
 	],
-	[CardKind.PendingQueue]: ["promote", "dismiss", "next", "prev", "refresh"],
+	[CardKind.PendingQueue]: [
+		"view",
+		"back",
+		"edit",
+		"refine",
+		"promote",
+		"dismiss",
+		"mark-posted",
+		"retry-api",
+		"next",
+		"prev",
+		"refresh",
+	],
 	[CardKind.Status]: [
 		"refresh",
 		"run-health-check",

--- a/src/telegram/control-command-actions.ts
+++ b/src/telegram/control-command-actions.ts
@@ -1,5 +1,6 @@
 import type { Api } from "grammy";
 import {
+	type BackgroundJob,
 	cancelJob as cancelBackgroundJob,
 	getJobByShortId as getBackgroundJobByShortId,
 	listJobs as listBackgroundJobs,
@@ -1104,6 +1105,34 @@ export function startSocialAskWizard(
 
 const BACKGROUND_LIST_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
+function backgroundStatusLabel(status: BackgroundJobCardState["status"]): string {
+	switch (status) {
+		case "queued":
+			return "Queued";
+		case "running":
+			return "Running";
+		case "completed":
+			return "Done";
+		case "failed":
+			return "Failed";
+		case "cancelled":
+			return "Cancelled";
+		case "interrupted":
+			return "Interrupted";
+	}
+}
+
+function jobStatusLabel(job: BackgroundJob): string {
+	return backgroundStatusLabel(job.status as BackgroundJobCardState["status"]);
+}
+
+function jobMatchesThread(job: BackgroundJob, threadId?: number): boolean {
+	if (threadId === undefined) {
+		return job.threadId === null || job.threadId === undefined;
+	}
+	return job.threadId === threadId;
+}
+
 export async function sendBackgroundJobList(
 	api: Api,
 	opts: { chatId: number; threadId?: number; actorScope: CardActorScope },
@@ -1170,7 +1199,7 @@ export async function sendBackgroundJobDetail(
 		actorScope: opts.actorScope,
 		threadId: opts.threadId,
 	});
-	return { callbackText: `Status: ${job.status}` };
+	return { callbackText: `Status: ${jobStatusLabel(job)}` };
 }
 
 export async function cancelBackgroundJobCommand(
@@ -1187,10 +1216,86 @@ export async function cancelBackgroundJobCommand(
 	}
 	const { transitioned, job: updated } = cancelBackgroundJob(job.id);
 	const text = transitioned
-		? `Cancelled ${job.shortId}.`
-		: `No-op: job ${job.shortId} is ${updated?.status ?? "unknown"}.`;
+		? `Cancelled background job ${job.shortId}.`
+		: `No-op: job ${job.shortId} is ${updated ? jobStatusLabel(updated) : "Unknown"}.`;
 	await api.sendMessage(opts.chatId, text, threadOptions(opts.threadId));
-	return { callbackText: transitioned ? "Cancelled" : `No-op (${updated?.status})` };
+	return {
+		callbackText: transitioned
+			? "Cancelled"
+			: `No-op (${updated ? jobStatusLabel(updated) : "Unknown"})`,
+	};
+}
+
+export async function stopActiveWorkCommand(
+	api: Api,
+	opts: { chatId: number; threadId?: number; shortId?: string },
+): Promise<CommandUiResult> {
+	const shortId = opts.shortId?.trim();
+	if (shortId) {
+		return cancelBackgroundJobCommand(api, {
+			chatId: opts.chatId,
+			threadId: opts.threadId,
+			shortId,
+		});
+	}
+
+	const activeJobs = listBackgroundJobs({
+		statuses: ["queued", "running"],
+		chatId: opts.chatId,
+		limit: 25,
+	}).filter((job) => jobMatchesThread(job, opts.threadId));
+
+	if (activeJobs.length === 0) {
+		await api.sendMessage(
+			opts.chatId,
+			[
+				"No supported active work is running in this chat.",
+				"/stop currently cancels queued/running background jobs.",
+				"Note: in-flight agent replies cannot be interrupted yet; use /new after they finish to start fresh.",
+			].join("\n"),
+			threadOptions(opts.threadId),
+		);
+		return { callbackText: "No supported active work", callbackAlert: true };
+	}
+
+	const cancelled: BackgroundJob[] = [];
+	const unchanged: BackgroundJob[] = [];
+	for (const job of activeJobs) {
+		const result = cancelBackgroundJob(job.id);
+		if (result.transitioned && result.job) {
+			cancelled.push(result.job);
+		} else if (result.job) {
+			unchanged.push(result.job);
+		}
+	}
+
+	const lines: string[] = [];
+	if (cancelled.length > 0) {
+		lines.push(`Stopped ${cancelled.length} background job${cancelled.length === 1 ? "" : "s"}:`);
+		for (const job of cancelled) {
+			lines.push(`- ${job.shortId}: ${job.title} (${jobStatusLabel(job)})`);
+		}
+	}
+	if (unchanged.length > 0) {
+		if (lines.length > 0) lines.push("");
+		lines.push("Already terminal:");
+		for (const job of unchanged) {
+			lines.push(`- ${job.shortId}: ${jobStatusLabel(job)}`);
+		}
+	}
+	lines.push(
+		"",
+		"Note: in-flight agent replies are not interruptible yet; use /new after they finish.",
+	);
+
+	await api.sendMessage(opts.chatId, lines.join("\n"), threadOptions(opts.threadId));
+	return {
+		callbackText:
+			cancelled.length === 0
+				? "No active jobs stopped"
+				: `Stopped ${cancelled.length} background job${cancelled.length === 1 ? "" : "s"}`,
+		callbackAlert: cancelled.length === 0,
+	};
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1328,16 +1433,23 @@ export async function openModelPicker(
 
 function classifyHealth(response?: ProviderHealthResponse): ProviderHealthIcon {
 	if (!response) return "unknown";
-	const status = response.status;
-	if (status === "healthy" || status === "ok") return "ok";
-	if (status === "degraded") return "degraded";
-	if (status === "unhealthy") return "degraded";
-	// Per-connector auth expiry
 	const hasAuthExpired = Object.values(response.connectors ?? {}).some(
 		(connector) => connector.status === "auth_expired",
 	);
 	if (hasAuthExpired) return "auth_expired";
+	const status = response.status;
+	if (status === "healthy" || status === "ok") return "ok";
+	if (status === "degraded") return "degraded";
+	if (status === "unhealthy") return "degraded";
 	return "unknown";
+}
+
+function providerRemediationKey(result: HealthCheckResult, health: ProviderHealthIcon) {
+	if (!result.reachable) return "provider_unreachable";
+	if (health === "auth_expired") return "provider_auth_expired";
+	if (result.response?.status === "degraded") return "provider_degraded";
+	if (result.response?.status === "unhealthy") return "provider_unreachable";
+	return undefined;
 }
 
 function summarizeHealthDetail(result: HealthCheckResult): string | undefined {
@@ -1376,14 +1488,16 @@ async function buildProviderListEntries(cfg: TelclaudeConfig): Promise<ProviderL
 		live.map(async (provider) => {
 			const check = await checkProviderHealth(provider.id, provider.baseUrl);
 			const meta = catalogById.get(provider.id);
+			const health = classifyHealth(check.response);
 			const entry: ProviderListEntry = {
 				id: provider.id,
 				label: meta?.displayName ?? provider.id,
 				description: meta?.description ?? provider.description,
-				health: classifyHealth(check.response),
+				health,
 				detail: summarizeHealthDetail(check),
 				oauthServiceId: meta?.oauthServiceId,
 				setupCommand: meta?.setupCommand,
+				remediationKey: providerRemediationKey(check, health),
 				baseUrl: provider.baseUrl,
 			};
 			return entry;
@@ -1402,6 +1516,7 @@ async function buildProviderListEntries(cfg: TelclaudeConfig): Promise<ProviderL
 			detail: String(settled.reason).slice(0, 120),
 			oauthServiceId: meta?.oauthServiceId,
 			setupCommand: meta?.setupCommand,
+			remediationKey: "provider_unreachable",
 			baseUrl: provider.baseUrl,
 		} satisfies ProviderListEntry;
 	});

--- a/src/telegram/control-commands.ts
+++ b/src/telegram/control-commands.ts
@@ -57,6 +57,7 @@ export type TelegramCommandId =
 	| "providers"
 	// Fast-path shortcuts (no domain prefix)
 	| "sethome"
+	| "stop"
 	| "approve"
 	| "deny"
 	| "new"
@@ -561,7 +562,7 @@ const TELEGRAM_CONTROL_COMMANDS: TelegramControlCommandDefinition[] = [
 		domain: "background",
 		domainDefault: true,
 		category: "Background",
-		description: "Inspect or cancel long-running background jobs.",
+		description: "Inspect or cancel long-running background jobs; use /stop for active jobs here.",
 		usage: "/background [list|show <id>|cancel <id>]",
 		examples: ["/background", "/background show a1b2c3d4", "/background cancel a1b2c3d4"],
 		keywords: ["background", "jobs", "background job", "long running task"],
@@ -655,6 +656,18 @@ const TELEGRAM_CONTROL_COMMANDS: TelegramControlCommandDefinition[] = [
 		examples: ["/sethome"],
 		keywords: ["set home", "cron home", "deliver here", "post here later"],
 		rateLimited: true,
+	},
+	{
+		id: "stop",
+		name: "stop",
+		category: "Background",
+		description:
+			"Stop supported active work in this chat. Currently cancels queued or running background jobs.",
+		usage: "/stop [background-job-id]",
+		examples: ["/stop", "/stop a1b2c3d4"],
+		keywords: ["stop", "cancel active work", "cancel background", "abort running job"],
+		rateLimited: true,
+		menuDescription: "Stop active work",
 	},
 	// ── Fast-path shortcuts ────────────────────────────────────────────
 	{
@@ -781,9 +794,9 @@ const TELEGRAM_HELP_TOPICS: TelegramHelpTopic[] = [
 		id: "background",
 		title: "Background Jobs",
 		summary:
-			"Background jobs run long tasks asynchronously and notify on completion. /background lists recent jobs; /background show <id> opens a status card; /background cancel <id> aborts a queued or running job.",
+			"Background jobs run long tasks asynchronously and notify on completion. /background lists recent jobs; /background show <id> opens a status card; /background cancel <id> aborts one queued or running job. /stop cancels queued/running background jobs in the current chat or topic.",
 		keywords: ["background", "jobs", "long running", "async"],
-		commands: ["background", "background:list", "background:show", "background:cancel"],
+		commands: ["background", "background:list", "background:show", "background:cancel", "stop"],
 	},
 	{
 		id: "reset-session",
@@ -1117,6 +1130,7 @@ export function formatTelegramHelpOverview(): string {
 		"  /social — Social persona, queue, posting",
 		"  /skills — Skill drafts and management",
 		"  /background — Long-running background jobs",
+		"  /stop — Stop active background work here",
 		"  /model — Pick a model",
 		"  /providers — External provider health",
 		"  /new — Reset conversation",
@@ -1256,6 +1270,7 @@ export function getTelegramMenuCommands(
 		{ command: "social", description: "Social persona management" },
 		{ command: "skills", description: "Skill management" },
 		{ command: "background", description: "Background jobs" },
+		{ command: "stop", description: "Stop active work" },
 		{ command: "model", description: "Pick a model" },
 		{ command: "providers", description: "External providers" },
 		{ command: "approve", description: "Approve a pending request" },

--- a/src/testing/integration-harness.ts
+++ b/src/testing/integration-harness.ts
@@ -1,0 +1,442 @@
+import { MoltbookClient } from "../social/backends/moltbook.js";
+import type { SocialNotification } from "../social/types.js";
+import { untrustedPublicText } from "./live-replay.js";
+
+export type FailureKind =
+	| "auth"
+	| "approval_required"
+	| "rate_limited"
+	| "not_found"
+	| "validation"
+	| "server"
+	| "network"
+	| "unknown"
+	| "skipped";
+
+export type ProbeCheck = {
+	name: string;
+	status: "passed" | "failed" | "skipped";
+	failureKind?: FailureKind;
+	detail?: string;
+};
+
+export type ProviderProbeResult = {
+	target: "provider";
+	providerId: string;
+	baseUrl: string;
+	checks: ProbeCheck[];
+	health?: unknown;
+	schema?: unknown;
+	readAction?: {
+		service: string;
+		action: string;
+		status: number;
+		response: unknown;
+		failureKind?: FailureKind;
+	};
+};
+
+export type SocialProbeResult = {
+	target: "social";
+	serviceId: "moltbook";
+	baseUrl: string;
+	checks: ProbeCheck[];
+	read?: {
+		status: "passed" | "failed";
+		notificationCount: number;
+		notifications: unknown[];
+		failureKind?: FailureKind;
+		error?: string;
+	};
+	post?: {
+		status: "passed" | "failed" | "skipped";
+		httpStatus?: number;
+		postId?: string;
+		failureKind?: FailureKind;
+		error?: string;
+	};
+};
+
+type FetchLike = typeof fetch;
+
+type ProviderActionSelection = {
+	service: string;
+	action: string;
+};
+
+function safeJsonParse(text: string): unknown {
+	try {
+		return text ? JSON.parse(text) : null;
+	} catch {
+		return text;
+	}
+}
+
+export function classifyHttpFailure(status: number | undefined, error?: string): FailureKind {
+	if (status === 401 || status === 403) return "auth";
+	if (status === 402) return "approval_required";
+	if (status === 404) return "not_found";
+	if (status === 408 || status === 429) return "rate_limited";
+	if (status !== undefined && status >= 400 && status < 500) return "validation";
+	if (status !== undefined && status >= 500) return "server";
+	if (error) return "network";
+	return "unknown";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function asString(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function actionList(service: Record<string, unknown>): Record<string, unknown>[] {
+	const candidates = [service.actions, service.endpoints];
+	for (const candidate of candidates) {
+		if (Array.isArray(candidate)) {
+			return candidate
+				.map((entry) => asRecord(entry))
+				.filter((entry): entry is Record<string, unknown> => Boolean(entry));
+		}
+		if (asRecord(candidate)) {
+			return Object.entries(candidate as Record<string, unknown>).map(([id, entry]) => ({
+				...(asRecord(entry) ?? {}),
+				id,
+			}));
+		}
+	}
+	return [];
+}
+
+export function selectReadProviderAction(schema: unknown): ProviderActionSelection | null {
+	const root = asRecord(schema);
+	const services = root?.services;
+	if (!Array.isArray(services)) {
+		return null;
+	}
+
+	for (const rawService of services) {
+		const service = asRecord(rawService);
+		if (!service) continue;
+		const serviceId = asString(service.id) ?? asString(service.service) ?? asString(service.name);
+		if (!serviceId) continue;
+
+		for (const action of actionList(service)) {
+			const actionId =
+				asString(action.id) ??
+				asString(action.action) ??
+				asString(action.name) ??
+				asString(action.key);
+			if (!actionId) continue;
+			const actionType = asString(action.type) ?? asString(action.mode);
+			const method = asString(action.method)?.toUpperCase();
+			const requiresAuth = action.requiresAuth === true;
+			if (actionType === "read" || method === "GET" || !requiresAuth) {
+				return { service: serviceId, action: actionId };
+			}
+		}
+	}
+
+	return null;
+}
+
+async function fetchJson(
+	fetchImpl: FetchLike,
+	url: URL,
+	init: RequestInit,
+): Promise<{ ok: boolean; status: number; payload: unknown; statusText: string }> {
+	const response = await fetchImpl(url, init);
+	const text = await response.text();
+	return {
+		ok: response.ok,
+		status: response.status,
+		statusText: response.statusText,
+		payload: safeJsonParse(text),
+	};
+}
+
+export async function runProviderProbe(options: {
+	providerId: string;
+	baseUrl: string;
+	readAction?: ProviderActionSelection;
+	readParams?: Record<string, unknown>;
+	fetchImpl?: FetchLike;
+}): Promise<ProviderProbeResult> {
+	const fetchImpl = options.fetchImpl ?? fetch;
+	const baseUrl = options.baseUrl.replace(/\/+$/, "");
+	const checks: ProbeCheck[] = [];
+	const result: ProviderProbeResult = {
+		target: "provider",
+		providerId: options.providerId,
+		baseUrl,
+		checks,
+	};
+
+	try {
+		const health = await fetchJson(fetchImpl, new URL("/v1/health", baseUrl), {
+			method: "GET",
+			headers: { accept: "application/json" },
+		});
+		result.health = health.payload;
+		checks.push(
+			health.ok
+				? { name: "provider.health", status: "passed" }
+				: {
+						name: "provider.health",
+						status: "failed",
+						failureKind: classifyHttpFailure(health.status),
+						detail: `HTTP ${health.status}: ${health.statusText}`,
+					},
+		);
+	} catch (error) {
+		checks.push({
+			name: "provider.health",
+			status: "failed",
+			failureKind: "network",
+			detail: error instanceof Error ? error.message : String(error),
+		});
+	}
+
+	try {
+		const schema = await fetchJson(fetchImpl, new URL("/v1/schema", baseUrl), {
+			method: "GET",
+			headers: { accept: "application/json" },
+		});
+		result.schema = schema.payload;
+		checks.push(
+			schema.ok
+				? { name: "provider.schema", status: "passed" }
+				: {
+						name: "provider.schema",
+						status: "failed",
+						failureKind: classifyHttpFailure(schema.status),
+						detail: `HTTP ${schema.status}: ${schema.statusText}`,
+					},
+		);
+
+		const selected = options.readAction ?? selectReadProviderAction(schema.payload);
+		if (!schema.ok || !selected) {
+			checks.push({
+				name: "provider.read_action",
+				status: "skipped",
+				detail: "No read action available from schema.",
+			});
+			return result;
+		}
+
+		const readBody = JSON.stringify({
+			service: selected.service,
+			action: selected.action,
+			params: options.readParams ?? {},
+		});
+		const read = await fetchJson(fetchImpl, new URL("/v1/fetch", baseUrl), {
+			method: "POST",
+			headers: {
+				accept: "application/json",
+				"content-type": "application/json",
+				"x-actor-user-id": "integration-harness",
+			},
+			body: readBody,
+		});
+		const failureKind = read.ok ? undefined : classifyHttpFailure(read.status);
+		result.readAction = {
+			service: selected.service,
+			action: selected.action,
+			status: read.status,
+			response: read.payload,
+			...(failureKind ? { failureKind } : {}),
+		};
+		checks.push(
+			read.ok
+				? { name: "provider.read_action", status: "passed" }
+				: {
+						name: "provider.read_action",
+						status: "failed",
+						failureKind,
+						detail: `HTTP ${read.status}: ${read.statusText}`,
+					},
+		);
+	} catch (error) {
+		checks.push({
+			name: "provider.schema_or_read",
+			status: "failed",
+			failureKind: "network",
+			detail: error instanceof Error ? error.message : String(error),
+		});
+	}
+
+	return result;
+}
+
+function markPublicFields(value: unknown, key?: string): unknown {
+	const publicTextKeys = new Set([
+		"content",
+		"text",
+		"message",
+		"body",
+		"authorName",
+		"authorHandle",
+	]);
+	if (typeof value === "string" && key && publicTextKeys.has(key)) {
+		return untrustedPublicText(value);
+	}
+	if (Array.isArray(value)) {
+		return value.map((entry) => markPublicFields(entry));
+	}
+	const record = asRecord(value);
+	if (!record) {
+		return value;
+	}
+	const next: Record<string, unknown> = {};
+	for (const [childKey, childValue] of Object.entries(record)) {
+		next[childKey] = markPublicFields(childValue, childKey);
+	}
+	return next;
+}
+
+export function markSocialNotificationsUntrusted(notifications: SocialNotification[]): unknown[] {
+	return notifications.map((notification) => markPublicFields(notification));
+}
+
+export async function runMoltbookSocialProbe(options: {
+	baseUrl: string;
+	apiKey: string;
+	fetchImpl?: FetchLike;
+	allowPublicMutation?: boolean;
+	postContent?: string;
+}): Promise<SocialProbeResult> {
+	const baseUrl = options.baseUrl.replace(/\/+$/, "");
+	const client = new MoltbookClient({
+		apiKey: options.apiKey,
+		baseUrl,
+		fetchImpl: options.fetchImpl ?? fetch,
+	});
+	const checks: ProbeCheck[] = [];
+	const result: SocialProbeResult = {
+		target: "social",
+		serviceId: "moltbook",
+		baseUrl,
+		checks,
+	};
+
+	try {
+		const notifications = await client.fetchNotifications();
+		result.read = {
+			status: "passed",
+			notificationCount: notifications.length,
+			notifications: markSocialNotificationsUntrusted(notifications),
+		};
+		checks.push({ name: "social.read_notifications", status: "passed" });
+	} catch (error) {
+		const status =
+			typeof error === "object" && error !== null
+				? (error as { status?: number }).status
+				: undefined;
+		const message = error instanceof Error ? error.message : String(error);
+		const failureKind = classifyHttpFailure(status, message);
+		result.read = {
+			status: "failed",
+			notificationCount: 0,
+			notifications: [],
+			failureKind,
+			error: message,
+		};
+		checks.push({
+			name: "social.read_notifications",
+			status: "failed",
+			failureKind,
+			detail: message,
+		});
+	}
+
+	if (!options.allowPublicMutation) {
+		result.post = {
+			status: "skipped",
+			failureKind: "skipped",
+			error: "Public mutation disabled. Set explicit live test account flags to enable.",
+		};
+		checks.push({
+			name: "social.create_post",
+			status: "skipped",
+			failureKind: "skipped",
+			detail: "Public mutation disabled.",
+		});
+		return result;
+	}
+
+	const postContent =
+		options.postContent ?? `telclaude integration harness smoke test ${new Date().toISOString()}`;
+	const post = await client.createPost(postContent);
+	if (post.ok) {
+		result.post = { status: "passed", httpStatus: post.status, postId: post.postId };
+		checks.push({ name: "social.create_post", status: "passed" });
+		return result;
+	}
+
+	const failureKind = post.rateLimited ? "rate_limited" : classifyHttpFailure(post.status);
+	result.post = {
+		status: "failed",
+		httpStatus: post.status,
+		failureKind,
+		error: post.error,
+	};
+	checks.push({
+		name: "social.create_post",
+		status: "failed",
+		failureKind,
+		detail: post.error,
+	});
+	return result;
+}
+
+export function assertProviderReplayFixture(result: ProviderProbeResult): void {
+	const failed = result.checks.filter((check) => check.status === "failed");
+	if (failed.length > 0) {
+		throw new Error(
+			`Provider replay fixture contains failed checks: ${failed.map((c) => c.name).join(", ")}`,
+		);
+	}
+	if (
+		!result.checks.some((check) => check.name === "provider.health" && check.status === "passed")
+	) {
+		throw new Error("Provider replay fixture is missing a passing health probe.");
+	}
+	if (
+		!result.checks.some((check) => check.name === "provider.schema" && check.status === "passed")
+	) {
+		throw new Error("Provider replay fixture is missing a passing schema probe.");
+	}
+	if (!result.readAction || result.readAction.status < 200 || result.readAction.status >= 300) {
+		throw new Error("Provider replay fixture is missing a successful read action.");
+	}
+}
+
+function hasUntrustedPublicMarker(value: unknown): boolean {
+	if (
+		typeof value === "object" &&
+		value !== null &&
+		(value as { trust?: unknown }).trust === "untrusted_public"
+	) {
+		return true;
+	}
+	if (Array.isArray(value)) {
+		return value.some(hasUntrustedPublicMarker);
+	}
+	const record = asRecord(value);
+	return record ? Object.values(record).some(hasUntrustedPublicMarker) : false;
+}
+
+export function assertSocialReplayFixture(result: SocialProbeResult): void {
+	if (!result.read || result.read.status !== "passed") {
+		throw new Error("Social replay fixture is missing a passing read probe.");
+	}
+	if (!hasUntrustedPublicMarker(result.read.notifications)) {
+		throw new Error("Social replay fixture must mark public content as untrusted.");
+	}
+	if (!result.post || result.post.status !== "failed" || !result.post.failureKind) {
+		throw new Error("Social replay fixture is missing post failure taxonomy.");
+	}
+}

--- a/src/testing/live-replay.ts
+++ b/src/testing/live-replay.ts
@@ -1,0 +1,205 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type IntegrationHarnessMode = "replay" | "live" | "capture";
+
+export type FixtureEnvelope<T> = {
+	schemaVersion: 1;
+	name: string;
+	capturedAt: string;
+	mode: "replay" | "capture";
+	data: T;
+	redactions: string[];
+};
+
+export type UntrustedPublicText = {
+	trust: "untrusted_public";
+	value: string;
+};
+
+export type SanitizedFixture<T> = {
+	data: T;
+	redactions: string[];
+};
+
+const SECRET_KEY_PATTERNS = [
+	/authorization/i,
+	/api[-_]?key/i,
+	/access[-_]?token/i,
+	/refresh[-_]?token/i,
+	/^token$/i,
+	/secret/i,
+	/password/i,
+	/passphrase/i,
+	/cookie/i,
+	/approval[-_]?token/i,
+];
+
+const IDENTIFIER_KEY_PATTERNS = [
+	/(^|[-_])user[-_]?id$/i,
+	/(^|[-_])actor[-_]?user[-_]?id$/i,
+	/(^|[-_])subject[-_]?user[-_]?id$/i,
+	/(^|[-_])telegram[-_]?user[-_]?id$/i,
+	/(^|[-_])chat[-_]?id$/i,
+	/(^|[-_])thread[-_]?id$/i,
+	/^username$/i,
+	/^handle$/i,
+	/^author[-_]?handle$/i,
+	/^author[-_]?name$/i,
+	/^display[-_]?name$/i,
+	/^email$/i,
+];
+
+const PRIVATE_TEXT_KEY_PATTERNS = [
+	/^message$/i,
+	/^message[-_]?preview$/i,
+	/^private[-_]?message[-_]?text$/i,
+	/^transcript$/i,
+	/^prompt$/i,
+	/^body$/i,
+	/^content$/i,
+	/^text$/i,
+	/^reply$/i,
+];
+
+const KNOWN_SECRET_VALUE_PATTERNS = [
+	/sk-[A-Za-z0-9_-]{20,}/,
+	/gh[pousr]_[A-Za-z0-9_]{20,}/,
+	/xox[baprs]-[A-Za-z0-9-]{20,}/,
+	/ya29\.[A-Za-z0-9_-]{20,}/,
+	/Bearer\s+[A-Za-z0-9._-]{20,}/i,
+	/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/,
+	/-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+];
+
+function keyMatches(key: string | undefined, patterns: RegExp[]): boolean {
+	return Boolean(key && patterns.some((pattern) => pattern.test(key)));
+}
+
+function stableRedactedId(value: unknown): string {
+	const hash = crypto.createHash("sha256").update(String(value)).digest("hex").slice(0, 10);
+	return `[REDACTED_ID:${hash}]`;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isUntrustedPublicText(value: unknown): value is UntrustedPublicText {
+	return (
+		isPlainRecord(value) && value.trust === "untrusted_public" && typeof value.value === "string"
+	);
+}
+
+export function untrustedPublicText(value: string): UntrustedPublicText {
+	return { trust: "untrusted_public", value };
+}
+
+function sanitizeValue(value: unknown, key: string | undefined, redactions: string[]): unknown {
+	if (isUntrustedPublicText(value)) {
+		return value;
+	}
+
+	if (keyMatches(key, SECRET_KEY_PATTERNS)) {
+		redactions.push(key ?? "<secret>");
+		return "[REDACTED_SECRET]";
+	}
+
+	if (keyMatches(key, IDENTIFIER_KEY_PATTERNS)) {
+		redactions.push(key ?? "<identifier>");
+		return stableRedactedId(value);
+	}
+
+	if (keyMatches(key, PRIVATE_TEXT_KEY_PATTERNS) && typeof value === "string") {
+		redactions.push(key ?? "<private_text>");
+		return "[REDACTED_TEXT]";
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((entry) => sanitizeValue(entry, undefined, redactions));
+	}
+
+	if (isPlainRecord(value)) {
+		const sanitized: Record<string, unknown> = {};
+		for (const [childKey, childValue] of Object.entries(value)) {
+			sanitized[childKey] = sanitizeValue(childValue, childKey, redactions);
+		}
+		return sanitized;
+	}
+
+	return value;
+}
+
+export function sanitizeFixtureData<T>(data: T): SanitizedFixture<T> {
+	const redactions: string[] = [];
+	const sanitized = sanitizeValue(data, undefined, redactions) as T;
+	return {
+		data: sanitized,
+		redactions: Array.from(new Set(redactions)).sort(),
+	};
+}
+
+export function assertNoKnownSecretPatterns(serializedFixture: string): void {
+	for (const pattern of KNOWN_SECRET_VALUE_PATTERNS) {
+		if (pattern.test(serializedFixture)) {
+			throw new Error(`Fixture contains an unredacted secret-like value: ${pattern}`);
+		}
+	}
+}
+
+export function buildFixtureEnvelope<T>(
+	name: string,
+	data: T,
+	options: { capturedAt?: string; mode?: "replay" | "capture" } = {},
+): FixtureEnvelope<T> {
+	return {
+		schemaVersion: 1,
+		name,
+		capturedAt: options.capturedAt ?? new Date().toISOString(),
+		mode: options.mode ?? "replay",
+		data,
+		redactions: [],
+	};
+}
+
+export async function readFixtureFile<T>(fixturePath: string): Promise<FixtureEnvelope<T>> {
+	const raw = await fs.readFile(fixturePath, "utf8");
+	assertNoKnownSecretPatterns(raw);
+	return JSON.parse(raw) as FixtureEnvelope<T>;
+}
+
+export async function writeFixtureFile<T>(
+	fixturePath: string,
+	envelope: FixtureEnvelope<T>,
+): Promise<FixtureEnvelope<T>> {
+	const sanitized = sanitizeFixtureData(envelope.data);
+	const safeEnvelope: FixtureEnvelope<T> = {
+		...envelope,
+		data: sanitized.data,
+		redactions: Array.from(new Set([...envelope.redactions, ...sanitized.redactions])).sort(),
+	};
+	const serialized = `${JSON.stringify(safeEnvelope, null, 2)}\n`;
+	assertNoKnownSecretPatterns(serialized);
+
+	await fs.mkdir(path.dirname(fixturePath), { recursive: true });
+	const tmpPath = `${fixturePath}.tmp.${process.pid}.${Date.now()}`;
+	await fs.writeFile(tmpPath, serialized, "utf8");
+	await fs.rename(tmpPath, fixturePath);
+	return safeEnvelope;
+}
+
+export function resolveHarnessMode(options: {
+	live?: boolean;
+	captureFixtures?: boolean;
+}): IntegrationHarnessMode {
+	if (options.captureFixtures) {
+		return "capture";
+	}
+	return options.live ? "live" : "replay";
+}
+
+export function integrationFixturePath(fixtureDir: string, fixtureName: string): string {
+	const safeName = fixtureName.endsWith(".json") ? fixtureName : `${fixtureName}.json`;
+	return path.join(fixtureDir, safeName);
+}

--- a/tests/dashboard/server.test.ts
+++ b/tests/dashboard/server.test.ts
@@ -19,6 +19,27 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 // ─── Mocks ─────────────────────────────────────────────────────────────────
 // NOTE: order matters — mocks must be declared before importing the server.
 
+vi.mock("../../src/logging.js", () => {
+	const noop = () => undefined;
+	const logger = {
+		debug: noop,
+		error: noop,
+		fatal: noop,
+		info: noop,
+		trace: noop,
+		warn: noop,
+		child: () => logger,
+	};
+	return {
+		getChildLogger: () => logger,
+		getLogger: () => logger,
+		getResolvedLoggerSettings: () => ({
+			level: "silent",
+			file: "/tmp/telclaude-dashboard-test.log",
+		}),
+	};
+});
+
 vi.mock("../../src/totp-client/client.js", () => {
 	const verifyFn = vi.fn(async (_userId: string, code: string) => code === "123456");
 	return {
@@ -84,6 +105,22 @@ vi.mock("../../src/security/audit.js", () => ({
 vi.mock("../../src/config/config.js", () => ({
 	loadConfig: () => ({
 		providers: [{ id: "health-provider", baseUrl: "https://example.test" }],
+		socialServices: [
+			{
+				id: "xtwitter",
+				type: "xtwitter",
+				enabled: true,
+				handle: "telclaude",
+				displayName: "Telclaude",
+				heartbeatEnabled: true,
+				heartbeatIntervalHours: 6,
+				enableSkills: true,
+				allowedSkills: ["summarize"],
+				notifyOnHeartbeat: "activity",
+			},
+		],
+		telegram: { heartbeat: { enabled: true, intervalHours: 6, notifyOnActivity: true } },
+		cron: { enabled: true, pollIntervalSeconds: 15, timeoutSeconds: 900 },
 		security: { audit: { enabled: true } },
 		dashboard: { enabled: true, port: 0 },
 	}),
@@ -100,6 +137,169 @@ vi.mock("../../src/commands/doctor.js", () => ({
 			},
 		],
 		summary: { pass: 1, warn: 0, fail: 0, skip: 0 },
+	}),
+}));
+
+vi.mock("../../src/commands/sessions.js", () => ({
+	collectSessionRows: () => [
+		{
+			key: "tg:42",
+			kind: "direct",
+			sessionId: "claude-session-secret",
+			updatedAt: 1_700_000_100_000,
+			ageMs: 60_000,
+			systemSent: true,
+		},
+	],
+}));
+
+vi.mock("../../src/background/index.js", () => ({
+	cancelJob: () => ({
+		transitioned: true,
+		job: {
+			id: "bg-1",
+			shortId: "job1",
+			status: "cancelled",
+			title: "Safe title",
+			tier: "WRITE_LOCAL",
+			userId: "operator",
+			chatId: 42,
+			threadId: null,
+			payload: { kind: "command", command: "echo secret" },
+			description: null,
+			result: null,
+			error: null,
+			createdAtMs: 1_700_000_000_000,
+			startedAtMs: null,
+			completedAtMs: 1_700_000_010_000,
+			cancelledAtMs: 1_700_000_010_000,
+		},
+	}),
+	getJobByShortId: () => ({ id: "bg-1", shortId: "job1", status: "running" }),
+	listJobs: () => [
+		{
+			id: "bg-1",
+			shortId: "job1",
+			status: "running",
+			title: "Safe title",
+			description: "No private prompt here",
+			tier: "WRITE_LOCAL",
+			userId: "operator",
+			chatId: 42,
+			threadId: null,
+			payload: { kind: "command", command: "echo should-not-leak" },
+			result: { message: "still running", stdout: "should-not-leak" },
+			error: "waiting on provider",
+			createdAtMs: 1_700_000_000_000,
+			startedAtMs: 1_700_000_005_000,
+			completedAtMs: null,
+			cancelledAtMs: null,
+		},
+	],
+}));
+
+vi.mock("../../src/cron/store.js", () => ({
+	getCronCoverage: () => ({
+		allSocial: false,
+		socialServiceIds: ["xtwitter"],
+		hasPrivateHeartbeat: true,
+	}),
+	getCronStatusSummary: () => ({
+		totalJobs: 1,
+		enabledJobs: 1,
+		runningJobs: 0,
+		nextRunAtMs: 1_700_000_300_000,
+	}),
+	listCronJobs: () => [
+		{
+			id: "cron-1",
+			name: "private heartbeat",
+			enabled: true,
+			running: false,
+			ownerId: "operator",
+			deliveryTarget: { kind: "home" },
+			schedule: { kind: "every", everyMs: 21_600_000 },
+			action: { kind: "agent-prompt", prompt: "should not leak" },
+			nextRunAtMs: 1_700_000_300_000,
+			lastRunAtMs: 1_700_000_000_000,
+			lastStatus: "success",
+			lastError: null,
+			createdAtMs: 1_699_999_000_000,
+			updatedAtMs: 1_700_000_000_000,
+		},
+	],
+	listCronRuns: () => [
+		{
+			jobId: "cron-1",
+			startedAtMs: 1_700_000_000_000,
+			finishedAtMs: 1_700_000_010_000,
+			status: "success",
+			message: "completed",
+		},
+	],
+}));
+
+vi.mock("../../src/memory/store.js", () => ({
+	getEntries: (query: { trust?: string[]; sources?: string[]; categories?: string[] }) => {
+		if (query.categories?.includes("posts") && query.trust?.includes("quarantined")) {
+			return [
+				{
+					id: "post-1",
+					category: "posts",
+					content: "raw draft content should not leak",
+					_provenance: {
+						source: "telegram",
+						trust: "quarantined",
+						createdAt: 1_700_000_000_000,
+					},
+				},
+			];
+		}
+		if (query.categories?.includes("posts") && query.trust?.includes("trusted")) {
+			return [
+				{
+					id: "post-2",
+					category: "posts",
+					content: "approved draft content should not leak",
+					_provenance: {
+						source: "social",
+						trust: "trusted",
+						createdAt: 1_700_000_010_000,
+						promotedAt: 1_700_000_020_000,
+					},
+				},
+			];
+		}
+		if (query.categories?.some((c) => c === "profile" || c === "interests" || c === "meta")) {
+			return [
+				{
+					id: "profile-1",
+					category: "profile",
+					content: "private profile should not leak",
+					_provenance: {
+						source: query.sources?.[0] ?? "telegram",
+						trust: "trusted",
+						createdAt: 1_700_000_000_000,
+					},
+				},
+			];
+		}
+		return [];
+	},
+}));
+
+vi.mock("../../src/providers/provider-health.js", () => ({
+	checkProviderHealth: async () => ({
+		providerId: "health-provider",
+		baseUrl: "https://example.test",
+		reachable: true,
+		response: {
+			status: "degraded",
+			connectors: {
+				gmail: { status: "auth_expired", failureCount: 2 },
+			},
+			alerts: [{ level: "warn", connector: "gmail", message: "token expired" }],
+		},
 	}),
 }));
 
@@ -198,6 +398,20 @@ describe("dashboard server", () => {
 
 	it("POST /api/doctor/run is 401 without a session cookie", async () => {
 		const res = await handle.server.inject({ method: "POST", url: "/api/doctor/run" });
+		expect(res.statusCode).toBe(401);
+	});
+
+	it.each([
+		["GET", "/api/operator/sessions-runs"],
+		["GET", "/api/operator/logs"],
+		["GET", "/api/operator/background-jobs"],
+		["GET", "/api/operator/cron"],
+		["GET", "/api/operator/social-queue"],
+		["GET", "/api/operator/personas"],
+		["GET", "/api/operator/provider-health"],
+		["POST", "/api/operator/background-jobs/job1/cancel"],
+	])("%s %s is 401 without a session cookie", async (method, url) => {
+		const res = await handle.server.inject({ method: method as "GET" | "POST", url });
 		expect(res.statusCode).toBe(401);
 	});
 
@@ -333,6 +547,164 @@ describe("dashboard server", () => {
 			headers: { cookie },
 		});
 		expect(res.statusCode).toBe(401);
+	});
+
+	it("GET /api/operator/sessions-runs returns metadata-only session and run shapes", async () => {
+		const cookie = await authedCookie();
+		const res = await handle.server.inject({
+			method: "GET",
+			url: "/api/operator/sessions-runs",
+			headers: { cookie },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.sessions[0]).toMatchObject({
+			key: "tg:42",
+			source: "direct",
+			persona: "private",
+			status: "active",
+			systemSent: true,
+		});
+		expect(body.sessions[0].sessionId).toBeUndefined();
+		expect(body.sessions[0].sessionRef).toContain("...");
+		expect(body.runs[0]).toMatchObject({
+			id: "r1",
+			source: "telegram",
+			persona: "private",
+			status: "completed",
+		});
+		expect(JSON.stringify(body)).not.toContain("messagePreview");
+		expect(JSON.stringify(body)).not.toContain("hi");
+	});
+
+	it("GET /api/operator/background-jobs omits command and process output", async () => {
+		const cookie = await authedCookie();
+		const res = await handle.server.inject({
+			method: "GET",
+			url: "/api/operator/background-jobs",
+			headers: { cookie },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.jobs[0]).toMatchObject({
+			shortId: "job1",
+			status: "running",
+			payloadKind: "command",
+			canCancel: true,
+		});
+		expect(JSON.stringify(body)).not.toContain("echo should-not-leak");
+		expect(JSON.stringify(body)).not.toContain("stdout");
+	});
+
+	it("POST /api/operator/background-jobs/:shortId/cancel uses the existing cancel path", async () => {
+		const cookie = await authedCookie();
+		const res = await handle.server.inject({
+			method: "POST",
+			url: "/api/operator/background-jobs/job1/cancel",
+			headers: { cookie },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.transitioned).toBe(true);
+		expect(body.job.shortId).toBe("job1");
+		expect(body.job.status).toBe("cancelled");
+	});
+
+	it("GET /api/operator/cron omits agent prompt text", async () => {
+		const cookie = await authedCookie();
+		const res = await handle.server.inject({
+			method: "GET",
+			url: "/api/operator/cron",
+			headers: { cookie },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.summary.totalJobs).toBe(1);
+		expect(body.jobs[0]).toMatchObject({
+			id: "cron-1",
+			actionKind: "agent-prompt",
+			actionSummary: "agent prompt (redacted)",
+		});
+		expect(JSON.stringify(body)).not.toContain("should not leak");
+	});
+
+	it("GET /api/operator/social-queue exposes queue state without raw post content", async () => {
+		const cookie = await authedCookie();
+		const res = await handle.server.inject({
+			method: "GET",
+			url: "/api/operator/social-queue",
+			headers: { cookie },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.pending[0]).toMatchObject({
+			id: "post-1",
+			source: "telegram",
+			status: "awaiting_promotion",
+		});
+		expect(body.promoted[0]).toMatchObject({
+			id: "post-2",
+			source: "social",
+			status: "awaiting_heartbeat",
+		});
+		expect(body.nextOperatorAction).toContain("/social queue");
+		expect(JSON.stringify(body)).not.toContain("raw draft content");
+		expect(JSON.stringify(body)).not.toContain("approved draft content");
+	});
+
+	it("GET /api/operator/personas returns profile status without memory text or credentials", async () => {
+		const cookie = await authedCookie();
+		const res = await handle.server.inject({
+			method: "GET",
+			url: "/api/operator/personas",
+			headers: { cookie },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.privatePersona.memoryCounts.profile).toBe(1);
+		expect(body.socialPersona.services[0]).toMatchObject({
+			id: "xtwitter",
+			enabled: true,
+			hasAgentUrl: false,
+			allowedSkillsCount: 1,
+		});
+		expect(JSON.stringify(body)).not.toContain("private profile should not leak");
+		expect(JSON.stringify(body)).not.toContain("apiKey");
+	});
+
+	it("GET /api/operator/provider-health returns failures and connector summaries", async () => {
+		const cookie = await authedCookie();
+		const res = await handle.server.inject({
+			method: "GET",
+			url: "/api/operator/provider-health",
+			headers: { cookie },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.providers[0]).toMatchObject({
+			id: "health-provider",
+			reachable: true,
+			status: "degraded",
+			failureCount: 2,
+		});
+		expect(body.providers[0].connectors[0]).toMatchObject({
+			name: "gmail",
+			status: "auth_expired",
+			failureCount: 2,
+		});
+	});
+
+	it("GET /api/operator/logs returns a filterable metadata envelope", async () => {
+		const cookie = await authedCookie();
+		const res = await handle.server.inject({
+			method: "GET",
+			url: "/api/operator/logs?component=agent-server&level=warn",
+			headers: { cookie },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.filters).toMatchObject({ component: "agent-server", level: "warn" });
+		expect(Array.isArray(body.entries)).toBe(true);
 	});
 
 	it("static UI index.html is publicly reachable (no auth)", async () => {

--- a/tests/fixtures/integration/dashboard-routes.json
+++ b/tests/fixtures/integration/dashboard-routes.json
@@ -1,0 +1,129 @@
+{
+  "schemaVersion": 1,
+  "name": "dashboard-routes",
+  "capturedAt": "2026-04-23T00:00:00.000Z",
+  "mode": "replay",
+  "data": {
+    "routes": {
+      "GET /api/health": {
+        "statusCode": 200,
+        "body": {
+          "ok": true,
+          "snapshot": {
+            "overallStatus": "ok",
+            "collectedAtMs": 1,
+            "items": [
+              {
+                "id": "test",
+                "label": "Test",
+                "status": "ok",
+                "detail": "mock"
+              }
+            ],
+            "issueCount": 0
+          }
+        }
+      },
+      "GET /api/providers": {
+        "statusCode": 200,
+        "body": {
+          "ok": true,
+          "catalog": [
+            {
+              "id": "health-provider",
+              "displayName": "Health",
+              "description": "d",
+              "services": []
+            }
+          ],
+          "configured": [
+            {
+              "id": "health-provider",
+              "baseUrl": "https://example.test"
+            }
+          ],
+          "oauthServices": [
+            {
+              "id": "google",
+              "displayName": "Google"
+            }
+          ]
+        }
+      },
+      "GET /api/skills": {
+        "statusCode": 200,
+        "body": {
+          "ok": true,
+          "active": [
+            "memory",
+            "summarize"
+          ],
+          "drafts": [
+            "experimental"
+          ]
+        }
+      },
+      "GET /api/approvals/allowlist": {
+        "statusCode": 200,
+        "body": {
+          "ok": true,
+          "entries": [
+            {
+              "id": 1,
+              "userId": "[REDACTED_ID:user]",
+              "tier": "WRITE_LOCAL",
+              "toolKey": "Bash",
+              "scope": "session",
+              "sessionKey": "k",
+              "grantedAt": 1000,
+              "expiresAt": 2000,
+              "lastUsedAt": null,
+              "chatId": "[REDACTED_ID:chat]"
+            }
+          ]
+        }
+      },
+      "GET /api/audit/tail": {
+        "statusCode": 200,
+        "body": {
+          "ok": true,
+          "enabled": true,
+          "entries": [
+            {
+              "timestamp": "2023-11-14T22:13:20.000Z",
+              "requestId": "r1",
+              "telegramUserId": "[REDACTED_ID:user]",
+              "chatId": "[REDACTED_ID:chat]",
+              "messagePreview": "[REDACTED_TEXT]",
+              "permissionTier": "READ_ONLY",
+              "outcome": "success"
+            }
+          ]
+        }
+      },
+      "POST /api/doctor/run": {
+        "statusCode": 200,
+        "body": {
+          "ok": true,
+          "report": {
+            "checks": [
+              {
+                "name": "config.loaded",
+                "category": "Config",
+                "status": "pass",
+                "summary": "ok"
+              }
+            ],
+            "summary": {
+              "pass": 1,
+              "warn": 0,
+              "fail": 0,
+              "skip": 0
+            }
+          }
+        }
+      }
+    }
+  },
+  "redactions": []
+}

--- a/tests/fixtures/integration/provider-basic.json
+++ b/tests/fixtures/integration/provider-basic.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "name": "provider-basic",
+  "capturedAt": "2026-04-23T00:00:00.000Z",
+  "mode": "replay",
+  "data": {
+    "target": "provider",
+    "providerId": "demo-provider",
+    "baseUrl": "http://provider.local",
+    "checks": [
+      {
+        "name": "provider.health",
+        "status": "passed"
+      },
+      {
+        "name": "provider.schema",
+        "status": "passed"
+      },
+      {
+        "name": "provider.read_action",
+        "status": "passed"
+      }
+    ],
+    "health": {
+      "status": "ok",
+      "connectors": {
+        "demo": {
+          "status": "ok",
+          "lastSuccess": "2026-04-23T00:00:00.000Z"
+        }
+      }
+    },
+    "schema": {
+      "version": "1",
+      "services": [
+        {
+          "id": "demo",
+          "name": "Demo Provider",
+          "description": "Synthetic replay provider for integration harness tests.",
+          "actions": [
+            {
+              "id": "list_items",
+              "type": "read",
+              "method": "GET",
+              "requiresAuth": false,
+              "description": "List synthetic replay items.",
+              "params": {}
+            }
+          ]
+        }
+      ]
+    },
+    "readAction": {
+      "service": "demo",
+      "action": "list_items",
+      "status": 200,
+      "response": {
+        "status": "ok",
+        "items": [
+          {
+            "id": "item-1",
+            "label": "Synthetic replay item"
+          }
+        ]
+      }
+    }
+  },
+  "redactions": []
+}

--- a/tests/fixtures/integration/social-moltbook-basic.json
+++ b/tests/fixtures/integration/social-moltbook-basic.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 1,
+  "name": "social-moltbook-basic",
+  "capturedAt": "2026-04-23T00:00:00.000Z",
+  "mode": "replay",
+  "data": {
+    "target": "social",
+    "serviceId": "moltbook",
+    "baseUrl": "https://moltbook.example.invalid/api/v1",
+    "checks": [
+      {
+        "name": "social.read_notifications",
+        "status": "passed"
+      },
+      {
+        "name": "social.create_post",
+        "status": "failed",
+        "failureKind": "rate_limited",
+        "detail": "rate limit"
+      }
+    ],
+    "read": {
+      "status": "passed",
+      "notificationCount": 1,
+      "notifications": [
+        {
+          "id": "notification-1",
+          "type": "mention",
+          "postId": "post-1",
+          "post": {
+            "id": "post-1",
+            "content": {
+              "trust": "untrusted_public",
+              "value": "Public replay post mentioning telclaude."
+            },
+            "author": {
+              "handle": {
+                "trust": "untrusted_public",
+                "value": "writer.example"
+              }
+            }
+          },
+          "content": {
+            "trust": "untrusted_public",
+            "value": "Public replay post mentioning telclaude."
+          },
+          "createdAt": "2026-04-23T00:00:00.000Z"
+        }
+      ]
+    },
+    "post": {
+      "status": "failed",
+      "httpStatus": 429,
+      "failureKind": "rate_limited",
+      "error": "rate limit"
+    }
+  },
+  "redactions": []
+}

--- a/tests/fixtures/integration/telegram-control-plane.json
+++ b/tests/fixtures/integration/telegram-control-plane.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "name": "telegram-control-plane",
+  "capturedAt": "2026-04-23T00:00:00.000Z",
+  "mode": "replay",
+  "data": {
+    "cardCallbacks": {
+      "providerList": {
+        "action": "select-0",
+        "callbackText": "Replay Provider",
+        "expectedView": "detail",
+        "expectedSelectedProviderId": "replay-provider",
+        "expectedRevision": 2
+      }
+    },
+    "backgroundJobs": {
+      "completion": {
+        "expectedStatus": "completed",
+        "expectedMessage": "replay ok"
+      },
+      "restartRecovery": {
+        "expectedInterruptedStatus": "interrupted",
+        "expectedRecoveredStatus": "completed"
+      }
+    }
+  },
+  "redactions": []
+}

--- a/tests/integration/dashboard-route-snapshots.test.ts
+++ b/tests/integration/dashboard-route-snapshots.test.ts
@@ -1,0 +1,149 @@
+import path from "node:path";
+
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { readFixtureFile } from "../../src/testing/live-replay.js";
+
+vi.mock("../../src/logging.js", () => ({
+	getChildLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+vi.mock("../../src/totp-client/client.js", () => ({
+	getTOTPClient: () => ({ verify: async (_userId: string, code: string) => code === "123456" }),
+}));
+
+vi.mock("../../src/telegram/status-overview.js", () => ({
+	collectSystemHealth: async () => ({
+		overallStatus: "ok",
+		collectedAtMs: 1,
+		items: [{ id: "test", label: "Test", status: "ok", detail: "mock" }],
+		issueCount: 0,
+	}),
+}));
+
+vi.mock("../../src/providers/catalog.js", () => ({
+	listCatalogOAuthServices: () => [{ id: "google", displayName: "Google" }],
+	listProviderCatalogEntries: () => [
+		{ id: "health-provider", displayName: "Health", description: "d", services: [] },
+	],
+}));
+
+vi.mock("../../src/commands/skills-promote.js", () => ({
+	listActiveSkills: () => ["memory", "summarize"],
+	listDraftSkills: () => ["experimental"],
+}));
+
+vi.mock("../../src/security/approvals.js", () => ({
+	listAllowlist: () => [
+		{
+			id: 1,
+			userId: "[REDACTED_ID:user]",
+			tier: "WRITE_LOCAL",
+			toolKey: "Bash",
+			scope: "session",
+			sessionKey: "k",
+			grantedAt: 1000,
+			expiresAt: 2000,
+			lastUsedAt: null,
+			chatId: "[REDACTED_ID:chat]",
+		},
+	],
+}));
+
+vi.mock("../../src/security/audit.js", () => ({
+	createAuditLogger: () => ({
+		readRecent: async () => [
+			{
+				timestamp: new Date(1_700_000_000_000),
+				requestId: "r1",
+				telegramUserId: "[REDACTED_ID:user]",
+				chatId: "[REDACTED_ID:chat]",
+				messagePreview: "[REDACTED_TEXT]",
+				permissionTier: "READ_ONLY" as const,
+				outcome: "success" as const,
+			},
+		],
+	}),
+}));
+
+vi.mock("../../src/config/config.js", () => ({
+	loadConfig: () => ({
+		providers: [{ id: "health-provider", baseUrl: "https://example.test" }],
+		security: { audit: { enabled: true } },
+		dashboard: { enabled: true, port: 0 },
+	}),
+}));
+
+vi.mock("../../src/commands/doctor.js", () => ({
+	runDoctor: async () => ({
+		checks: [
+			{
+				name: "config.loaded",
+				category: "Config",
+				status: "pass",
+				summary: "ok",
+			},
+		],
+		summary: { pass: 1, warn: 0, fail: 0, skip: 0 },
+	}),
+}));
+
+vi.mock("../../src/dashboard/routes/operator.js", () => ({
+	registerOperatorRoutes: async () => {},
+}));
+
+import { registerApprovalsRoute } from "../../src/dashboard/routes/approvals.js";
+import { registerAuditRoute } from "../../src/dashboard/routes/audit.js";
+import { registerDoctorRoute } from "../../src/dashboard/routes/doctor.js";
+import { registerHealthRoute } from "../../src/dashboard/routes/health.js";
+import { registerProvidersRoute } from "../../src/dashboard/routes/providers.js";
+import { registerSkillsRoute } from "../../src/dashboard/routes/skills.js";
+
+type DashboardRoutesFixture = {
+	routes: Record<string, { statusCode: number; body: unknown }>;
+};
+
+const fixturePath = path.join(
+	process.cwd(),
+	"tests",
+	"fixtures",
+	"integration",
+	"dashboard-routes.json",
+);
+
+describe("dashboard route replay snapshots", () => {
+	let server: FastifyInstance;
+
+	beforeAll(async () => {
+		server = Fastify({ logger: false });
+		await registerHealthRoute(server);
+		await registerProvidersRoute(server);
+		await registerSkillsRoute(server);
+		await registerApprovalsRoute(server);
+		await registerAuditRoute(server);
+		await registerDoctorRoute(server);
+		await server.ready();
+	});
+
+	afterAll(async () => {
+		await server.close();
+	});
+
+	it("matches checked-in route snapshots without live services", async () => {
+		const fixture = await readFixtureFile<DashboardRoutesFixture>(fixturePath);
+
+		for (const [key, expected] of Object.entries(fixture.data.routes)) {
+			const [method, url] = key.split(" ");
+			const res = await server.inject({
+				method: method as "GET" | "POST",
+				url,
+			});
+			expect({ statusCode: res.statusCode, body: JSON.parse(res.body) }).toEqual(expected);
+		}
+	});
+});

--- a/tests/integration/live-replay-harness.test.ts
+++ b/tests/integration/live-replay-harness.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/logging.js", () => ({
+	getChildLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+vi.mock("../../src/secrets/index.js", () => ({
+	getSecret: vi.fn(),
+	SECRET_KEYS: { MOLTBOOK_API_KEY: "moltbook-api-key" },
+}));
+
+import {
+	assertProviderReplayFixture,
+	assertSocialReplayFixture,
+	type ProviderProbeResult,
+	type SocialProbeResult,
+} from "../../src/testing/integration-harness.js";
+import {
+	buildFixtureEnvelope,
+	readFixtureFile,
+	untrustedPublicText,
+	writeFixtureFile,
+} from "../../src/testing/live-replay.js";
+
+const fixtureDir = path.join(process.cwd(), "tests", "fixtures", "integration");
+
+describe("live/replay integration harness fixtures", () => {
+	let tempDir: string | null = null;
+
+	afterEach(() => {
+		if (tempDir) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+			tempDir = null;
+		}
+	});
+
+	it("redacts structured secrets, identifiers, and private text before writing", async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "telclaude-fixture-redaction-"));
+		const fixturePath = path.join(tempDir, "redacted.json");
+		const secret = ["Bear", "er", " ", "sk", "-", "a".repeat(32)].join("");
+
+		const written = await writeFixtureFile(
+			fixturePath,
+			buildFixtureEnvelope(
+				"redacted",
+				{
+					headers: { authorization: secret },
+					actorUserId: "telegram-user-123",
+					chatId: 99999,
+					message: "private Telegram message",
+					publicPost: untrustedPublicText("Public social post text"),
+				},
+				{ mode: "capture", capturedAt: "2026-04-23T00:00:00.000Z" },
+			),
+		);
+
+		expect(written.data.headers.authorization).toBe("[REDACTED_SECRET]");
+		expect(written.data.actorUserId).toMatch(/^\[REDACTED_ID:/);
+		expect(written.data.chatId).toMatch(/^\[REDACTED_ID:/);
+		expect(written.data.message).toBe("[REDACTED_TEXT]");
+		expect(written.data.publicPost).toEqual({
+			trust: "untrusted_public",
+			value: "Public social post text",
+		});
+		expect(fs.readFileSync(fixturePath, "utf8")).not.toContain("sk-");
+	});
+
+	it("fails closed when a secret-looking value survives structured redaction", async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "telclaude-fixture-secret-"));
+		const fixturePath = path.join(tempDir, "unsafe.json");
+
+		await expect(
+			writeFixtureFile(
+				fixturePath,
+				buildFixtureEnvelope(
+					"unsafe",
+					{
+						description: `unexpected sk-${"b".repeat(32)}`,
+					},
+					{ mode: "capture" },
+				),
+			),
+		).rejects.toThrow(/unredacted secret-like value/);
+	});
+
+	it("validates provider and social replay fixtures without network", async () => {
+		const provider = await readFixtureFile<ProviderProbeResult>(
+			path.join(fixtureDir, "provider-basic.json"),
+		);
+		const social = await readFixtureFile<SocialProbeResult>(
+			path.join(fixtureDir, "social-moltbook-basic.json"),
+		);
+
+		expect(() => assertProviderReplayFixture(provider.data)).not.toThrow();
+		expect(() => assertSocialReplayFixture(social.data)).not.toThrow();
+	});
+});

--- a/tests/integration/telegram-control-plane.replay.test.ts
+++ b/tests/integration/telegram-control-plane.replay.test.ts
@@ -1,0 +1,202 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFixtureFile } from "../../src/testing/live-replay.js";
+
+vi.mock("../../src/logging.js", () => ({
+	getChildLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+const ORIGINAL_DATA_DIR = process.env.TELCLAUDE_DATA_DIR;
+const fixturePath = path.join(
+	process.cwd(),
+	"tests",
+	"fixtures",
+	"integration",
+	"telegram-control-plane.json",
+);
+
+type ControlPlaneFixture = {
+	cardCallbacks: {
+		providerList: {
+			action: string;
+			callbackText: string;
+			expectedView: string;
+			expectedSelectedProviderId: string;
+			expectedRevision: number;
+		};
+	};
+	backgroundJobs: {
+		completion: { expectedStatus: string; expectedMessage: string };
+		restartRecovery: { expectedInterruptedStatus: string; expectedRecoveredStatus: string };
+	};
+};
+
+async function settle(ms = 30): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("Telegram control-plane replay harness", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "telclaude-control-plane-"));
+		process.env.TELCLAUDE_DATA_DIR = tempDir;
+		vi.resetModules();
+		const { resetDatabase } = await import("../../src/storage/db.js");
+		resetDatabase();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+		if (ORIGINAL_DATA_DIR === undefined) {
+			delete process.env.TELCLAUDE_DATA_DIR;
+		} else {
+			process.env.TELCLAUDE_DATA_DIR = ORIGINAL_DATA_DIR;
+		}
+	});
+
+	it("replays provider card callback reducers/executors with persisted state", async () => {
+		const fixture = await readFixtureFile<ControlPlaneFixture>(fixturePath);
+		const { buildCallbackToken } = await import("../../src/telegram/cards/callback-tokens.js");
+		const { CardRegistry } = await import("../../src/telegram/cards/registry.js");
+		const { createCard, getCard } = await import("../../src/telegram/cards/store.js");
+		const { handleCallback } = await import("../../src/telegram/cards/callback-controller.js");
+		const { CardKind } = await import("../../src/telegram/cards/types.js");
+
+		const registry = new CardRegistry();
+		registry.register(CardKind.ProviderList, {
+			render: (current) => ({
+				text: `${current.state.title}:${current.state.view}`,
+				parseMode: "MarkdownV2",
+				keyboard: null,
+			}),
+			reduce: (current) => current.state,
+			execute: ({ card }) => ({
+				state: {
+					...card.state,
+					view: "detail",
+					selectedProviderId: fixture.data.cardCallbacks.providerList.expectedSelectedProviderId,
+				},
+				callbackText: fixture.data.cardCallbacks.providerList.callbackText,
+				rerender: true,
+			}),
+		});
+
+		const card = createCard({
+			kind: CardKind.ProviderList,
+			chatId: 123,
+			messageId: 77,
+			actorScope: "user:456",
+			entityRef: "provider-list",
+			state: {
+				kind: CardKind.ProviderList,
+				title: "Providers",
+				view: "list",
+				page: 0,
+				canMutate: false,
+				providers: [
+					{
+						id: fixture.data.cardCallbacks.providerList.expectedSelectedProviderId,
+						label: fixture.data.cardCallbacks.providerList.callbackText,
+						health: "ok",
+					},
+				],
+			},
+			expiresAt: Date.now() + 60_000,
+		});
+
+		const answerCallbackQuery = vi.fn(async () => {});
+		const editMessageText = vi.fn(async () => ({}));
+		await handleCallback(
+			{
+				callbackQuery: {
+					data: buildCallbackToken({
+						shortId: card.shortId,
+						action: fixture.data.cardCallbacks.providerList.action,
+						revision: card.revision,
+					}),
+					message: { message_id: card.messageId },
+				},
+				chat: { id: card.chatId },
+				from: { id: 456, username: "operator" },
+				api: { editMessageText },
+				answerCallbackQuery,
+			} as any,
+			{ registry },
+		);
+
+		const persisted = getCard(card.cardId);
+		expect(answerCallbackQuery).toHaveBeenCalledWith({
+			text: fixture.data.cardCallbacks.providerList.callbackText,
+			show_alert: false,
+		});
+		expect(persisted?.revision).toBe(fixture.data.cardCallbacks.providerList.expectedRevision);
+		expect(persisted?.state).toEqual(
+			expect.objectContaining({
+				view: fixture.data.cardCallbacks.providerList.expectedView,
+				selectedProviderId: fixture.data.cardCallbacks.providerList.expectedSelectedProviderId,
+			}),
+		);
+	});
+
+	it("replays background completion and restart recovery semantics", async () => {
+		const fixture = await readFixtureFile<ControlPlaneFixture>(fixturePath);
+		const { claimQueuedJobs, createJob, getJob, markInterruptedOnStartup } = await import(
+			"../../src/background/jobs.js"
+		);
+		const { startBackgroundRunner } = await import("../../src/background/runner.js");
+
+		const completed = createJob({
+			title: "replay completion",
+			userId: "fixture-user",
+			tier: "WRITE_LOCAL",
+			payload: { kind: "noop", message: fixture.data.backgroundJobs.completion.expectedMessage },
+		});
+		const handle = startBackgroundRunner({ pollIntervalMs: 10 });
+		await handle.tick();
+		await settle(50);
+		handle.stop();
+		expect(getJob(completed.id)?.status).toBe(
+			fixture.data.backgroundJobs.completion.expectedStatus,
+		);
+		expect(getJob(completed.id)?.result?.message).toBe(
+			fixture.data.backgroundJobs.completion.expectedMessage,
+		);
+
+		const stuck = createJob({
+			title: "stuck",
+			userId: "fixture-user",
+			tier: "WRITE_LOCAL",
+			payload: { kind: "noop" },
+		});
+		claimQueuedJobs();
+		const recovered = createJob({
+			title: "recovered",
+			userId: "fixture-user",
+			tier: "WRITE_LOCAL",
+			payload: { kind: "noop", message: "recovered" },
+		});
+
+		const interrupted = markInterruptedOnStartup();
+		expect(interrupted.map((job) => job.id)).toContain(stuck.id);
+		expect(getJob(stuck.id)?.status).toBe(
+			fixture.data.backgroundJobs.restartRecovery.expectedInterruptedStatus,
+		);
+
+		const restartHandle = startBackgroundRunner({ pollIntervalMs: 10 });
+		await restartHandle.tick();
+		await settle(50);
+		restartHandle.stop();
+		expect(getJob(recovered.id)?.status).toBe(
+			fixture.data.backgroundJobs.restartRecovery.expectedRecoveredStatus,
+		);
+	});
+});

--- a/tests/status/personas.test.ts
+++ b/tests/status/personas.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import type { TelclaudeConfig } from "../../src/config/config.js";
+import type { CronJob } from "../../src/cron/types.js";
+import {
+	buildPersonaStatusSnapshot,
+	formatPersonaStatusSnapshot,
+	type PersonaAgentStatus,
+	type PersonaPluginStatus,
+} from "../../src/status/personas.js";
+
+const EMPTY_PLUGINS: PersonaPluginStatus = {
+	configured: true,
+	enabled: [],
+	installed: [],
+	error: null,
+};
+
+const REACHABLE_AGENT: PersonaAgentStatus = {
+	configured: true,
+	source: "test",
+	endpoint: "http://agent:8788",
+	reachability: "reachable",
+	checkedAt: "2026-04-23T00:00:00.000Z",
+	error: null,
+};
+
+function makeConfig(overrides: Partial<TelclaudeConfig> = {}): TelclaudeConfig {
+	return {
+		security: {
+			profile: "simple",
+			permissions: { defaultTier: "READ_ONLY", users: {} },
+			network: { additionalDomains: [], privateEndpoints: [] },
+		},
+		telegram: { heartbeatSeconds: 60 },
+		inbound: { reply: { enabled: true, timeoutSeconds: 600, typingIntervalSeconds: 8 } },
+		logging: {},
+		sdk: { betas: [] },
+		openai: {},
+		transcription: { provider: "openai", model: "whisper-1", timeoutSeconds: 60 },
+		imageGeneration: {
+			provider: "gpt-image",
+			model: "gpt-image-1.5",
+			size: "1024x1024",
+			quality: "medium",
+			maxPerHourPerUser: 10,
+			maxPerDayPerUser: 50,
+		},
+		videoProcessing: {
+			enabled: false,
+			frameInterval: 1,
+			maxFrames: 30,
+			maxDurationSeconds: 300,
+			extractAudio: true,
+		},
+		tts: {
+			provider: "openai",
+			voice: "alloy",
+			speed: 1,
+			autoReadResponses: false,
+			maxPerHourPerUser: 30,
+			maxPerDayPerUser: 100,
+		},
+		summarize: {
+			maxPerHourPerUser: 30,
+			maxPerDayPerUser: 100,
+			maxCharacters: 8000,
+			timeoutMs: 30_000,
+		},
+		providers: [],
+		socialServices: [],
+		cron: { enabled: true, pollIntervalSeconds: 15, timeoutSeconds: 900 },
+		dashboard: { enabled: false, port: 3005 },
+		...overrides,
+	} as TelclaudeConfig;
+}
+
+function cronJob(input: {
+	action: CronJob["action"];
+	lastRunAtMs: number;
+	lastStatus?: CronJob["lastStatus"];
+	lastError?: string | null;
+}): CronJob {
+	return {
+		id: "job",
+		name: "job",
+		enabled: true,
+		running: false,
+		ownerId: null,
+		deliveryTarget: { kind: "origin" },
+		schedule: { kind: "every", everyMs: 60_000 },
+		action: input.action,
+		nextRunAtMs: null,
+		lastRunAtMs: input.lastRunAtMs,
+		lastStatus: input.lastStatus ?? "success",
+		lastError: input.lastError ?? null,
+		createdAtMs: input.lastRunAtMs,
+		updatedAtMs: input.lastRunAtMs,
+	};
+}
+
+describe("persona status", () => {
+	it("fails closed when the social Claude profile is not configured", () => {
+		const snapshot = buildPersonaStatusSnapshot({
+			config: makeConfig({
+				socialServices: [
+					{
+						id: "xtwitter",
+						type: "xtwitter",
+						enabled: true,
+						heartbeatEnabled: true,
+						heartbeatIntervalHours: 4,
+						enableSkills: true,
+						notifyOnHeartbeat: "activity",
+					},
+				],
+			}),
+			env: {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: "/profiles/private",
+				TELCLAUDE_AGENT_URL: "http://agent:8788",
+			},
+			nowMs: 0,
+			activeSkillNames: ["memory"],
+			privatePlugins: EMPTY_PLUGINS,
+			agentReachability: { private: REACHABLE_AGENT },
+		});
+
+		expect(snapshot.overallHealth).toBe("not_configured");
+		expect(snapshot.personas.social.health).toBe("not_configured");
+		expect(snapshot.personas.social.profile).toEqual({
+			configured: false,
+			claudeHome: null,
+			source: "TELCLAUDE_SOCIAL_CLAUDE_HOME missing",
+		});
+		expect(snapshot.personas.social.skills.policy).toBe("fail_closed");
+		expect(snapshot.personas.social.skills.effective).toEqual([]);
+		expect(snapshot.personas.social.plugins.error).toContain("TELCLAUDE_SOCIAL_CLAUDE_HOME");
+	});
+
+	it("keeps private and social memory, filesystem, and skill boundaries separate", () => {
+		const snapshot = buildPersonaStatusSnapshot({
+			config: makeConfig({
+				providers: [
+					{
+						id: "google",
+						baseUrl: "http://private-provider.internal:3001",
+						services: ["gmail", "calendar"],
+					},
+				],
+				socialServices: [
+					{
+						id: "xtwitter",
+						type: "xtwitter",
+						enabled: true,
+						apiKey: "social-secret-api-key",
+						heartbeatEnabled: true,
+						heartbeatIntervalHours: 4,
+						enableSkills: true,
+						allowedSkills: ["social-posting"],
+						notifyOnHeartbeat: "activity",
+					},
+				],
+			}),
+			env: {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: "/profiles/private",
+				TELCLAUDE_SOCIAL_CLAUDE_HOME: "/profiles/social",
+				TELCLAUDE_AGENT_URL: "http://private-agent:8788",
+				TELCLAUDE_SOCIAL_AGENT_URL: "http://social-agent:8789",
+				TELCLAUDE_SKILL_CATALOG_DIR: "/catalog",
+			},
+			activeSkillNames: ["external-provider", "memory", "social-posting"],
+			privatePlugins: {
+				configured: true,
+				enabled: ["github@official"],
+				installed: ["github@official"],
+				error: null,
+			},
+			socialPlugins: {
+				configured: true,
+				enabled: ["browser-use@official"],
+				installed: ["browser-use@official"],
+				error: null,
+			},
+			agentReachability: { private: REACHABLE_AGENT, social: REACHABLE_AGENT },
+			latestSocialActivityAtMs: Date.parse("2026-04-23T10:00:00.000Z"),
+		});
+
+		expect(snapshot.personas.private.memory.source).toBe("telegram");
+		expect(snapshot.personas.social.memory.source).toBe("social");
+		expect(snapshot.personas.private.memory.contentsExposed).toBe(false);
+		expect(snapshot.personas.social.memory.contentsExposed).toBe(false);
+		expect(snapshot.personas.private.skills.effective).toEqual([
+			"external-provider",
+			"memory",
+			"social-posting",
+		]);
+		expect(snapshot.personas.social.skills.effective).toEqual(["social-posting"]);
+		expect(snapshot.personas.social.filesystem.workspace).toBe("not_mounted");
+		expect(snapshot.personas.social.boundaries.socialHasWorkspaceMount).toBe(false);
+		expect(snapshot.personas.private.boundaries.privateProcessesSocialMemory).toBe(false);
+		expect(snapshot.personas.social.providers.providerIds).toEqual(["google"]);
+		expect(snapshot.personas.social.providers.serviceIds).toEqual(["calendar", "gmail"]);
+
+		const serialized = JSON.stringify(snapshot);
+		expect(serialized).not.toContain("social-secret-api-key");
+		expect(serialized).not.toContain("private-provider.internal");
+	});
+
+	it("redacts secrets from operational errors before formatting", () => {
+		const snapshot = buildPersonaStatusSnapshot({
+			config: makeConfig(),
+			env: {
+				TELCLAUDE_PRIVATE_CLAUDE_HOME: "/profiles/private",
+				TELCLAUDE_SOCIAL_CLAUDE_HOME: "/profiles/social",
+			},
+			privatePlugins: EMPTY_PLUGINS,
+			socialPlugins: EMPTY_PLUGINS,
+			cronJobs: [
+				cronJob({
+					action: { kind: "private-heartbeat" },
+					lastRunAtMs: Date.parse("2026-04-23T09:00:00.000Z"),
+					lastStatus: "error",
+					lastError: "agent leaked sk-ant-1234567890abcdef in error",
+				}),
+			],
+			activeSkillNames: [],
+		});
+
+		expect(snapshot.personas.private.operations.lastError).toContain(
+			"[REDACTED:anthropic_api_key]",
+		);
+		expect(snapshot.personas.private.operations.lastError).not.toContain("sk-ant-1234567890abcdef");
+
+		const formatted = formatPersonaStatusSnapshot(snapshot);
+		expect(formatted).toContain("[REDACTED:anthropic_api_key]");
+		expect(formatted).not.toContain("sk-ant-1234567890abcdef");
+	});
+});

--- a/tests/telegram/background-control.test.ts
+++ b/tests/telegram/background-control.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let claimQueuedJobs: typeof import("../../src/background/index.js").claimQueuedJobs;
+let createJob: typeof import("../../src/background/index.js").createJob;
+let getJob: typeof import("../../src/background/index.js").getJob;
+let resetDatabase: typeof import("../../src/storage/db.js").resetDatabase;
+let stopActiveWorkCommand: typeof import("../../src/telegram/control-command-actions.js").stopActiveWorkCommand;
+
+const ORIGINAL_DATA_DIR = process.env.TELCLAUDE_DATA_DIR;
+
+describe("telegram background control", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "telclaude-bg-control-"));
+		process.env.TELCLAUDE_DATA_DIR = tempDir;
+
+		vi.resetModules();
+		({ resetDatabase } = await import("../../src/storage/db.js"));
+		resetDatabase();
+		({ claimQueuedJobs, createJob, getJob } = await import("../../src/background/index.js"));
+		({ stopActiveWorkCommand } = await import("../../src/telegram/control-command-actions.js"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+		if (ORIGINAL_DATA_DIR === undefined) {
+			delete process.env.TELCLAUDE_DATA_DIR;
+		} else {
+			process.env.TELCLAUDE_DATA_DIR = ORIGINAL_DATA_DIR;
+		}
+	});
+
+	it("cancels active background jobs scoped to the current chat topic", async () => {
+		const queued = createJob({
+			title: "queued job",
+			userId: "tg:100",
+			chatId: 100,
+			threadId: 7,
+			tier: "WRITE_LOCAL",
+			payload: { kind: "noop" },
+		});
+		const running = createJob({
+			title: "running job",
+			userId: "tg:100",
+			chatId: 100,
+			threadId: 7,
+			tier: "WRITE_LOCAL",
+			payload: { kind: "noop" },
+		});
+		const otherThread = createJob({
+			title: "other topic",
+			userId: "tg:100",
+			chatId: 100,
+			threadId: 8,
+			tier: "WRITE_LOCAL",
+			payload: { kind: "noop" },
+		});
+		claimQueuedJobs(Date.now(), 1);
+
+		const sendMessage = vi.fn(async () => ({ message_id: 1 }));
+		const result = await stopActiveWorkCommand({ sendMessage } as any, {
+			chatId: 100,
+			threadId: 7,
+		});
+
+		expect(result.callbackText).toBe("Stopped 2 background jobs");
+		expect(sendMessage).toHaveBeenCalledWith(
+			100,
+			expect.stringContaining("Stopped 2 background jobs"),
+			{ message_thread_id: 7 },
+		);
+		expect(sendMessage.mock.calls[0]?.[1]).toContain(queued.shortId);
+		expect(sendMessage.mock.calls[0]?.[1]).toContain(running.shortId);
+		expect(sendMessage.mock.calls[0]?.[1]).not.toContain(otherThread.shortId);
+		expect(getJob(queued.id)?.status).toBe("cancelled");
+		expect(getJob(running.id)?.status).toBe("cancelled");
+		expect(getJob(otherThread.id)?.status).toBe("queued");
+	});
+
+	it("explains the supported stop surface when there is nothing active", async () => {
+		const sendMessage = vi.fn(async () => ({ message_id: 1 }));
+		const result = await stopActiveWorkCommand({ sendMessage } as any, {
+			chatId: 100,
+		});
+
+		expect(result.callbackAlert).toBe(true);
+		expect(result.callbackText).toBe("No supported active work");
+		expect(sendMessage.mock.calls[0]?.[1]).toContain("queued/running background jobs");
+		expect(sendMessage.mock.calls[0]?.[1]).toContain("in-flight agent replies");
+	});
+});

--- a/tests/telegram/cards/card-hardening.test.ts
+++ b/tests/telegram/cards/card-hardening.test.ts
@@ -280,7 +280,7 @@ describe("card hardening", () => {
 		await pending;
 
 		expect(answerCallbackQuery).toHaveBeenCalledWith({
-			text: "Card expired",
+			text: "Card expired. Run the command again.",
 			show_alert: true,
 		});
 		expect(getCard(card.cardId)).toEqual(
@@ -326,7 +326,8 @@ describe("card hardening", () => {
 		expect(
 			[first.answerCallbackQuery, second.answerCallbackQuery].some((mock) =>
 				mock.mock.calls.some(
-					(args) => args[0]?.text === "Card outdated" && args[0]?.show_alert === true,
+					(args) =>
+						args[0]?.text === "Card outdated. Use the latest card." && args[0]?.show_alert === true,
 				),
 			),
 		).toBe(true);
@@ -515,7 +516,7 @@ describe("card hardening", () => {
 		await handleCallback(ctx, { registry });
 
 		expect(answerCallbackQuery).toHaveBeenCalledWith({
-			text: "Card outdated",
+			text: "Card outdated. Use the latest card.",
 			show_alert: true,
 		});
 	});

--- a/tests/telegram/cards/provider-list.test.ts
+++ b/tests/telegram/cards/provider-list.test.ts
@@ -107,6 +107,33 @@ describe("provider list card", () => {
 		expect(labels.filter((l) => l.includes("Remove")).length).toBe(1);
 	});
 
+	it("renders central remediation commands for provider health failures", () => {
+		const card = {
+			...baseCard(),
+			state: {
+				kind: CardKind.ProviderList,
+				title: "Providers",
+				providers: [
+					{
+						id: "private-api",
+						label: "Private API",
+						health: "auth_expired" as const,
+						detail: "connector auth expired",
+						remediationKey: "provider_auth_expired",
+					},
+				],
+				selectedProviderId: "private-api",
+				page: 0,
+				view: "detail" as const,
+				canMutate: false,
+			},
+		} as any;
+
+		const render = providerListRenderer.render(card);
+		expect(render.text).toContain("Provider auth expired");
+		expect(render.text).toContain("telclaude providers setup");
+	});
+
 	it("paginates server-side; token carries only the action verb", async () => {
 		const providers = Array.from({ length: 20 }, (_, idx) => ({
 			id: `p-${idx}`,

--- a/tests/telegram/control-commands.test.ts
+++ b/tests/telegram/control-commands.test.ts
@@ -35,9 +35,7 @@ describe("telegram control command registry", () => {
 				"social:promote",
 			);
 			expect(matchTelegramControlCommand("/social run xtwitter")?.command.id).toBe("social:run");
-			expect(matchTelegramControlCommand("/social log xtwitter 12")?.command.id).toBe(
-				"social:log",
-			);
+			expect(matchTelegramControlCommand("/social log xtwitter 12")?.command.id).toBe("social:log");
 			expect(matchTelegramControlCommand("/social ask what did you post?")?.command.id).toBe(
 				"social:ask",
 			);
@@ -47,9 +45,7 @@ describe("telegram control command registry", () => {
 			);
 			expect(matchTelegramControlCommand("/skills reload")?.command.id).toBe("skills:reload");
 			expect(matchTelegramControlCommand("/skills list")?.command.id).toBe("skills:list");
-			expect(matchTelegramControlCommand("/skills new my-skill")?.command.id).toBe(
-				"skills:new",
-			);
+			expect(matchTelegramControlCommand("/skills new my-skill")?.command.id).toBe("skills:new");
 			expect(matchTelegramControlCommand("/skills import")?.command.id).toBe("skills:import");
 			expect(matchTelegramControlCommand("/skills scan")?.command.id).toBe("skills:scan");
 			expect(matchTelegramControlCommand("/skills doctor")?.command.id).toBe("skills:doctor");
@@ -104,6 +100,13 @@ describe("telegram control command registry", () => {
 		it("matches shortcuts", () => {
 			const sethomeMatch = matchTelegramControlCommand("/sethome");
 			expect(sethomeMatch?.command.id).toBe("sethome");
+
+			const stopMatch = matchTelegramControlCommand("/stop");
+			expect(stopMatch?.command.id).toBe("stop");
+
+			const stopJobMatch = matchTelegramControlCommand("/stop a1b2c3d4");
+			expect(stopJobMatch?.command.id).toBe("stop");
+			expect(stopJobMatch?.args).toEqual(["a1b2c3d4"]);
 
 			const approveMatch = matchTelegramControlCommand("/approve 123456");
 			expect(approveMatch?.command.id).toBe("approve");
@@ -171,6 +174,7 @@ describe("telegram control command registry", () => {
 				"social",
 				"skills",
 				"background",
+				"stop",
 				"approve",
 				"new",
 			]) {
@@ -226,6 +230,14 @@ describe("telegram control command registry", () => {
 			expect(catalog).toContain("/skills drafts");
 			expect(catalog).toContain("/skills promote");
 			expect(catalog).toContain("/skills reload");
+		});
+	});
+
+	describe("/stop command help", () => {
+		it("documents supported active-work cancellation", () => {
+			const help = formatTelegramHelp("background");
+			expect(help).toContain("/stop");
+			expect(help).toContain("background jobs");
 		});
 	});
 });

--- a/tests/telegram/pending-queue-card.test.ts
+++ b/tests/telegram/pending-queue-card.test.ts
@@ -23,7 +23,9 @@ function makePendingQueueCard(options: {
 	chatId?: number;
 	actorScope?: string;
 	page?: number;
-	entries: Array<{ id: string; label: string; summary?: string }>;
+	entries: Array<Record<string, unknown> & { id: string; label: string; summary?: string }>;
+	view?: "list" | "detail";
+	selectedEntryId?: string;
 }) {
 	return createCard({
 		kind: CardKind.PendingQueue,
@@ -37,6 +39,8 @@ function makePendingQueueCard(options: {
 			entries: options.entries,
 			total: options.entries.length,
 			page: options.page ?? 0,
+			view: options.view ?? "list",
+			selectedEntryId: options.selectedEntryId,
 		},
 		expiresAt: Date.now() + 60_000,
 	});
@@ -45,10 +49,19 @@ function makePendingQueueCard(options: {
 function makeCallbackContext(options: {
 	card: ReturnType<typeof makePendingQueueCard>;
 	actorId: number;
-	action: "promote" | "dismiss";
+	action:
+		| "view"
+		| "back"
+		| "edit"
+		| "refine"
+		| "promote"
+		| "dismiss"
+		| "mark-posted"
+		| "retry-api";
 }) {
 	const answerCallbackQuery = vi.fn(async () => {});
 	const editMessageText = vi.fn(async () => {});
+	const sendMessage = vi.fn(async () => ({ message_id: 99 }));
 	return {
 		ctx: {
 			callbackQuery: {
@@ -61,22 +74,28 @@ function makeCallbackContext(options: {
 			},
 			chat: { id: options.card.chatId },
 			from: { id: options.actorId, username: `user${options.actorId}` },
-			api: { editMessageText },
+			api: { editMessageText, sendMessage },
 			answerCallbackQuery,
 		} as any,
 		answerCallbackQuery,
 		editMessageText,
+		sendMessage,
 	};
 }
 
 function makePagedEntries() {
-	return [
-		{ id: "page-5", label: "Entry 5" },
-		{ id: "page-4", label: "Entry 4" },
-		{ id: "page-3", label: "Entry 3" },
-		{ id: "page-2", label: "Entry 2" },
-		{ id: "page-1", label: "Entry 1" },
-	];
+	for (let index = 1; index <= 5; index += 1) {
+		createQuarantinedEntry(
+			{
+				id: `page-${index}`,
+				category: "posts",
+				content: `post ${index}`,
+				chatId: "777",
+			},
+			index,
+		);
+	}
+	return loadPendingQueueEntries("777");
 }
 
 describe("pending queue cards", () => {
@@ -123,7 +142,7 @@ describe("pending queue cards", () => {
 		const card = makePendingQueueCard({
 			chatId: 777,
 			actorScope: "user:101",
-			entries: [{ id: "allowed-post", label: "Allowed post" }],
+			entries: loadPendingQueueEntries("777"),
 		});
 		const { ctx, answerCallbackQuery, editMessageText } = makeCallbackContext({
 			card,
@@ -133,13 +152,18 @@ describe("pending queue cards", () => {
 
 		await handleCallback(ctx);
 
-		expect(answerCallbackQuery).toHaveBeenCalledWith({ text: "Promoted", show_alert: false });
+		expect(answerCallbackQuery).toHaveBeenCalledWith({ text: "Approved", show_alert: false });
 		expect(editMessageText).toHaveBeenCalledOnce();
 		const promoted = getEntries({ chatId: "777", order: "asc" })[0];
 		expect(promoted._provenance.trust).toBe("trusted");
 		expect(promoted._provenance.promotedBy).toBe("telegram:777:101");
+		expect(promoted.metadata).toEqual(expect.objectContaining({ draftState: "queued" }));
 		expect(getCard(card.cardId)?.state).toEqual(
-			expect.objectContaining({ entries: [], total: 0, page: 0 }),
+			expect.objectContaining({
+				entries: [expect.objectContaining({ id: "allowed-post", status: "queued" })],
+				total: 1,
+				page: 0,
+			}),
 		);
 	});
 
@@ -237,7 +261,7 @@ describe("pending queue cards", () => {
 				summary: expect.stringContaining("quote @writer"),
 			}),
 		);
-		expect(entries[0]?.summary).toContain("Quoted source text worth keeping around");
+		expect(entries[0]?.summary).toContain("Quoted source text worth");
 		expect(entries.at(-1)).toEqual(
 			expect.objectContaining({
 				id: "telegram-4",
@@ -246,15 +270,144 @@ describe("pending queue cards", () => {
 		);
 	});
 
-	it("clamps to the previous page after promote removes the last item on the final page", async () => {
-		for (let index = 1; index <= 5; index += 1) {
-			createQuarantinedEntry({
-				id: `page-${index}`,
-				category: "posts",
-				content: `post ${index}`,
-				chatId: "777",
-			});
-		}
+	it("opens a detail view with metadata and copy-ready text", async () => {
+		createEntries(
+			[
+				{
+					id: "detail-quote",
+					category: "posts",
+					content: "Copy ready quote text",
+					metadata: {
+						action: "quote",
+						draftState: "manual_action_needed",
+						draftWorkflow: "workbench",
+						serviceId: "xtwitter",
+						targetPostId: "tweet-9",
+						targetAuthor: "@writer",
+						targetExcerpt: "Original source text",
+						targetUrl: "https://x.example/post/tweet-9",
+						manualActionReason: "quote API unavailable",
+					},
+				},
+			],
+			"social",
+			Date.now(),
+		);
+		const entries = loadPendingQueueEntries("777");
+		const card = makePendingQueueCard({
+			chatId: 777,
+			actorScope: "user:101",
+			entries,
+		});
+
+		const result = await pendingQueueRenderer.execute({
+			ctx: { from: { id: 101 } } as any,
+			card,
+			action: { type: "view" },
+		});
+		const nextState = result.state;
+		expect(nextState).toEqual(
+			expect.objectContaining({
+				view: "detail",
+				selectedEntryId: "detail-quote",
+			}),
+		);
+
+		const rendered = pendingQueueRenderer.render({ ...card, state: nextState! });
+		expect(rendered.text).toContain("Manual action");
+		expect(rendered.text).toContain("xtwitter");
+		expect(rendered.text).toContain("Copy-ready text");
+		expect(rendered.text).toContain("Copy ready quote text");
+		expect(JSON.stringify(rendered.keyboard?.inline_keyboard)).toContain("Open target");
+	});
+
+	it("queues manual-action drafts for API retry", async () => {
+		createEntries(
+			[
+				{
+					id: "manual-retry",
+					category: "posts",
+					content: "Retry this draft",
+					metadata: {
+						draftState: "manual_action_needed",
+						draftWorkflow: "workbench",
+						serviceId: "xtwitter",
+						manualActionReason: "API unavailable",
+					},
+				},
+			],
+			"social",
+			Date.now(),
+		);
+		const card = makePendingQueueCard({
+			chatId: 777,
+			actorScope: "user:101",
+			entries: loadPendingQueueEntries("777"),
+			view: "detail",
+			selectedEntryId: "manual-retry",
+		});
+
+		const result = await pendingQueueRenderer.execute({
+			ctx: { from: { id: 101 } } as any,
+			card,
+			action: { type: "retry-api" },
+		});
+
+		expect(result.callbackText).toBe("Queued for API retry");
+		expect(result.state).toEqual(
+			expect.objectContaining({
+				entries: [expect.objectContaining({ id: "manual-retry", status: "queued" })],
+				selectedEntryId: "manual-retry",
+			}),
+		);
+		const stored = getEntries({ sources: ["social"], order: "asc" })[0];
+		expect(stored._provenance.trust).toBe("trusted");
+		expect(stored.metadata).toEqual(expect.objectContaining({ draftState: "queued" }));
+	});
+
+	it("starts edit and refine flows through deferred card actions", async () => {
+		createEntries(
+			[
+				{
+					id: "editable-draft",
+					category: "posts",
+					content: "Needs polish",
+					metadata: {
+						draftState: "needs_review",
+						draftWorkflow: "workbench",
+						serviceId: "moltbook",
+					},
+				},
+			],
+			"social",
+			Date.now(),
+		);
+		const card = makePendingQueueCard({
+			chatId: 777,
+			actorScope: "user:101",
+			entries: loadPendingQueueEntries("777"),
+			view: "detail",
+			selectedEntryId: "editable-draft",
+		});
+
+		const editResult = await pendingQueueRenderer.execute({
+			ctx: { from: { id: 101 } } as any,
+			card,
+			action: { type: "edit" },
+		});
+		const refineResult = await pendingQueueRenderer.execute({
+			ctx: { from: { id: 101 } } as any,
+			card,
+			action: { type: "refine" },
+		});
+
+		expect(editResult.callbackText).toBe("Reply with edited text");
+		expect(editResult.afterCommit).toBeTypeOf("function");
+		expect(refineResult.callbackText).toBe("Reply with refinement instruction");
+		expect(refineResult.afterCommit).toBeTypeOf("function");
+	});
+
+	it("clamps to the previous page after mark-posted removes the last item on the final page", async () => {
 		const card = makePendingQueueCard({
 			chatId: 777,
 			actorScope: "user:101",
@@ -265,7 +418,7 @@ describe("pending queue cards", () => {
 		const result = await pendingQueueRenderer.execute({
 			ctx: { from: { id: 101 } } as any,
 			card,
-			action: { type: "promote" },
+			action: { type: "mark-posted" },
 		});
 		const nextState = result.state;
 		expect(nextState).toEqual(
@@ -275,10 +428,14 @@ describe("pending queue cards", () => {
 			}),
 		);
 
+		const posted = getEntries({ posted: true, order: "asc" })[0];
+		expect(posted.id).toBe("page-1");
+		expect(posted.metadata).toEqual(expect.objectContaining({ draftState: "marked_posted" }));
+
 		const rendered = pendingQueueRenderer.render({ ...card, state: nextState! });
-		expect(rendered.text).toContain("Entry 5");
-		expect(rendered.text).toContain("Entry 2");
-		expect(rendered.text).not.toContain("Entry 1");
+		expect(rendered.text).toContain("post 5");
+		expect(rendered.text).toContain("post 2");
+		expect(rendered.text).not.toContain("post 1");
 		expect(rendered.text).not.toContain("_No pending entries_");
 	});
 
@@ -304,9 +461,9 @@ describe("pending queue cards", () => {
 		);
 
 		const rendered = pendingQueueRenderer.render({ ...card, state: nextState! });
-		expect(rendered.text).toContain("Entry 5");
-		expect(rendered.text).toContain("Entry 2");
-		expect(rendered.text).not.toContain("Entry 1");
+		expect(rendered.text).toContain("post 5");
+		expect(rendered.text).toContain("post 2");
+		expect(rendered.text).not.toContain("post 1");
 		expect(rendered.text).not.toContain("_No pending entries_");
 	});
 });


### PR DESCRIPTION
Add the #90-#94 operator follow-up wave in one coordinated branch.

The PR makes Telegram control-plane operations calmer and more recoverable, expands the loopback dashboard into a read-mostly operator cockpit, turns /social queue into a persisted public draft workbench, adds replay-first integration coverage for provider/social/control-plane/dashboard boundaries, and exposes metadata-only private/social persona status across CLI, Telegram, and dashboard surfaces.

The release review also found high-severity dependency audit findings that would block deployment, so this branch includes narrow pnpm overrides for patched Fastify, Vite, Rollup, minimatch, and picomatch versions.

Reviewer focus: dashboard/operator APIs should stay metadata-only, persona status must not expose secrets or private/social memory contents, and social draft actions must preserve operator approval boundaries before public posting.

Fixes #90
Fixes #91
Fixes #92
Fixes #93
Fixes #94