### PR TITLE
fix: build WhatsApp bridge image

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,4 +9,4 @@ cd "$(dirname "$0")/.."
 export GIT_COMMIT
 GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
 
-exec docker compose -f docker/docker-compose.yml build "$@"
+exec docker compose -f docker/docker-compose.yml --profile whatsapp build "$@"

--- a/tests/docker/whatsapp-bridge-topology.test.ts
+++ b/tests/docker/whatsapp-bridge-topology.test.ts
@@ -47,6 +47,12 @@ function networksSection(service: string | null): string {
 }
 
 describe("WhatsApp bridge Docker topology", () => {
+	it("includes the WhatsApp profile in the shared Docker build helper", () => {
+		const buildScript = readDockerFile("docker/build.sh");
+
+		expect(buildScript).toContain("--profile whatsapp build");
+	});
+
 	it.each([
 		"docker/docker-compose.yml",
 		"docker/docker-compose.deploy.yml",


### PR DESCRIPTION
## Summary
- include the WhatsApp compose profile in `docker/build.sh` so CI/deploy builds `telclaude-whatsapp-bridge:latest` without starting it
- add a topology test assertion that the shared build helper includes the WhatsApp profile

## Why
#128 landed the WhatsApp bridge as a profile-gated service, but the default deploy build helper only built default compose services. That left the bridge image absent on William until a manual/profile build. This keeps runtime startup profile-gated while making the image available for later pairing and phone allowlist setup.

## Validation
- `pnpm install --frozen-lockfile` in the worktree, then build/prepare passed
- `pnpm typecheck`
- `pnpm exec vitest run tests/docker/whatsapp-bridge-topology.test.ts`
- `pnpm exec biome check docker/build.sh tests/docker/whatsapp-bridge-topology.test.ts`
- `git diff --check`
- Claude peer review approved via AMQ; Claude also independently test-built `Dockerfile.whatsapp-bridge` locally on Colima: build OK
