### PR TITLE
fix(ci): make gitleaks test-fixture allowlisting squash-proof

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -87,8 +87,3 @@ e0dea00a83982bd35dbf329029903fa2031f6b58:tests/curator/store.test.ts:github-pat:
 e0dea00a83982bd35dbf329029903fa2031f6b58:tests/curator/collectors.test.ts:github-pat:33
 e0dea00a83982bd35dbf329029903fa2031f6b58:tests/curator/collectors.test.ts:github-pat:38
 e0dea00a83982bd35dbf329029903fa2031f6b58:tests/curator/collectors.test.ts:github-pat:58
-
-# PR #115 review-fix test fixtures: fake encryption passphrase + sentinel bot tokens (not real secrets)
-3929d79433d4ea61e279a8cdb0eda6d120125228:tests/crypto/encrypted-file-store.test.ts:credentials-javascript:18
-3929d79433d4ea61e279a8cdb0eda6d120125228:tests/commands/audit-fixers.test.ts:credentials-javascript:221
-3929d79433d4ea61e279a8cdb0eda6d120125228:tests/commands/audit-fixers.test.ts:credentials-javascript:373

--- a/tests/commands/audit-fixers.test.ts
+++ b/tests/commands/audit-fixers.test.ts
@@ -218,7 +218,7 @@ describe("raw-policy-only write (no overlay/default leak)", () => {
 	// Sentinel values that exist ONLY in the merged config / private overlay, never in
 	// the raw policy file on disk. If any of these surface in the rewritten policy file,
 	// the fixer leaked merged state.
-	const PRIVATE_BOT_TOKEN = "1111111111:LEAKED-PRIVATE-BOT-TOKEN-do-not-write";
+	const PRIVATE_BOT_TOKEN = "1111111111:LEAKED-PRIVATE-BOT-TOKEN-do-not-write"; // gitleaks:allow -- fake sentinel, not a real bot token
 	const PRIVATE_ALLOWED_CHAT = 7_001_002_003;
 	const PRIVATE_ADMIN_CHAT = 9_008_007_006;
 	const PRIVATE_USER_ID = "424242";
@@ -370,7 +370,7 @@ describe("raw-policy-only write (no overlay/default leak)", () => {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 describe("overlay guard (raw-only regardless of TELCLAUDE_PRIVATE_CONFIG)", () => {
-	const PRIVATE_BOT_TOKEN = "2222222222:OVERLAY-TOKEN-must-not-leak";
+	const PRIVATE_BOT_TOKEN = "2222222222:OVERLAY-TOKEN-must-not-leak"; // gitleaks:allow -- fake sentinel, not a real bot token
 	const PRIVATE_ALLOWED_CHAT = 8_111_222_333;
 
 	it("writes only the raw policy even when TELCLAUDE_PRIVATE_CONFIG is set and points at a real overlay", () => {

--- a/tests/crypto/encrypted-file-store.test.ts
+++ b/tests/crypto/encrypted-file-store.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { EncryptedFileStore } from "../../src/crypto/encrypted-file-store.js";
 
-const KEY = "test-encryption-key-at-least-32-chars-long";
+const KEY = "test-encryption-key-at-least-32-chars-long"; // gitleaks:allow -- fake test passphrase, not a real secret
 const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
 
 describe("EncryptedFileStore", () => {


### PR DESCRIPTION
## Why
PR #115's `.gitleaksignore` entries were **commit-pinned fingerprints** (`3929d79:…`). The squash-merge created a new commit SHA (`b781e9a`), so the fingerprints stopped matching and the **Gitleaks check failed on `main`** (the test fixtures re-flagged under the new SHA).

## Fix
Replace the fragile fingerprints with inline `gitleaks:allow` on the three fake fixtures (a test encryption passphrase + two `1111…`/`2222…` sentinel bot tokens used by the H1/H3 regression tests). Inline allow is **commit-agnostic** — it travels with the code and survives any future squash/rebase — and self-documents that the value is an intentional non-secret.

- `tests/crypto/encrypted-file-store.test.ts` — passphrase fixture
- `tests/commands/audit-fixers.test.ts` — two sentinel-token fixtures
- `.gitleaksignore` — removed the 3 dead fingerprints

typecheck clean; affected suites pass (37/37). No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)