### PR TITLE
[codex] Fail Docker builds without sqlite binding

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,6 +66,11 @@ RUN pnpm prune --prod --ignore-scripts \
     && rm -rf node_modules/.pnpm/@img+sharp-libvips-linuxmusl* \
     && rm -rf node_modules/.pnpm/@img+sharp-linuxmusl*
 
+# pnpm prune can relink native packages after install scripts ran. Rebuild the
+# runtime SQLite binding after pruning and fail the image build if it is absent.
+RUN pnpm rebuild better-sqlite3 \
+    && node -e "require('better-sqlite3'); console.log('better-sqlite3 OK')"
+
 # ─────────────────────────────────────────────────────────────────────────────────
 # Stage 2: Claude CLI
 # Install Claude Code CLI in a separate stage
@@ -171,6 +176,10 @@ COPY --chown=node:node docs/soul.md ./docs/soul.md
 COPY --chown=node:node docs/social-contract.md ./docs/social-contract.md
 COPY --chown=node:node docs/architecture.md ./docs/architecture.md
 COPY --chown=node:node assets/logo/logo-512.png ./assets/logo/logo-512.png
+
+# Prove the copied production tree can load the native SQLite binding in the
+# final runtime image, not only in the builder stage.
+RUN node -e "require('better-sqlite3'); console.log('better-sqlite3 runtime OK')"
 
 # Copy firewall initialization scripts and entrypoint wrapper
 COPY --chown=node:node docker/init-firewall.sh /usr/local/bin/init-firewall.sh

--- a/docker/Dockerfile.google-services
+++ b/docker/Dockerfile.google-services
@@ -42,6 +42,12 @@ RUN pnpm rebuild
 # Prune dev dependencies
 RUN pnpm prune --prod --ignore-scripts
 
+# The Google sidecar uses the same better-sqlite3 runtime binding as the relay.
+# Rebuild after prune so pnpm cannot leave a production tree without the native
+# addon, then fail the image build if the binding cannot be loaded.
+RUN pnpm rebuild better-sqlite3 \
+    && node -e "require('better-sqlite3'); console.log('better-sqlite3 OK')"
+
 # ─────────────────────────────────────────────────────────────────────────────────
 # Stage 2: Runtime (Minimal)
 # ─────────────────────────────────────────────────────────────────────────────────
@@ -64,6 +70,8 @@ WORKDIR /app
 COPY --from=builder --chown=node:node /build/dist ./dist
 COPY --from=builder --chown=node:node /build/node_modules ./node_modules
 COPY --from=builder --chown=node:node /build/package.json ./
+
+RUN node -e "require('better-sqlite3'); console.log('better-sqlite3 runtime OK')"
 
 # Environment
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- rebuild better-sqlite3 after production prune in the relay and Google Services Docker builders
- add builder-stage and final-runtime-image require checks so missing native bindings fail the image build loudly

## Why
William production hit a relay crash loop because the built telclaude image was missing better_sqlite3.node at runtime. The Dockerfile installed with scripts disabled, rebuilt native modules, then pruned production dependencies; pnpm can relink after prune and leave the production tree without the compiled binding.

## Validation
- git diff --check
- peer review via AMQ approved the diff
- Docker CLI is not available on this local machine; the PR/deploy runner will perform the actual image build proof
