### PR TITLE
[codex] Add secretless provider enrollment relay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
           operator_relay_public_key="$(read_deploy_env OPERATOR_RPC_RELAY_PUBLIC_KEY || true)"
           whatsapp_bridge_secret="$(read_deploy_env TELCLAUDE_WHATSAPP_BRIDGE_SECRET || true)"
           whatsapp_inbound_secret="$(read_deploy_env TELCLAUDE_WHATSAPP_INBOUND_SECRET || true)"
+          israel_sidecar_hmac_key="$(read_deploy_env TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY || true)"
+          israel_sidecar_hmac_vault_target="$(read_deploy_env TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET || true)"
           if [ -z "$operator_agent_private_key" ] || [ -z "$operator_agent_public_key" ] || [ -z "$operator_relay_private_key" ] || [ -z "$operator_relay_public_key" ]; then
             while IFS='=' read -r key value; do
               case "$key" in
@@ -134,7 +136,7 @@ jobs:
           fi
           [ -n "$whatsapp_bridge_secret" ] || whatsapp_bridge_secret="$(openssl rand -hex 32)"
           [ -n "$whatsapp_inbound_secret" ] || whatsapp_inbound_secret="$(openssl rand -hex 32)"
-          for secret in "$TELCLAUDE_HERMES_API_SERVER_KEY" "$TELCLAUDE_HERMES_SOCIAL_API_SERVER_KEY" "$TELCLAUDE_HERMES_MCP_RELAY_TOKEN" "$operator_agent_private_key" "$operator_agent_public_key" "$operator_relay_private_key" "$operator_relay_public_key" "$whatsapp_bridge_secret" "$whatsapp_inbound_secret"; do
+          for secret in "$TELCLAUDE_HERMES_API_SERVER_KEY" "$TELCLAUDE_HERMES_SOCIAL_API_SERVER_KEY" "$TELCLAUDE_HERMES_MCP_RELAY_TOKEN" "$operator_agent_private_key" "$operator_agent_public_key" "$operator_relay_private_key" "$operator_relay_public_key" "$whatsapp_bridge_secret" "$whatsapp_inbound_secret" "$israel_sidecar_hmac_key"; do
             [ -n "$secret" ] && echo "::add-mask::${secret}"
           done
           hermes_private_subnet='172.30.92.0/24'
@@ -149,8 +151,8 @@ jobs:
           hermes_live_mcp_admin_enabled=1
           hermes_live_mcp_additional_binds="${hermes_social_relay_ip}@telclaude-hermes-social"
           hermes_live_mcp_allowed_peers="${hermes_contained_ip},${hermes_social_ip}"
-          shell_key_pattern='^(export[[:space:]]+)?(TELCLAUDE_HERMES_(API_SERVER_KEY|SOCIAL_API_SERVER_KEY|MCP_RELAY_TOKEN|RELAY_SUBNET|SOCIAL_RELAY_SUBNET|RELAY_IP|SOCIAL_RELAY_IP|CONTAINED_IP|SOCIAL_IP|LIVE_MCP_ENABLED|LIVE_MCP_ADMIN_ENABLED|LIVE_MCP_HOST|LIVE_MCP_ADDITIONAL_BINDS|LIVE_MCP_ALLOWED_PEERS|SERVED_MCP_OFF_DOMAIN_PEER_IP)|TELCLAUDE_WHATSAPP_(BRIDGE_SECRET|INBOUND_SECRET)|OPERATOR_RPC_(AGENT_PRIVATE_KEY|AGENT_PUBLIC_KEY|RELAY_PRIVATE_KEY|RELAY_PUBLIC_KEY))='
-          compose_key_pattern='^(export[[:space:]]+)?(TELCLAUDE_HERMES_(API_SERVER_KEY|SOCIAL_API_SERVER_KEY|MCP_RELAY_TOKEN|RELAY_SUBNET|SOCIAL_RELAY_SUBNET|RELAY_IP|SOCIAL_RELAY_IP|CONTAINED_IP|SOCIAL_IP|LIVE_MCP_ENABLED|LIVE_MCP_ADMIN_ENABLED|LIVE_MCP_HOST|LIVE_MCP_ADDITIONAL_BINDS|LIVE_MCP_ALLOWED_PEERS|SERVED_MCP_OFF_DOMAIN_PEER_IP)|TELCLAUDE_WHATSAPP_(BRIDGE_SECRET|INBOUND_SECRET)|OPERATOR_RPC_(AGENT_PUBLIC_KEY|RELAY_PRIVATE_KEY))='
+          shell_key_pattern='^(export[[:space:]]+)?(TELCLAUDE_HERMES_(API_SERVER_KEY|SOCIAL_API_SERVER_KEY|MCP_RELAY_TOKEN|RELAY_SUBNET|SOCIAL_RELAY_SUBNET|RELAY_IP|SOCIAL_RELAY_IP|CONTAINED_IP|SOCIAL_IP|LIVE_MCP_ENABLED|LIVE_MCP_ADMIN_ENABLED|LIVE_MCP_HOST|LIVE_MCP_ADDITIONAL_BINDS|LIVE_MCP_ALLOWED_PEERS|SERVED_MCP_OFF_DOMAIN_PEER_IP)|TELCLAUDE_WHATSAPP_(BRIDGE_SECRET|INBOUND_SECRET)|TELCLAUDE_ISRAEL_SIDECAR_HMAC_(KEY|VAULT_TARGET)|OPERATOR_RPC_(AGENT_PRIVATE_KEY|AGENT_PUBLIC_KEY|RELAY_PRIVATE_KEY|RELAY_PUBLIC_KEY))='
+          compose_key_pattern='^(export[[:space:]]+)?(TELCLAUDE_HERMES_(API_SERVER_KEY|SOCIAL_API_SERVER_KEY|MCP_RELAY_TOKEN|RELAY_SUBNET|SOCIAL_RELAY_SUBNET|RELAY_IP|SOCIAL_RELAY_IP|CONTAINED_IP|SOCIAL_IP|LIVE_MCP_ENABLED|LIVE_MCP_ADMIN_ENABLED|LIVE_MCP_HOST|LIVE_MCP_ADDITIONAL_BINDS|LIVE_MCP_ALLOWED_PEERS|SERVED_MCP_OFF_DOMAIN_PEER_IP)|TELCLAUDE_WHATSAPP_(BRIDGE_SECRET|INBOUND_SECRET)|TELCLAUDE_ISRAEL_SIDECAR_HMAC_(KEY|VAULT_TARGET)|OPERATOR_RPC_(AGENT_PUBLIC_KEY|RELAY_PRIVATE_KEY))='
           grep -Ev "$shell_key_pattern" "$shell_env_file" > "$tmp_file" || true
           {
             cat "$tmp_file"
@@ -171,6 +173,8 @@ jobs:
             printf 'export TELCLAUDE_HERMES_SERVED_MCP_OFF_DOMAIN_PEER_IP=%s\n' "$hermes_social_ip"
             printf 'export TELCLAUDE_WHATSAPP_BRIDGE_SECRET=%q\n' "$whatsapp_bridge_secret"
             printf 'export TELCLAUDE_WHATSAPP_INBOUND_SECRET=%q\n' "$whatsapp_inbound_secret"
+            [ -z "$israel_sidecar_hmac_key" ] || printf 'export TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY=%q\n' "$israel_sidecar_hmac_key"
+            [ -z "$israel_sidecar_hmac_vault_target" ] || printf 'export TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET=%q\n' "$israel_sidecar_hmac_vault_target"
             printf 'export OPERATOR_RPC_AGENT_PRIVATE_KEY=%q\n' "$operator_agent_private_key"
             printf 'export OPERATOR_RPC_AGENT_PUBLIC_KEY=%q\n' "$operator_agent_public_key"
             printf 'export OPERATOR_RPC_RELAY_PRIVATE_KEY=%q\n' "$operator_relay_private_key"
@@ -196,6 +200,8 @@ jobs:
             printf 'TELCLAUDE_HERMES_SERVED_MCP_OFF_DOMAIN_PEER_IP=%s\n' "$hermes_social_ip"
             printf 'TELCLAUDE_WHATSAPP_BRIDGE_SECRET=%s\n' "$whatsapp_bridge_secret"
             printf 'TELCLAUDE_WHATSAPP_INBOUND_SECRET=%s\n' "$whatsapp_inbound_secret"
+            [ -z "$israel_sidecar_hmac_key" ] || printf 'TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY=%s\n' "$israel_sidecar_hmac_key"
+            [ -z "$israel_sidecar_hmac_vault_target" ] || printf 'TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET=%s\n' "$israel_sidecar_hmac_vault_target"
             printf 'OPERATOR_RPC_AGENT_PUBLIC_KEY=%s\n' "$operator_agent_public_key"
             printf 'OPERATOR_RPC_RELAY_PRIVATE_KEY=%s\n' "$operator_relay_private_key"
           } > "$compose_env_file"

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -157,6 +157,15 @@ TELCLAUDE_FIREWALL=1
 # if you publish it to a registry.
 # TELCLAUDE_WHATSAPP_BRIDGE_IMAGE=telclaude-whatsapp-bridge:latest
 
+# Israel services sidecar relay HMAC signing. Preferred: store the relay secret
+# in vault target `israel-services/relay-hmac/v1`:
+#   docker exec -it telclaude telclaude vault add secret israel-services/relay-hmac/v1
+# The raw env fallback is relay-only and must match the sidecar's
+# ISRAEL_SIDECAR_HMAC_KEY. Do not mount it into Hermes runtime containers.
+# Generate with: openssl rand -hex 32
+# TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY=
+# TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET=israel-services/relay-hmac/v1
+
 # Relay egress policy. restricted (default) = domain allowlist + default-deny;
 # permissive = all public egress (metadata/RFC1918 always kernel-blocked).
 # The relay-served tc_web_fetch capability needs permissive to reach arbitrary

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -96,6 +96,10 @@ services:
       - TELCLAUDE_WHATSAPP_INBOUND_PROFILE_ID=${TELCLAUDE_WHATSAPP_INBOUND_PROFILE_ID:-default}
       - TELCLAUDE_WHATSAPP_INBOUND_ACTOR_ID=${TELCLAUDE_WHATSAPP_INBOUND_ACTOR_ID:-}
       - TELCLAUDE_WHATSAPP_INBOUND_DISPLAY_NAME=${TELCLAUDE_WHATSAPP_INBOUND_DISPLAY_NAME:-}
+      # Israel services sidecar relay HMAC signing secret — RELAY ONLY. The
+      # matching sidecar key is ISRAEL_SIDECAR_HMAC_KEY and is not mounted here.
+      - TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY=${TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY:-}
+      - TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET=${TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET:-israel-services/relay-hmac/v1}
       # Relay egress policy: restricted (domain allowlist) or permissive (all public
       # egress; metadata/RFC1918 stay kernel-blocked). tc_web_fetch executes in the
       # relay, so the free-GET web capability requires permissive.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -108,6 +108,10 @@ services:
       - TELCLAUDE_WHATSAPP_INBOUND_PROFILE_ID=${TELCLAUDE_WHATSAPP_INBOUND_PROFILE_ID:-default}
       - TELCLAUDE_WHATSAPP_INBOUND_ACTOR_ID=${TELCLAUDE_WHATSAPP_INBOUND_ACTOR_ID:-}
       - TELCLAUDE_WHATSAPP_INBOUND_DISPLAY_NAME=${TELCLAUDE_WHATSAPP_INBOUND_DISPLAY_NAME:-}
+      # Israel services sidecar relay HMAC signing secret — RELAY ONLY. The
+      # matching sidecar key is ISRAEL_SIDECAR_HMAC_KEY and is not mounted here.
+      - TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY=${TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY:-}
+      - TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET=${TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET:-israel-services/relay-hmac/v1}
       # Relay egress policy: restricted (domain allowlist) or permissive (all public
       # egress; metadata/RFC1918 stay kernel-blocked). tc_web_fetch executes in the
       # relay, so the free-GET web capability requires permissive.

--- a/src/commands/doctor-helpers.ts
+++ b/src/commands/doctor-helpers.ts
@@ -19,6 +19,11 @@ import type { TelclaudeConfig } from "../config/config.js";
 import { fetchWithTimeout } from "../infra/timeout.js";
 import { getChildLogger } from "../logging.js";
 import {
+	PROVIDER_SIDECAR_HMAC_DEFAULT_VAULT_TARGET,
+	PROVIDER_SIDECAR_HMAC_SECRET_ENV,
+	PROVIDER_SIDECAR_HMAC_VAULT_TARGET_ENV,
+} from "../relay/provider-sidecar-auth.js";
+import {
 	TELCLAUDE_WHATSAPP_ALLOWED_RECIPIENTS_ENV,
 	TELCLAUDE_WHATSAPP_BRIDGE_SECRET_ENV,
 	TELCLAUDE_WHATSAPP_SIDECAR_URL_ENV,
@@ -31,6 +36,7 @@ import {
 import { getAllDraftSkillRoots, getAllSkillRoots } from "./skill-path.js";
 
 const logger = getChildLogger({ module: "doctor-helpers" });
+const SIDECAR_REQUIRE_RELAY_HMAC_ENV = "SIDECAR_REQUIRE_RELAY_HMAC";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -633,6 +639,7 @@ export async function checkProviders(cfg: TelclaudeConfig): Promise<CheckResult[
 export interface HermesConnectorReadinessOptions {
 	readonly env?: Partial<Record<string, string | undefined>>;
 	readonly webSearchConfigured?: boolean | (() => boolean | Promise<boolean>);
+	readonly providerSidecarHmacConfigured?: boolean | (() => boolean | Promise<boolean>);
 }
 
 /**
@@ -656,6 +663,7 @@ export async function checkHermesConnectorReadiness(
 	checks.push(await checkHermesWebFetchReadiness(capabilityScopes, env));
 	checks.push(await checkHermesWebSearchReadiness(capabilityScopes, options));
 	checks.push(...checkHermesWhatsAppReadiness(outboundChannels, env));
+	checks.push(await checkHermesIsraelServicesHmacReadiness(providers, env, options));
 
 	return checks;
 }
@@ -970,6 +978,89 @@ function checkHermesWhatsAppReadiness(
 	}
 
 	return checks;
+}
+
+async function checkHermesIsraelServicesHmacReadiness(
+	providers: NonNullable<TelclaudeConfig["providers"]>,
+	env: Partial<Record<string, string | undefined>>,
+	options: HermesConnectorReadinessOptions,
+): Promise<CheckResult> {
+	const category = "Hermes Connectors";
+	if (!providers.some((provider) => provider.id === "israel-services")) {
+		return skip(
+			"hermes.connectors.israel-services.hmac",
+			category,
+			"Israel services provider not configured",
+		);
+	}
+
+	if (await resolveProviderSidecarHmacConfigured(env, options)) {
+		return pass(
+			"hermes.connectors.israel-services.hmac",
+			category,
+			"Israel services relay HMAC signing secret configured",
+		);
+	}
+
+	const vaultTarget =
+		env[PROVIDER_SIDECAR_HMAC_VAULT_TARGET_ENV]?.trim() ||
+		PROVIDER_SIDECAR_HMAC_DEFAULT_VAULT_TARGET;
+	const detail = `Set ${PROVIDER_SIDECAR_HMAC_SECRET_ENV} with at least 32 bytes or store the secret in vault target ${vaultTarget}. Run a signed canary before setting ${SIDECAR_REQUIRE_RELAY_HMAC_ENV}=1.`;
+	if (isTruthyEnv(env[SIDECAR_REQUIRE_RELAY_HMAC_ENV])) {
+		return fail(
+			"hermes.connectors.israel-services.hmac",
+			category,
+			"Israel services sidecar HMAC enforcement is enabled but relay signing is not configured",
+			`${SIDECAR_REQUIRE_RELAY_HMAC_ENV}=1 requires relay signing first. ${detail}`,
+			`telclaude vault add secret ${vaultTarget}`,
+		);
+	}
+	return warn(
+		"hermes.connectors.israel-services.hmac",
+		category,
+		"Israel services provider configured without relay HMAC signing secret",
+		detail,
+		`telclaude vault add secret ${vaultTarget}`,
+	);
+}
+
+async function resolveProviderSidecarHmacConfigured(
+	env: Partial<Record<string, string | undefined>>,
+	options: HermesConnectorReadinessOptions,
+): Promise<boolean> {
+	const override = options.providerSidecarHmacConfigured;
+	if (typeof override === "boolean") return override;
+	if (typeof override === "function") return await override();
+
+	if (isUsableProviderSidecarHmacSecret(env[PROVIDER_SIDECAR_HMAC_SECRET_ENV])) {
+		return true;
+	}
+
+	const vaultTarget =
+		env[PROVIDER_SIDECAR_HMAC_VAULT_TARGET_ENV]?.trim() ||
+		PROVIDER_SIDECAR_HMAC_DEFAULT_VAULT_TARGET;
+	try {
+		const { getVaultClient } = await import("../vault-daemon/client.js");
+		const response = await getVaultClient().getSecret(vaultTarget, { timeout: 2_000 });
+		return (
+			response.ok &&
+			response.type === "get-secret" &&
+			isUsableProviderSidecarHmacSecret(response.value)
+		);
+	} catch (err) {
+		logger.debug({ error: String(err), vaultTarget }, "provider sidecar HMAC doctor check failed");
+		return false;
+	}
+}
+
+function isUsableProviderSidecarHmacSecret(value: string | undefined): boolean {
+	const trimmed = value?.trim();
+	return !!trimmed && Buffer.byteLength(trimmed, "utf8") >= 32;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+	const normalized = value?.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
 function checkWhatsAppSidecarUrl(sidecarUrl: string): CheckResult {

--- a/src/relay/provider-enrollment.ts
+++ b/src/relay/provider-enrollment.ts
@@ -1,0 +1,249 @@
+import { type ExternalProviderConfig, loadConfig } from "../config/config.js";
+import { getChildLogger } from "../logging.js";
+import { validateProviderBaseUrl } from "../providers/provider-validation.js";
+import { buildRequiredProviderSidecarRelayAuthHeaders } from "./provider-sidecar-auth.js";
+
+const logger = getChildLogger({ module: "provider-enrollment" });
+
+const ENROLL_SESSION_PATH = "/v1/credentials/enroll-session";
+const DEFAULT_ENROLL_TIMEOUT_MS = 30_000;
+const POLL_PATH_PREFIX = `${ENROLL_SESSION_PATH}/`;
+
+export type ProviderEnrollmentStartRequest = {
+	service: string;
+	subjectUserId: string;
+	actorUserId: string;
+};
+
+export type ProviderEnrollmentStartResult =
+	| {
+			status: "enroll_pending";
+			enrollmentId: string;
+			interactUrl: string;
+			expiresAt: number;
+			pollPath: string;
+	  }
+	| {
+			status: "busy" | "error";
+			error: string;
+	  };
+
+export type ProviderEnrollmentPollResult =
+	| { status: "pending"; expiresAt: number }
+	| {
+			status: "ok";
+			summary: {
+				service: string;
+				owner: string;
+				authorizedOperators: string[];
+				credentialKeys: string[];
+				hasSession: boolean;
+				updatedAt: string;
+			};
+	  }
+	| { status: "failed"; error: string }
+	| { status: "expired" }
+	| { status: "error"; error: string };
+
+type ProviderResolution = {
+	provider: ExternalProviderConfig;
+};
+
+export async function startProviderSessionEnrollment(
+	request: ProviderEnrollmentStartRequest,
+): Promise<ProviderEnrollmentStartResult> {
+	const service = request.service.trim();
+	const subjectUserId = request.subjectUserId.trim();
+	const actorUserId = request.actorUserId.trim();
+	if (!service || !subjectUserId || !actorUserId) {
+		return { status: "error", error: "service, subjectUserId, and actorUserId are required" };
+	}
+
+	const resolution = resolveProviderForEnrollment(service);
+	if (!resolution) {
+		return { status: "error", error: `No provider configured for service '${service}'` };
+	}
+
+	const body = JSON.stringify({ service, subjectUserId });
+	const response = await fetchEnrollmentSidecar(resolution.provider, {
+		method: "POST",
+		path: ENROLL_SESSION_PATH,
+		body,
+		actorUserId,
+	});
+	const data = await readJsonResponse(response, resolution.provider.id);
+
+	if (response.status === 202 && isEnrollmentPending(data)) {
+		return data;
+	}
+	if (response.status === 409) {
+		return { status: "busy", error: extractError(data) ?? "interactive session active" };
+	}
+	return {
+		status: "error",
+		error: extractError(data) ?? `Provider returned HTTP ${response.status}`,
+	};
+}
+
+export async function pollProviderSessionEnrollment(params: {
+	pollPath: string;
+	actorUserId: string;
+	service: string;
+}): Promise<ProviderEnrollmentPollResult> {
+	const service = params.service.trim();
+	const actorUserId = params.actorUserId.trim();
+	if (!service || !actorUserId) {
+		return { status: "error", error: "service and actorUserId are required" };
+	}
+	const pollPath = validateEnrollmentPollPath(params.pollPath);
+	if (!pollPath) {
+		return { status: "error", error: "Invalid enrollment poll path" };
+	}
+
+	const resolution = resolveProviderForEnrollment(service);
+	if (!resolution) {
+		return { status: "error", error: `No provider configured for service '${service}'` };
+	}
+
+	const response = await fetchEnrollmentSidecar(resolution.provider, {
+		method: "GET",
+		path: pollPath,
+		body: "",
+		actorUserId,
+	});
+	const data = await readJsonResponse(response, resolution.provider.id);
+
+	if (response.status === 404) {
+		return { status: "error", error: extractError(data) ?? "unknown enrollment" };
+	}
+	if (!response.ok) {
+		return {
+			status: "error",
+			error: extractError(data) ?? `Provider returned HTTP ${response.status}`,
+		};
+	}
+	if (isEnrollmentPollResult(data)) {
+		return data;
+	}
+	return { status: "error", error: "Invalid provider enrollment poll response" };
+}
+
+async function fetchEnrollmentSidecar(
+	provider: ExternalProviderConfig,
+	request: { method: "GET" | "POST"; path: string; body: string; actorUserId: string },
+): Promise<Response> {
+	const { url } = await validateProviderBaseUrl(provider.baseUrl);
+	const providerUrl = new URL(request.path, url);
+	if (providerUrl.origin !== url.origin) {
+		throw new Error("Provider enrollment path escaped provider origin");
+	}
+	const requestPath = `${providerUrl.pathname}${providerUrl.search}`;
+	const headers: Record<string, string> = {
+		Accept: "application/json",
+		"x-actor-user-id": request.actorUserId,
+		...(request.method === "POST" ? { "Content-Type": "application/json" } : {}),
+		...(await buildRequiredProviderSidecarRelayAuthHeaders({
+			provider,
+			method: request.method,
+			path: requestPath,
+			rawBody: request.body,
+		})),
+	};
+
+	return fetch(providerUrl.toString(), {
+		method: request.method,
+		headers,
+		body: request.method === "POST" ? request.body : undefined,
+		signal: AbortSignal.timeout(DEFAULT_ENROLL_TIMEOUT_MS),
+	});
+}
+
+function resolveProviderForEnrollment(service: string): ProviderResolution | null {
+	const providers = loadConfig().providers ?? [];
+	const provider = providers.find((candidate) => candidate.services.includes(service));
+	if (!provider) return null;
+	return { provider };
+}
+
+function validateEnrollmentPollPath(value: string): string | null {
+	const trimmed = value.trim();
+	if (!trimmed.startsWith(POLL_PATH_PREFIX)) return null;
+	if (trimmed.startsWith("//")) return null;
+	try {
+		const parsed = new URL(trimmed, "http://provider.local");
+		if (parsed.origin !== "http://provider.local") return null;
+		if (!parsed.pathname.startsWith(POLL_PATH_PREFIX)) return null;
+		return `${parsed.pathname}${parsed.search}`;
+	} catch {
+		return null;
+	}
+}
+
+async function readJsonResponse(response: Response, providerId: string): Promise<unknown> {
+	const contentType = response.headers.get("content-type") || "";
+	if (!contentType.includes("application/json")) {
+		logger.warn(
+			{ providerId, status: response.status, contentType },
+			"provider enrollment non-json",
+		);
+		return undefined;
+	}
+	try {
+		return JSON.parse(await response.text());
+	} catch (err) {
+		logger.warn(
+			{ providerId, status: response.status, error: String(err) },
+			"provider enrollment bad json",
+		);
+		return undefined;
+	}
+}
+
+function isEnrollmentPending(
+	value: unknown,
+): value is Extract<ProviderEnrollmentStartResult, { status: "enroll_pending" }> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const fields = value as Record<string, unknown>;
+	return (
+		fields.status === "enroll_pending" &&
+		typeof fields.enrollmentId === "string" &&
+		typeof fields.interactUrl === "string" &&
+		typeof fields.expiresAt === "number" &&
+		typeof fields.pollPath === "string" &&
+		validateEnrollmentPollPath(fields.pollPath) !== null
+	);
+}
+
+function isEnrollmentPollResult(value: unknown): value is ProviderEnrollmentPollResult {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const fields = value as Record<string, unknown>;
+	if (fields.status === "pending") return typeof fields.expiresAt === "number";
+	if (fields.status === "failed") return typeof fields.error === "string";
+	if (fields.status === "expired") return true;
+	if (fields.status === "ok") return isEnrollmentSummary(fields.summary);
+	if (fields.status === "error") return typeof fields.error === "string";
+	return false;
+}
+
+function isEnrollmentSummary(
+	value: unknown,
+): value is Extract<ProviderEnrollmentPollResult, { status: "ok" }>["summary"] {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const fields = value as Record<string, unknown>;
+	return (
+		typeof fields.service === "string" &&
+		typeof fields.owner === "string" &&
+		Array.isArray(fields.authorizedOperators) &&
+		fields.authorizedOperators.every((item) => typeof item === "string") &&
+		Array.isArray(fields.credentialKeys) &&
+		fields.credentialKeys.every((item) => typeof item === "string") &&
+		typeof fields.hasSession === "boolean" &&
+		typeof fields.updatedAt === "string"
+	);
+}
+
+function extractError(data: unknown): string | undefined {
+	if (!data || typeof data !== "object" || Array.isArray(data)) return undefined;
+	const error = (data as Record<string, unknown>).error;
+	return typeof error === "string" && error.trim() ? error : undefined;
+}

--- a/src/relay/provider-proxy.ts
+++ b/src/relay/provider-proxy.ts
@@ -15,14 +15,32 @@ import { getChildLogger } from "../logging.js";
 import { validateProviderBaseUrl } from "../providers/provider-validation.js";
 import { createAttachmentRef } from "../storage/attachment-refs.js";
 import { buildAttachmentFilename, ensureDocumentsDir } from "./attachment-helpers.js";
+import { buildProviderSidecarRelayAuthHeaders } from "./provider-sidecar-auth.js";
 
 const logger = getChildLogger({ module: "provider-proxy" });
 
 const MAX_ATTACHMENT_SIZE = 20 * 1024 * 1024; // 20MB
 const DEFAULT_PROXY_TIMEOUT_MS = 30_000;
+const PROVIDER_CHALLENGE_PENDING_ERROR =
+	"Provider challenge pending; check the relay-rendered operator prompt.";
 const CANONICAL_PROVIDER_SERVICE_ALIASES: Record<string, readonly string[]> = {
 	bank: ["poalim", "massad"],
 };
+const MODEL_VISIBLE_SECRET_RESPONSE_FIELDS = new Set([
+	"interacturl",
+	"novncurl",
+	"screenshot",
+	"preview",
+]);
+const MODEL_VISIBLE_SECRET_RESPONSE_FIELD_PATTERN =
+	/(?:interact|novnc)[_-]?url$|(?:screenshot|preview)$/i;
+const VISUAL_PAYLOAD_FIELD_PATTERN = /(?:image|thumb|thumbnail|snapshot|frame)$/i;
+const TOKEN_BEARING_URL_PARAM_PATTERN =
+	/(^|[_-])(access|auth|bearer|challenge|session|singleuse|single_use|one[_-]?time)?[_-]?(token|jwt|signature|sig|secret|code)$/i;
+const INTERACTIVE_URL_PATH_PATTERN = /(challenge|interactive|interact|novnc|vnc|browser)/i;
+const URL_SUBSTRING_PATTERN = /https?:\/\/[^\s<>"'`]+/gi;
+const OPAQUE_BASE64_MIN_LENGTH = 256;
+const REDACT_PROVIDER_VALUE = Symbol("redact-provider-value");
 
 export type ProviderProxyRequest = {
 	providerId: string;
@@ -254,6 +272,10 @@ export async function proxyProviderRequest(
 		return { status: "error", error: "Provider not available" };
 	}
 
+	const fetchMethod = method.toUpperCase();
+	const outgoingBody = fetchMethod !== "GET" ? requestBody : undefined;
+	const providerRequestPath = `${providerUrl.pathname}${providerUrl.search}`;
+
 	// Prepare headers
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
@@ -273,6 +295,16 @@ export async function proxyProviderRequest(
 		headers["x-approval-token"] = request.approvalToken;
 	}
 
+	Object.assign(
+		headers,
+		await buildProviderSidecarRelayAuthHeaders({
+			provider,
+			method: fetchMethod,
+			path: providerRequestPath,
+			rawBody: outgoingBody ?? "",
+		}),
+	);
+
 	// Make request
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), DEFAULT_PROXY_TIMEOUT_MS);
@@ -280,9 +312,9 @@ export async function proxyProviderRequest(
 	let response: Response;
 	try {
 		response = await fetch(providerUrl.toString(), {
-			method: method.toUpperCase(),
+			method: fetchMethod,
 			headers,
-			body: method.toUpperCase() !== "GET" ? requestBody : undefined,
+			body: outgoingBody,
 			signal: controller.signal,
 		});
 	} catch (err) {
@@ -312,6 +344,15 @@ export async function proxyProviderRequest(
 	}
 
 	// Check for provider-level error
+	if (isProviderChallengePending(response.status, data)) {
+		return {
+			status: "error",
+			errorCode: "challenge_pending",
+			error: PROVIDER_CHALLENGE_PENDING_ERROR,
+			data: sanitizeProviderChallengePayload(data),
+		};
+	}
+
 	if (!response.ok) {
 		const errorData = data as Record<string, unknown>;
 		const errorCode = errorData.errorCode as string | undefined;
@@ -347,7 +388,7 @@ export async function proxyProviderRequest(
 				return {
 					status: "error",
 					errorCode: "approval_required",
-					error: (errorData.error as string) || "Action requires approval",
+					error: sanitizeProviderVisibleError(errorData.error, "Action requires approval"),
 					approvalNonce: nonce,
 				};
 			} catch (err) {
@@ -358,7 +399,7 @@ export async function proxyProviderRequest(
 		return {
 			status: "error",
 			errorCode,
-			error: (errorData.error as string) || `Provider error: ${response.status}`,
+			error: sanitizeProviderVisibleError(errorData.error, `Provider error: ${response.status}`),
 		};
 	}
 
@@ -366,7 +407,7 @@ export async function proxyProviderRequest(
 	const actorUserId = userId || "unknown";
 	try {
 		const rewritten = await rewriteResponse(data, actorUserId, providerId);
-		return { status: "ok", data: rewritten };
+		return { status: "ok", data: sanitizeProviderModelVisiblePayload(rewritten) };
 	} catch (err) {
 		logger.error({ providerId, error: String(err) }, "failed to rewrite response");
 		return { status: "error", error: "Failed to process attachments" };
@@ -417,4 +458,129 @@ function rewriteProviderRequestBody(
 	} catch {
 		return body;
 	}
+}
+
+function isProviderChallengePending(statusCode: number, data: unknown): boolean {
+	if (statusCode === 202) return true;
+	if (!data || typeof data !== "object" || Array.isArray(data)) return false;
+	const record = data as Record<string, unknown>;
+	return record.status === "challenge_pending" || record.errorCode === "challenge_pending";
+}
+
+function sanitizeProviderChallengePayload(data: unknown): unknown {
+	return sanitizeProviderModelVisiblePayload(data);
+}
+
+function sanitizeProviderModelVisiblePayload(data: unknown): unknown {
+	if (Array.isArray(data)) {
+		const sanitizedItems: unknown[] = [];
+		for (const item of data) {
+			const sanitized = sanitizeProviderModelVisiblePayload(item);
+			if (sanitized !== REDACT_PROVIDER_VALUE) {
+				sanitizedItems.push(sanitized);
+			}
+		}
+		return sanitizedItems;
+	}
+	if (typeof data === "string" && containsTokenBearingInteractiveUrl(data)) {
+		return REDACT_PROVIDER_VALUE;
+	}
+	if (!data || typeof data !== "object") {
+		return data;
+	}
+
+	const sanitized: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+		if (isModelVisibleSecretProviderField(key, value)) {
+			continue;
+		}
+		const sanitizedValue = sanitizeProviderModelVisiblePayload(value);
+		if (sanitizedValue === REDACT_PROVIDER_VALUE) {
+			continue;
+		}
+		sanitized[key] = sanitizedValue;
+	}
+	return sanitized;
+}
+
+function isModelVisibleSecretProviderField(key: string, value: unknown): boolean {
+	if (isProviderSecretFieldName(key)) {
+		return true;
+	}
+	if (typeof value !== "string") {
+		return false;
+	}
+	if (containsTokenBearingInteractiveUrl(value)) {
+		return true;
+	}
+	return isPotentialVisualPayloadField(key) && isLargeOpaqueBase64(value);
+}
+
+function sanitizeProviderVisibleError(value: unknown, fallback: string): string {
+	if (typeof value !== "string" || !value.trim()) {
+		return fallback;
+	}
+	const sanitized = sanitizeProviderModelVisiblePayload(value);
+	return sanitized === REDACT_PROVIDER_VALUE ? fallback : value;
+}
+
+function isProviderSecretFieldName(key: string): boolean {
+	const normalized = key.toLowerCase();
+	return (
+		MODEL_VISIBLE_SECRET_RESPONSE_FIELDS.has(normalized) ||
+		MODEL_VISIBLE_SECRET_RESPONSE_FIELD_PATTERN.test(normalized)
+	);
+}
+
+function isPotentialVisualPayloadField(key: string): boolean {
+	return VISUAL_PAYLOAD_FIELD_PATTERN.test(key.toLowerCase());
+}
+
+function containsTokenBearingInteractiveUrl(value: string): boolean {
+	if (isTokenBearingInteractiveUrl(value)) {
+		return true;
+	}
+	for (const match of value.matchAll(URL_SUBSTRING_PATTERN)) {
+		if (isTokenBearingInteractiveUrl(trimUrlCandidate(match[0]))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function trimUrlCandidate(value: string): string {
+	return value.replace(/[),.;:!?]+$/g, "");
+}
+
+function isLargeOpaqueBase64(value: string): boolean {
+	const trimmed = value.trim();
+	const withoutDataPrefix = trimmed.replace(/^data:[^;]+;base64,/i, "");
+	const compact = withoutDataPrefix.replace(/\s+/g, "");
+	if (compact.length < OPAQUE_BASE64_MIN_LENGTH) {
+		return false;
+	}
+	return /^[A-Za-z0-9+/]+={0,2}$/.test(compact);
+}
+
+function isTokenBearingInteractiveUrl(value: string): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		return false;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+		return false;
+	}
+
+	const hasTokenParam = Array.from(parsed.searchParams.keys()).some((key) =>
+		TOKEN_BEARING_URL_PARAM_PATTERN.test(key),
+	);
+	if (hasTokenParam) {
+		return true;
+	}
+	if (!INTERACTIVE_URL_PATH_PATTERN.test(parsed.pathname)) {
+		return false;
+	}
+	return parsed.pathname.split("/").some((segment) => /^[A-Za-z0-9_-]{16,}$/.test(segment));
 }

--- a/src/relay/provider-sidecar-auth.ts
+++ b/src/relay/provider-sidecar-auth.ts
@@ -1,0 +1,160 @@
+import crypto from "node:crypto";
+
+import type { ExternalProviderConfig } from "../config/config.js";
+import { getChildLogger } from "../logging.js";
+import { getVaultClient } from "../vault-daemon/client.js";
+
+const logger = getChildLogger({ module: "provider-sidecar-auth" });
+
+export const PROVIDER_SIDECAR_HMAC_SECRET_ENV = "TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY";
+export const PROVIDER_SIDECAR_HMAC_VAULT_TARGET_ENV = "TELCLAUDE_ISRAEL_SIDECAR_HMAC_VAULT_TARGET";
+export const PROVIDER_SIDECAR_HMAC_DEFAULT_VAULT_TARGET = "israel-services/relay-hmac/v1";
+
+const DEFAULT_KEY_ID = "v1";
+const MIN_SECRET_BYTES = 32;
+const VAULT_LOOKUP_TIMEOUT_MS = 2_000;
+const SECRET_CACHE_TTL_MS = 5 * 60 * 1000;
+const NEGATIVE_CACHE_TTL_MS = 30 * 1000;
+
+type ProviderSidecarHmacHeadersOptions = {
+	keyId: string;
+	method: string;
+	path: string;
+	rawBody: string;
+	secret: string;
+	timestampMs?: number;
+	nonce?: string;
+};
+
+type ProviderSidecarRelayAuthOptions = {
+	provider: ExternalProviderConfig;
+	method: string;
+	path: string;
+	rawBody: string;
+};
+
+type SecretCache = {
+	value?: string;
+	expiresAt: number;
+};
+
+let vaultSecretCache: SecretCache | null = null;
+
+export function buildProviderSidecarHmacHeaders(
+	options: ProviderSidecarHmacHeadersOptions,
+): Record<string, string> {
+	const timestamp = String(options.timestampMs ?? Date.now());
+	const nonce = options.nonce ?? crypto.randomBytes(16).toString("base64url");
+	const bodyHash = crypto.createHash("sha256").update(options.rawBody).digest("hex");
+	const canonical = [options.method.toUpperCase(), options.path, bodyHash, timestamp, nonce].join(
+		"\n",
+	);
+	const signature = crypto
+		.createHmac("sha256", options.secret)
+		.update(canonical)
+		.digest("base64url");
+
+	return {
+		"x-relay-key-id": options.keyId,
+		"x-relay-timestamp": timestamp,
+		"x-relay-nonce": nonce,
+		"x-relay-signature": signature,
+	};
+}
+
+export async function buildProviderSidecarRelayAuthHeaders(
+	options: ProviderSidecarRelayAuthOptions,
+): Promise<Record<string, string>> {
+	if (!shouldSignProviderSidecarRequest(options.provider)) {
+		return {};
+	}
+
+	const secret = await resolveProviderSidecarHmacSecret();
+	if (!secret) {
+		return {};
+	}
+
+	return buildProviderSidecarHmacHeaders({
+		keyId: DEFAULT_KEY_ID,
+		method: options.method,
+		path: options.path,
+		rawBody: options.rawBody,
+		secret,
+	});
+}
+
+export async function buildRequiredProviderSidecarRelayAuthHeaders(
+	options: ProviderSidecarRelayAuthOptions,
+): Promise<Record<string, string>> {
+	if (!shouldSignProviderSidecarRequest(options.provider)) {
+		throw new Error(`Provider '${options.provider.id}' does not support relay HMAC signing`);
+	}
+
+	const secret = await resolveProviderSidecarHmacSecret();
+	if (!secret) {
+		throw new Error("Provider sidecar HMAC secret is not configured");
+	}
+
+	return buildProviderSidecarHmacHeaders({
+		keyId: DEFAULT_KEY_ID,
+		method: options.method,
+		path: options.path,
+		rawBody: options.rawBody,
+		secret,
+	});
+}
+
+export function shouldSignProviderSidecarRequest(provider: ExternalProviderConfig): boolean {
+	return provider.id === "israel-services";
+}
+
+export function resetProviderSidecarHmacSecretCacheForTests(): void {
+	vaultSecretCache = null;
+}
+
+async function resolveProviderSidecarHmacSecret(): Promise<string | undefined> {
+	const envSecret = normalizeSecret(
+		process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV],
+		`env:${PROVIDER_SIDECAR_HMAC_SECRET_ENV}`,
+	);
+	if (envSecret) {
+		return envSecret;
+	}
+
+	const now = Date.now();
+	if (vaultSecretCache && vaultSecretCache.expiresAt > now) {
+		return vaultSecretCache.value;
+	}
+
+	const vaultTarget =
+		process.env[PROVIDER_SIDECAR_HMAC_VAULT_TARGET_ENV]?.trim() ||
+		PROVIDER_SIDECAR_HMAC_DEFAULT_VAULT_TARGET;
+	try {
+		const response = await getVaultClient().getSecret(vaultTarget, {
+			timeout: VAULT_LOOKUP_TIMEOUT_MS,
+		});
+		const vaultSecret =
+			response.ok && response.type === "get-secret"
+				? normalizeSecret(response.value, `vault-secret:${vaultTarget}`)
+				: undefined;
+		vaultSecretCache = {
+			value: vaultSecret,
+			expiresAt: now + (vaultSecret ? SECRET_CACHE_TTL_MS : NEGATIVE_CACHE_TTL_MS),
+		};
+		return vaultSecret;
+	} catch (error) {
+		vaultSecretCache = { expiresAt: now + NEGATIVE_CACHE_TTL_MS };
+		logger.debug({ error: String(error), vaultTarget }, "provider sidecar HMAC secret unavailable");
+		return undefined;
+	}
+}
+
+function normalizeSecret(value: string | undefined, source: string): string | undefined {
+	const trimmed = value?.trim();
+	if (!trimmed) return undefined;
+	if (Buffer.byteLength(trimmed, "utf8") < MIN_SECRET_BYTES) {
+		logger.warn({ source }, "provider sidecar HMAC secret is too short; skipping signing");
+		return undefined;
+	}
+	return trimmed;
+}

--- a/src/telegram/auto-reply.ts
+++ b/src/telegram/auto-reply.ts
@@ -120,6 +120,7 @@ import {
 	sendSocialActivityLogCommand,
 	sendSocialAskResponse,
 	setHomeTargetCommand,
+	startProviderSessionEnrollmentCommand,
 	startSkillsNewWizard,
 	startSocialAskWizard,
 	stopActiveWorkCommand,
@@ -429,6 +430,47 @@ function resolveCommandBody(msg: TelegramInboundMessage): string {
 
 function resolveProcessingBody(msg: TelegramInboundMessage): string {
 	return msg.normalizedBody ?? msg.body;
+}
+
+async function routeWizardTextBeforeAuthGate(
+	msg: TelegramInboundMessage,
+	api: Api,
+	trimmedBody: string,
+	controlCommandMatch: TelegramCommandMatch | null,
+): Promise<boolean> {
+	if (controlCommandMatch || isKnownDomainCommand(trimmedBody)) {
+		return false;
+	}
+
+	const consumed = routeWizardTextMessage(msg.chatId, trimmedBody, {
+		actorId: msg.senderId,
+		threadId: msg.messageThreadId,
+	});
+	if (!consumed) {
+		return false;
+	}
+
+	await deleteInboundWizardTextMessage(api, msg);
+	return true;
+}
+
+async function deleteInboundWizardTextMessage(
+	api: Api,
+	msg: TelegramInboundMessage,
+): Promise<void> {
+	const messageId = Number.parseInt(msg.id, 10);
+	if (!Number.isSafeInteger(messageId) || messageId <= 0) {
+		return;
+	}
+
+	try {
+		await api.deleteMessage(msg.chatId, messageId);
+	} catch (err) {
+		logger.debug(
+			{ chatId: msg.chatId, messageId, error: String(err) },
+			"wizard text delete failed",
+		);
+	}
 }
 
 type TelegramControlCommandContext = {
@@ -1120,6 +1162,28 @@ async function dispatchTelegramControlCommand(
 				actorScope: `user:${msg.senderId ?? msg.chatId}`,
 				threadId: msg.messageThreadId,
 				cfg,
+			});
+			return true;
+		}
+		case "providers:enroll": {
+			const service = match.args[0]?.trim();
+			if (!service) {
+				await msg.reply("Usage: /providers enroll <service>");
+				return true;
+			}
+			const link = getIdentityLink(msg.chatId);
+			if (!link) {
+				await msg.reply(
+					"This chat is not linked to a local user. Use `telclaude identity deep-link <user-id>` first.",
+				);
+				return true;
+			}
+			await startProviderSessionEnrollmentCommand(bot.api, {
+				chatId: msg.chatId,
+				threadId: msg.messageThreadId,
+				service,
+				actorUserId: String(msg.senderId ?? msg.chatId),
+				subjectUserId: link.localUserId,
 			});
 			return true;
 		}
@@ -1853,10 +1917,12 @@ export const __test = {
 	dispatchTelegramControlCommand,
 	executeAndReply,
 	executePlanPhase,
+	handleInboundMessage,
 	handleLinkCommand,
 	handleProfileSwitchCommand,
 	resolveCommandBody,
 	resolveProcessingBody,
+	routeWizardTextBeforeAuthGate,
 	shouldShowPlanPreview,
 };
 
@@ -2276,6 +2342,13 @@ async function handleInboundMessage(
 	// Commands exempt from auth gate (needed for TOTP setup)
 	const isAuthExemptCommand = isTelegramAuthExemptCommand(trimmedBody, commandMatchOpts);
 
+	if (
+		await routeWizardTextBeforeAuthGate(msg, _bot.api, trimmedBody, controlCommandMatch ?? null)
+	) {
+		logger.debug({ chatId: msg.chatId }, "message consumed by active wizard text prompt");
+		return;
+	}
+
 	if (!isAuthExemptCommand) {
 		const authGateResult = await checkTOTPAuthGate(msg.chatId, msg.body, {
 			chatId: msg.chatId,
@@ -2374,20 +2447,6 @@ async function handleInboundMessage(
 	if (!controlCommandMatch && isKnownDomainCommand(trimmedBody)) {
 		const domain = trimmedBody.slice(1).split(/[\s@]/)[0]?.toLowerCase();
 		await msg.reply(`Unknown subcommand. Try /help ${domain} or /${domain} for the default view.`);
-		return;
-	}
-
-	// ══════════════════════════════════════════════════════════════════════════
-	// WIZARD TEXT ROUTING - Intercept text messages for active wizard prompts
-	// ══════════════════════════════════════════════════════════════════════════
-
-	if (
-		routeWizardTextMessage(msg.chatId, trimmedBody, {
-			actorId: msg.senderId,
-			threadId: msg.messageThreadId,
-		})
-	) {
-		logger.debug({ chatId: msg.chatId }, "message consumed by active wizard text prompt");
 		return;
 	}
 

--- a/src/telegram/cards/renderers/provider-list.ts
+++ b/src/telegram/cards/renderers/provider-list.ts
@@ -3,6 +3,7 @@ import {
 	startProviderAddWizard,
 	startProviderEditWizard,
 	startProviderRemoveWizard,
+	startProviderSessionEnrollmentCommand,
 } from "../../control-command-actions.js";
 import { getRemediation, type RemediationKey } from "../../remediation-commands.js";
 import type {
@@ -162,6 +163,9 @@ function renderDetailView(card: CardInstance<K>): CardRenderResult {
 
 	const kb = keyboard();
 	if (s.canMutate) {
+		if (entry.health === "auth_expired" && entry.enrollmentService) {
+			kb.text("\uD83D\uDD10 Re-auth", btn(card, "enroll")).row();
+		}
 		kb.text("\u270F\uFE0F Edit", btn(card, "edit"))
 			.text("\uD83D\uDDD1\uFE0F Remove", btn(card, "remove"))
 			.row();
@@ -260,6 +264,31 @@ export const providerListRenderer: CardRenderer<K> = {
 							chatId: card.chatId,
 							threadId: card.threadId,
 							providerId: entry.id,
+						});
+					},
+				};
+			}
+
+			case "enroll": {
+				if (!s.canMutate || !canActorManageProviders(card.chatId)) {
+					return { callbackText: "Only admin can re-auth providers.", callbackAlert: true };
+				}
+				const entry = resolveSelected(s);
+				if (!entry?.enrollmentService) {
+					return {
+						callbackText: "No enrollment flow is available for this provider.",
+						callbackAlert: true,
+					};
+				}
+				return {
+					callbackText: `Starting re-auth for ${entry.enrollmentService}`,
+					rerender: false,
+					afterCommit: async () => {
+						await startProviderSessionEnrollmentCommand(context.ctx.api, {
+							actorUserId: String(context.ctx.from.id),
+							chatId: card.chatId,
+							threadId: card.threadId,
+							service: entry.enrollmentService as string,
 						});
 					},
 				};

--- a/src/telegram/cards/types.ts
+++ b/src/telegram/cards/types.ts
@@ -291,6 +291,8 @@ export type ProviderListEntry = {
 	remediationKey?: string;
 	/** Base URL for health tap-through. */
 	baseUrl?: string;
+	/** Provider service id to pass to /credentials/enroll-session for re-auth. */
+	enrollmentService?: string;
 };
 
 export type ProviderListView = "list" | "detail";
@@ -541,6 +543,7 @@ export type ProviderListCardAction =
 	| PickerSelectAction
 	| { type: "add" }
 	| { type: "edit" }
+	| { type: "enroll" }
 	| { type: "remove" }
 	| { type: "page-next" }
 	| { type: "page-prev" }

--- a/src/telegram/control-command-actions.ts
+++ b/src/telegram/control-command-actions.ts
@@ -48,9 +48,20 @@ import {
 	type HealthCheckResult,
 	type ProviderHealthResponse,
 } from "../providers/provider-health.js";
+import {
+	type ProviderEnrollmentPollResult,
+	type ProviderEnrollmentStartResult,
+	pollProviderSessionEnrollment,
+	startProviderSessionEnrollment,
+} from "../relay/provider-enrollment.js";
 import { revokeSessionAllowlist } from "../security/approvals.js";
-import { isAdmin } from "../security/linking.js";
+import { getIdentityLink, isAdmin } from "../security/linking.js";
 import { getUserPermissionTier } from "../security/permissions.js";
+import {
+	freshTotpStepUpVerification,
+	getTOTPSessionForChat,
+	stepUpMetadataForTOTPSession,
+} from "../security/totp-session.js";
 import {
 	sendBackgroundJobCard,
 	sendBackgroundJobListCard,
@@ -87,6 +98,12 @@ import { createTypingControllerFromCallback } from "./typing.js";
 import { createWizardPrompter, WizardCancelledError, WizardTimeoutError } from "./wizard/index.js";
 
 const logger = getChildLogger({ module: "telegram-control-command-actions" });
+const PROVIDER_ENROLLMENT_SAFE_ERROR_DETAIL = "Check provider status and relay logs.";
+const PROVIDER_ENROLLMENT_TOKEN_BEARING_URL_PARAM_PATTERN =
+	/(^|[_-])(access|auth|bearer|challenge|session|singleuse|single_use|one[_-]?time)?[_-]?(token|jwt|signature|sig|secret|code)$/i;
+const PROVIDER_ENROLLMENT_INTERACTIVE_URL_PATH_PATTERN =
+	/(challenge|interactive|interact|novnc|vnc|browser)/i;
+const URL_SUBSTRING_PATTERN = /https?:\/\/[^\s<>"'`]+/gi;
 
 export type CommandUiResult = {
 	callbackText: string;
@@ -227,6 +244,281 @@ function formatProviderRemovalMessage(result: ProviderRemovalResult): string {
 		lines.push("Provider runtime state cleared.");
 	}
 	return lines.join("\n");
+}
+
+type ProviderSessionEnrollmentCommandOptions = {
+	chatId: number;
+	threadId?: number;
+	service: string;
+	actorUserId: string;
+	subjectUserId?: string;
+	poll?: boolean;
+	pollIntervalMs?: number;
+};
+
+export async function startProviderSessionEnrollmentCommand(
+	api: Api,
+	opts: ProviderSessionEnrollmentCommandOptions,
+): Promise<CommandUiResult> {
+	if (!isAdmin(opts.chatId)) {
+		const message = "Only admin can enroll provider sessions.";
+		await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
+		return { callbackText: message, callbackAlert: true };
+	}
+
+	const service = opts.service.trim();
+	const actorUserId = opts.actorUserId.trim();
+	const subjectUserId =
+		opts.subjectUserId?.trim() || getIdentityLink(opts.chatId)?.localUserId || "";
+	if (!service || !actorUserId) {
+		const message = "Usage: /providers enroll <service>";
+		await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
+		return { callbackText: message, callbackAlert: true };
+	}
+	if (!subjectUserId) {
+		const message =
+			"This chat is not linked to a local user. Use `telclaude identity deep-link <user-id>` first.";
+		await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
+		return { callbackText: message, callbackAlert: true };
+	}
+
+	const stepUp = await resolveFreshProviderEnrollmentStepUp(opts.chatId, actorUserId);
+	if (!stepUp.ok) {
+		const message =
+			"Fresh 2FA verification is required before provider enrollment. Send /auth verify <code>, then retry the enrollment.";
+		await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
+		return { callbackText: message, callbackAlert: true };
+	}
+
+	let result: ProviderEnrollmentStartResult;
+	try {
+		result = await startProviderSessionEnrollment({
+			service,
+			actorUserId,
+			subjectUserId,
+		});
+	} catch (err) {
+		logger.warn(
+			{ error: sanitizeProviderEnrollmentVisibleError(err), service },
+			"provider enrollment start failed",
+		);
+		const message = `Enrollment failed for '${service}'. Check provider status and relay HMAC configuration.`;
+		await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
+		return { callbackText: message, callbackAlert: true };
+	}
+
+	if (result.status !== "enroll_pending") {
+		const message =
+			result.status === "busy"
+				? `Enrollment is already active for another session. Retry shortly.`
+				: `Enrollment failed for '${service}': ${sanitizeProviderEnrollmentVisibleError(
+						result.error,
+					)}`;
+		await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
+		return { callbackText: message, callbackAlert: result.status === "busy" };
+	}
+
+	const enrollmentMessage = await api.sendMessage(
+		opts.chatId,
+		[
+			`Secure enrollment started for ${service}.`,
+			"Open the browser button below and complete login in the provider portal.",
+			"The relay will poll until the session is captured, fails, or expires.",
+			`Expires: ${new Date(result.expiresAt).toISOString()}`,
+		].join("\n"),
+		{
+			...threadOptions(opts.threadId),
+			reply_markup: {
+				inline_keyboard: [[{ text: "Open secure browser", url: result.interactUrl }]],
+			},
+		},
+	);
+
+	if (opts.poll !== false) {
+		void pollProviderEnrollmentUntilTerminal(api, opts, result, enrollmentMessage.message_id);
+	}
+
+	return { callbackText: `Enrollment started for ${service}.` };
+}
+
+async function resolveFreshProviderEnrollmentStepUp(
+	chatId: number,
+	actorUserId: string,
+): Promise<{ ok: true } | { ok: false }> {
+	const session = getTOTPSessionForChat(chatId);
+	if (!session) {
+		return { ok: false };
+	}
+	// The current metadata source makes this primarily a freshness gate today;
+	// keep requiredActorId wired so a future persisted actor binding cannot drift open.
+	const result = await freshTotpStepUpVerification.verify({
+		metadata: stepUpMetadataForTOTPSession({
+			actorId: actorUserId,
+			session,
+		}),
+		requiredActorId: actorUserId,
+	});
+	return result.ok ? { ok: true } : { ok: false };
+}
+
+async function pollProviderEnrollmentUntilTerminal(
+	api: Api,
+	opts: ProviderSessionEnrollmentCommandOptions,
+	enrollment: Extract<ProviderEnrollmentStartResult, { status: "enroll_pending" }>,
+	enrollmentMessageId: number | undefined,
+): Promise<void> {
+	const service = opts.service.trim();
+	const intervalMs = opts.pollIntervalMs ?? 5_000;
+	try {
+		while (Date.now() <= enrollment.expiresAt + intervalMs) {
+			await delay(intervalMs);
+			const result = await pollProviderSessionEnrollment({
+				service,
+				pollPath: enrollment.pollPath,
+				actorUserId: opts.actorUserId,
+			});
+			if (result.status === "pending") {
+				continue;
+			}
+			await sendProviderEnrollmentTerminalStatus(api, opts, result, enrollmentMessageId);
+			return;
+		}
+		await sendProviderEnrollmentTerminalStatus(
+			api,
+			opts,
+			{ status: "expired" },
+			enrollmentMessageId,
+		);
+	} catch (err) {
+		logger.warn(
+			{ error: sanitizeProviderEnrollmentVisibleError(err), service },
+			"provider enrollment poll failed",
+		);
+		await sendProviderEnrollmentTerminalStatus(
+			api,
+			opts,
+			{
+				status: "error",
+				error: getProviderEnrollmentErrorText(err),
+			},
+			enrollmentMessageId,
+		);
+	}
+}
+
+async function sendProviderEnrollmentTerminalStatus(
+	api: Api,
+	opts: ProviderSessionEnrollmentCommandOptions,
+	result: Exclude<ProviderEnrollmentPollResult, { status: "pending" }>,
+	enrollmentMessageId: number | undefined,
+): Promise<void> {
+	const service = opts.service.trim();
+	let message: string;
+	switch (result.status) {
+		case "ok":
+			message = `Enrollment complete for ${result.summary.service}. Session captured for ${result.summary.owner}.`;
+			break;
+		case "failed":
+			message = `Enrollment failed for ${service}: ${sanitizeProviderEnrollmentVisibleError(
+				result.error,
+			)}`;
+			break;
+		case "expired":
+			message = `Enrollment expired for ${service}. Start a new enrollment when ready.`;
+			break;
+		case "error":
+			message = `Enrollment status check failed for ${service}: ${sanitizeProviderEnrollmentVisibleError(
+				result.error,
+			)}`;
+			break;
+		default: {
+			const exhaustive: never = result;
+			throw new Error(`Unhandled enrollment result: ${String(exhaustive)}`);
+		}
+	}
+	await api.sendMessage(opts.chatId, message, threadOptions(opts.threadId));
+	await clearProviderEnrollmentInlineKeyboard(api, opts, enrollmentMessageId);
+}
+
+async function clearProviderEnrollmentInlineKeyboard(
+	api: Api,
+	opts: ProviderSessionEnrollmentCommandOptions,
+	enrollmentMessageId: number | undefined,
+): Promise<void> {
+	if (enrollmentMessageId === undefined) return;
+	try {
+		await api.editMessageReplyMarkup(opts.chatId, enrollmentMessageId, {
+			reply_markup: undefined,
+		});
+	} catch (err) {
+		logger.warn(
+			{ error: String(err), service: opts.service.trim(), enrollmentMessageId },
+			"failed to clear provider enrollment inline keyboard",
+		);
+	}
+}
+
+function sanitizeProviderEnrollmentVisibleError(value: unknown): string {
+	const text = getProviderEnrollmentErrorText(value);
+	if (!text.trim()) {
+		return PROVIDER_ENROLLMENT_SAFE_ERROR_DETAIL;
+	}
+	return containsTokenBearingProviderEnrollmentUrl(text)
+		? PROVIDER_ENROLLMENT_SAFE_ERROR_DETAIL
+		: text.trim();
+}
+
+function getProviderEnrollmentErrorText(value: unknown): string {
+	if (value instanceof Error) {
+		return value.message;
+	}
+	return typeof value === "string" ? value : String(value);
+}
+
+function containsTokenBearingProviderEnrollmentUrl(value: string): boolean {
+	if (isTokenBearingProviderEnrollmentUrl(value)) {
+		return true;
+	}
+	for (const match of value.matchAll(URL_SUBSTRING_PATTERN)) {
+		if (isTokenBearingProviderEnrollmentUrl(trimUrlCandidate(match[0]))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function trimUrlCandidate(value: string): string {
+	return value.replace(/[),.;:!?]+$/g, "");
+}
+
+function isTokenBearingProviderEnrollmentUrl(value: string): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		return false;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+		return false;
+	}
+
+	const hasTokenParam = Array.from(parsed.searchParams.keys()).some((key) =>
+		PROVIDER_ENROLLMENT_TOKEN_BEARING_URL_PARAM_PATTERN.test(key),
+	);
+	if (hasTokenParam) {
+		return true;
+	}
+	if (!PROVIDER_ENROLLMENT_INTERACTIVE_URL_PATH_PATTERN.test(parsed.pathname)) {
+		return false;
+	}
+	return parsed.pathname.split("/").some((segment) => /^[A-Za-z0-9_-]{16,}$/.test(segment));
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		const timeout = setTimeout(resolve, ms);
+		timeout.unref?.();
+	});
 }
 
 export async function setHomeTargetCommand(
@@ -1810,6 +2102,25 @@ function summarizeHealthDetail(result: HealthCheckResult): string | undefined {
 	return undefined;
 }
 
+function authExpiredConnectorIds(result: HealthCheckResult): string[] {
+	return Object.entries(result.response?.connectors ?? {})
+		.filter(([, info]) => info.status === "auth_expired")
+		.map(([name]) => name);
+}
+
+function resolveProviderEnrollmentService(
+	provider: NonNullable<TelclaudeConfig["providers"]>[number],
+	result: HealthCheckResult,
+): string | undefined {
+	if (provider.id !== "israel-services") {
+		return undefined;
+	}
+	const authExpired = authExpiredConnectorIds(result).find((service) =>
+		provider.services.includes(service),
+	);
+	return authExpired ?? (provider.services.length === 1 ? provider.services[0] : undefined);
+}
+
 async function buildProviderListEntries(cfg: TelclaudeConfig): Promise<ProviderListEntry[]> {
 	// Use the cfg.providers declared list — that's the live deployment shape.
 	// Merge catalog metadata so descriptions and setup commands are richer.
@@ -1834,6 +2145,7 @@ async function buildProviderListEntries(cfg: TelclaudeConfig): Promise<ProviderL
 				setupCommand: meta?.setupCommand,
 				remediationKey: providerRemediationKey(check, health),
 				baseUrl: provider.baseUrl,
+				enrollmentService: resolveProviderEnrollmentService(provider, check),
 			};
 			return entry;
 		}),

--- a/src/telegram/control-commands.ts
+++ b/src/telegram/control-commands.ts
@@ -64,6 +64,7 @@ export type TelegramCommandId =
 	| "model"
 	| "model:reset"
 	| "providers"
+	| "providers:enroll"
 	| "curator"
 	// Fast-path shortcuts (no domain prefix)
 	| "sethome"
@@ -760,6 +761,7 @@ const TELEGRAM_CONTROL_COMMANDS: TelegramControlCommandDefinition[] = [
 		id: "providers",
 		name: "providers",
 		domain: "providers",
+		aliases: ["provider"],
 		domainDefault: true,
 		category: "Providers",
 		description: "List configured external providers with live health status.",
@@ -769,6 +771,18 @@ const TELEGRAM_CONTROL_COMMANDS: TelegramControlCommandDefinition[] = [
 		readOnly: true,
 		rateLimited: true,
 		menuDescription: "External providers",
+	},
+	{
+		id: "providers:enroll",
+		name: "providers",
+		domain: "providers",
+		subcommand: "enroll",
+		category: "Providers",
+		description: "Open a relay-rendered, session-only provider enrollment browser.",
+		usage: "/providers enroll <service>",
+		examples: ["/providers enroll clalit", "/provider enroll poalim"],
+		keywords: ["provider enroll", "service login", "credential enrollment", "session capture"],
+		rateLimited: true,
 	},
 	// ── /sethome shortcut (W3) ───────────────────────────────────────
 	{
@@ -963,13 +977,25 @@ const COMMAND_BY_ID = new Map(
  */
 const DOMAIN_COMMANDS = new Map<string, TelegramControlCommandDefinition[]>();
 const DOMAIN_DEFAULTS = new Map<string, TelegramControlCommandDefinition>();
+const DOMAIN_ROOT_ALIASES = new Map<string, string[]>();
+for (const command of TELEGRAM_CONTROL_COMMANDS) {
+	if (command.domain && command.domainDefault && command.aliases?.length) {
+		DOMAIN_ROOT_ALIASES.set(command.domain, command.aliases);
+	}
+}
 for (const command of TELEGRAM_CONTROL_COMMANDS) {
 	if (!command.domain) continue;
-	const list = DOMAIN_COMMANDS.get(command.domain) ?? [];
-	list.push(command);
-	DOMAIN_COMMANDS.set(command.domain, list);
+	const domainTokens = [command.domain, ...(DOMAIN_ROOT_ALIASES.get(command.domain) ?? [])];
+	for (const domainToken of domainTokens) {
+		const list = DOMAIN_COMMANDS.get(domainToken) ?? [];
+		list.push(command);
+		DOMAIN_COMMANDS.set(domainToken, list);
+	}
 	if (command.domainDefault) {
 		DOMAIN_DEFAULTS.set(command.domain, command);
+		for (const alias of command.aliases ?? []) {
+			DOMAIN_DEFAULTS.set(alias, command);
+		}
 	}
 }
 

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -396,6 +396,59 @@ describe("checkHermesConnectorReadiness", () => {
 		);
 		expect(results.some((r) => r.status === "fail")).toBe(false);
 	});
+
+	it("fails Israel services relay HMAC readiness when sidecar enforcement is on without signing", async () => {
+		const cfg = makeMinimalConfig({
+			providers: [
+				{
+					id: "israel-services",
+					baseUrl: "http://israel-services:3003",
+					services: ["clalit", "poalim"],
+				},
+			],
+		});
+
+		const missing = await checkHermesConnectorReadiness(cfg, {
+			env: { SIDECAR_REQUIRE_RELAY_HMAC: "1" },
+			webSearchConfigured: false,
+			providerSidecarHmacConfigured: false,
+		});
+		const missingCheck = missing.find((r) => r.name === "hermes.connectors.israel-services.hmac");
+		expect(missingCheck?.status).toBe("fail");
+		expect(missingCheck?.detail).toMatch(/SIDECAR_REQUIRE_RELAY_HMAC=1/);
+
+		const configured = await checkHermesConnectorReadiness(cfg, {
+			env: { SIDECAR_REQUIRE_RELAY_HMAC: "1" },
+			webSearchConfigured: false,
+			providerSidecarHmacConfigured: true,
+		});
+		expect(
+			configured.find((r) => r.name === "hermes.connectors.israel-services.hmac")?.status,
+		).toBe("pass");
+		expect(configured.some((r) => r.status === "fail")).toBe(false);
+	});
+
+	it("warns Israel services relay HMAC readiness before enforcement is flipped", async () => {
+		const cfg = makeMinimalConfig({
+			providers: [
+				{
+					id: "israel-services",
+					baseUrl: "http://israel-services:3003",
+					services: ["clalit", "poalim"],
+				},
+			],
+		});
+
+		const results = await checkHermesConnectorReadiness(cfg, {
+			env: {},
+			webSearchConfigured: false,
+			providerSidecarHmacConfigured: false,
+		});
+
+		const check = results.find((r) => r.name === "hermes.connectors.israel-services.hmac");
+		expect(check?.status).toBe("warn");
+		expect(check?.detail).toMatch(/signed canary/);
+	});
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/relay/provider-enrollment.test.ts
+++ b/tests/relay/provider-enrollment.test.ts
@@ -1,0 +1,157 @@
+import crypto from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PROVIDER_SIDECAR_HMAC_SECRET_ENV } from "../../src/relay/provider-sidecar-auth.js";
+
+const loadConfigMock = vi.hoisted(() =>
+	vi.fn(() => ({
+		logging: {},
+		providers: [
+			{
+				id: "israel-services",
+				baseUrl: "https://israel-services.test",
+				services: ["clalit"],
+			},
+		],
+	})),
+);
+const validateProviderBaseUrlMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/config/config.js", () => ({
+	loadConfig: loadConfigMock,
+}));
+
+vi.mock("../../src/providers/provider-validation.js", () => ({
+	validateProviderBaseUrl: validateProviderBaseUrlMock,
+}));
+
+import {
+	pollProviderSessionEnrollment,
+	startProviderSessionEnrollment,
+} from "../../src/relay/provider-enrollment.js";
+
+describe("provider enrollment relay client", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV] =
+			"relay-sidecar-hmac-secret-with-at-least-32-bytes";
+		loadConfigMock.mockReturnValue({
+			providers: [
+				{
+					id: "israel-services",
+					baseUrl: "https://israel-services.test",
+					services: ["clalit"],
+				},
+			],
+		});
+		validateProviderBaseUrlMock.mockResolvedValue({ url: new URL("https://israel-services.test") });
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		delete process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV];
+	});
+
+	it("starts session enrollment with HMAC over the exact request body", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						status: "enroll_pending",
+						enrollmentId: "enr_123",
+						interactUrl: "https://novnc.test/?token=single-use",
+						expiresAt: 1_700_000_100_000,
+						pollPath: "/v1/credentials/enroll-session/enr_123",
+					}),
+					{ status: 202, headers: { "content-type": "application/json" } },
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			startProviderSessionEnrollment({
+				service: "clalit",
+				subjectUserId: "admin",
+				actorUserId: "453371121",
+			}),
+		).resolves.toMatchObject({
+			status: "enroll_pending",
+			enrollmentId: "enr_123",
+			pollPath: "/v1/credentials/enroll-session/enr_123",
+		});
+
+		const [, init] = fetchMock.mock.calls[0];
+		const body = JSON.stringify({ service: "clalit", subjectUserId: "admin" });
+		const headers = init?.headers as Record<string, string>;
+		const canonical = [
+			"POST",
+			"/v1/credentials/enroll-session",
+			crypto.createHash("sha256").update(body).digest("hex"),
+			headers["x-relay-timestamp"],
+			headers["x-relay-nonce"],
+		].join("\n");
+		const expectedSignature = crypto
+			.createHmac("sha256", process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV] ?? "")
+			.update(canonical)
+			.digest("base64url");
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://israel-services.test/v1/credentials/enroll-session",
+			expect.objectContaining({
+				method: "POST",
+				body,
+			}),
+		);
+		expect(headers["x-actor-user-id"]).toBe("453371121");
+		expect(headers["x-relay-key-id"]).toBe("v1");
+		expect(headers["x-relay-signature"]).toBe(expectedSignature);
+	});
+
+	it("polls enrollment status with an empty-body HMAC", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						status: "ok",
+						summary: {
+							service: "clalit",
+							owner: "admin",
+							authorizedOperators: ["453371121"],
+							credentialKeys: [],
+							hasSession: true,
+							updatedAt: "2026-06-13T20:45:00.000Z",
+						},
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			pollProviderSessionEnrollment({
+				service: "clalit",
+				pollPath: "/v1/credentials/enroll-session/enr_123",
+				actorUserId: "453371121",
+			}),
+		).resolves.toMatchObject({
+			status: "ok",
+			summary: { service: "clalit", owner: "admin", hasSession: true },
+		});
+
+		const [, init] = fetchMock.mock.calls[0];
+		const headers = init?.headers as Record<string, string>;
+		const canonical = [
+			"GET",
+			"/v1/credentials/enroll-session/enr_123",
+			crypto.createHash("sha256").update("").digest("hex"),
+			headers["x-relay-timestamp"],
+			headers["x-relay-nonce"],
+		].join("\n");
+		const expectedSignature = crypto
+			.createHmac("sha256", process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV] ?? "")
+			.update(canonical)
+			.digest("base64url");
+
+		expect(init?.body).toBeUndefined();
+		expect(headers["x-relay-signature"]).toBe(expectedSignature);
+	});
+});

--- a/tests/relay/provider-proxy.test.ts
+++ b/tests/relay/provider-proxy.test.ts
@@ -1,4 +1,6 @@
+import crypto from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PROVIDER_SIDECAR_HMAC_SECRET_ENV } from "../../src/relay/provider-sidecar-auth.js";
 
 const loadConfigMock = vi.hoisted(() =>
 	vi.fn(() => ({
@@ -96,6 +98,241 @@ describe("provider proxy approval interception", () => {
 		});
 
 		expect(createProviderApprovalMock).not.toHaveBeenCalled();
+	});
+
+	it("does not expose provider challenge interaction URLs or visual payloads to callers", async () => {
+		const opaqueFrame = Buffer.from("login-page-capture".repeat(64)).toString("base64");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							status: "challenge_pending",
+							message: "Open the secure browser challenge.",
+							interactUrl: "https://operator-console.test/session/secret",
+							challenge: {
+								challengeId: "challenge-1",
+								interactUrl: "https://operator-console.test/session/secret",
+								screenshot: "base64-screenshot",
+								preview: { html: "<form>secret</form>" },
+								snapshotFrame: opaqueFrame,
+							},
+						}),
+						{
+							status: 202,
+							headers: { "content-type": "application/json" },
+						},
+					),
+			),
+		);
+
+		const result = await proxyProviderRequest({
+			providerId: "google",
+			path: "/v1/fetch",
+			body: JSON.stringify({ service: "gmail", action: "search", params: {} }),
+			userId: "operator",
+		});
+
+		const serialized = JSON.stringify(result);
+		expect(result).toMatchObject({
+			status: "error",
+			errorCode: "challenge_pending",
+			error: "Provider challenge pending; check the relay-rendered operator prompt.",
+			data: {
+				status: "challenge_pending",
+				message: "Open the secure browser challenge.",
+				challenge: { challengeId: "challenge-1" },
+			},
+		});
+		expect(serialized).not.toContain("operator-console.test");
+		expect(serialized).not.toContain("base64-screenshot");
+		expect(serialized).not.toContain("<form>");
+		expect(serialized).not.toContain(opaqueFrame);
+	});
+
+	it("redacts embedded interactive bearer URLs from HTTP 202 challenge strings", async () => {
+		const marker = "embedded-202-marker";
+		const tokenQuery = new URLSearchParams([["token", marker]]).toString();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							status: "challenge_pending",
+							message: `Open https://operator-console.test/novnc?${tokenQuery} to continue.`,
+							challenge: { challengeId: "challenge-202" },
+						}),
+						{
+							status: 202,
+							headers: { "content-type": "application/json" },
+						},
+					),
+			),
+		);
+
+		const result = await proxyProviderRequest({
+			providerId: "google",
+			path: "/v1/fetch",
+			body: JSON.stringify({ service: "gmail", action: "search", params: {} }),
+			userId: "operator",
+		});
+
+		const serialized = JSON.stringify(result);
+		expect(result).toMatchObject({
+			status: "error",
+			errorCode: "challenge_pending",
+			data: {
+				status: "challenge_pending",
+				challenge: { challengeId: "challenge-202" },
+			},
+		});
+		expect(serialized).not.toContain(marker);
+		expect(serialized).not.toContain("operator-console.test");
+		expect(serialized).not.toContain("message");
+	});
+
+	it("redacts interactive bearer URLs from generic provider read challenge responses", async () => {
+		const marker = "provider-redaction-marker";
+		const tokenQuery = new URLSearchParams([["token", marker]]).toString();
+		const sessionTokenQuery = new URLSearchParams([["session_token", marker]]).toString();
+		const authTokenQuery = new URLSearchParams([["auth_token", marker]]).toString();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							status: "challenge_pending",
+							challengeRef: "challenge:poalim:read:123",
+							message: `Open https://operator-console.test/novnc?${tokenQuery} to continue.`,
+							interactUrl: `https://operator-console.test/novnc?${tokenQuery}`,
+							challenge: {
+								challengeId: "challenge-1",
+								noVncUrl: `https://operator-console.test/vnc?${sessionTokenQuery}`,
+								controlUrl: `https://operator-console.test/v1/challenge/interactive/abc/respond?${tokenQuery}`,
+								pathTokenUrl:
+									"https://operator-console.test/v1/challenge/interactive/opaqueSingleUseToken123/respond",
+								links: [
+									`https://operator-console.test/browser/session?${authTokenQuery}`,
+									{ label: "public help", url: "https://help.example.com/article" },
+								],
+							},
+						}),
+						{
+							status: 200,
+							headers: { "content-type": "application/json" },
+						},
+					),
+			),
+		);
+
+		const result = await proxyProviderRequest({
+			providerId: "google",
+			path: "/v1/fetch",
+			body: JSON.stringify({ service: "gmail", action: "search", params: {} }),
+			userId: "operator",
+		});
+
+		const serialized = JSON.stringify(result);
+		expect(result).toMatchObject({
+			status: "error",
+			errorCode: "challenge_pending",
+			error: "Provider challenge pending; check the relay-rendered operator prompt.",
+			data: {
+				status: "challenge_pending",
+				challengeRef: "challenge:poalim:read:123",
+				challenge: {
+					challengeId: "challenge-1",
+					links: [{ label: "public help", url: "https://help.example.com/article" }],
+				},
+			},
+		});
+		expect(serialized).not.toContain(marker);
+		expect(serialized).not.toContain("opaqueSingleUseToken123");
+		expect(serialized).not.toContain("operator-console.test");
+		expect(serialized).not.toContain("noVncUrl");
+		expect(serialized).not.toContain("message");
+	});
+
+	it("redacts embedded interactive bearer URLs from provider error strings", async () => {
+		const marker = "error-path-marker";
+		const tokenQuery = new URLSearchParams([["session_token", marker]]).toString();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							errorCode: "provider_failed",
+							error: `Provider needs login at https://operator-console.test/browser/session?${tokenQuery}.`,
+						}),
+						{
+							status: 500,
+							headers: { "content-type": "application/json" },
+						},
+					),
+			),
+		);
+
+		const result = await proxyProviderRequest({
+			providerId: "google",
+			path: "/v1/fetch",
+			body: JSON.stringify({ service: "gmail", action: "search", params: {} }),
+			userId: "operator",
+		});
+
+		const serialized = JSON.stringify(result);
+		expect(result).toEqual({
+			status: "error",
+			errorCode: "provider_failed",
+			error: "Provider error: 500",
+		});
+		expect(serialized).not.toContain(marker);
+		expect(serialized).not.toContain("operator-console.test");
+	});
+
+	it("redacts embedded interactive bearer URLs from approval-required errors", async () => {
+		const marker = "approval-error-marker";
+		const tokenQuery = new URLSearchParams([["auth_token", marker]]).toString();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							errorCode: "approval_required",
+							error: `Approve after opening https://operator-console.test/vnc?${tokenQuery}.`,
+						}),
+						{
+							status: 403,
+							headers: { "content-type": "application/json" },
+						},
+					),
+			),
+		);
+
+		const result = await proxyProviderRequest({
+			providerId: "google",
+			path: "/v1/fetch",
+			body: JSON.stringify({
+				service: "gmail",
+				action: "create_draft",
+				params: { to: "a@example.com" },
+			}),
+			userId: "operator",
+		});
+
+		const serialized = JSON.stringify(result);
+		expect(result).toEqual({
+			status: "error",
+			errorCode: "approval_required",
+			error: "Action requires approval",
+			approvalNonce: "nonce-approval",
+		});
+		expect(serialized).not.toContain(marker);
+		expect(serialized).not.toContain("operator-console.test");
 	});
 
 	it("routes canonical provider domains through a matching configured service", async () => {
@@ -202,6 +439,76 @@ describe("provider proxy approval interception", () => {
 				}),
 			}),
 		);
+	});
+
+	it("signs israel-services requests over the exact rewritten body bytes", async () => {
+		const previousSecret = process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV];
+		process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV] =
+			"relay-sidecar-hmac-secret-with-at-least-32-bytes";
+		try {
+			loadConfigMock.mockReturnValue({
+				logging: {},
+				providers: [
+					{
+						id: "israel-services",
+						baseUrl: "https://israel-services.test",
+						services: ["poalim"],
+					},
+				],
+			});
+			validateProviderBaseUrlMock.mockResolvedValue({
+				url: new URL("https://israel-services.test"),
+			});
+			const fetchMock = vi.fn(
+				async () =>
+					new Response(JSON.stringify({ balances: [{ accountId: "primary" }] }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+			);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const originalBody = JSON.stringify({
+				service: "bank",
+				action: "balance",
+				params: {},
+			});
+			const rewrittenBody = JSON.stringify({
+				service: "poalim",
+				action: "balance",
+				params: {},
+			});
+
+			await expect(
+				proxyProviderRequest({
+					providerId: "bank",
+					path: "/v1/fetch",
+					body: originalBody,
+					userId: "operator",
+				}),
+			).resolves.toMatchObject({ status: "ok" });
+
+			const [, init] = fetchMock.mock.calls[0];
+			const headers = init?.headers as Record<string, string>;
+			const timestamp = headers["x-relay-timestamp"];
+			const nonce = headers["x-relay-nonce"];
+			const bodyHash = crypto.createHash("sha256").update(rewrittenBody).digest("hex");
+			const canonical = ["POST", "/v1/fetch", bodyHash, timestamp, nonce].join("\n");
+			const expectedSignature = crypto
+				.createHmac("sha256", process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV] ?? "")
+				.update(canonical)
+				.digest("base64url");
+
+			expect(init?.body).toBe(rewrittenBody);
+			expect(headers["x-relay-key-id"]).toBe("v1");
+			expect(headers["x-relay-signature"]).toBe(expectedSignature);
+		} finally {
+			if (previousSecret === undefined) {
+				delete process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV];
+			} else {
+				process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV] = previousSecret;
+			}
+		}
 	});
 
 	it("prefers exact provider id matches over service membership matches", async () => {

--- a/tests/relay/provider-sidecar-auth.test.ts
+++ b/tests/relay/provider-sidecar-auth.test.ts
@@ -1,0 +1,64 @@
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	buildProviderSidecarHmacHeaders,
+	buildRequiredProviderSidecarRelayAuthHeaders,
+	PROVIDER_SIDECAR_HMAC_SECRET_ENV,
+} from "../../src/relay/provider-sidecar-auth.js";
+
+describe("provider sidecar relay auth", () => {
+	afterEach(() => {
+		delete process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV];
+		delete process.env.TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY_ID;
+	});
+
+	it("signs the agreed HMAC contract over the raw body bytes", () => {
+		const rawBody = '{"service":"poalim","action":"balance","params":{}}';
+		const timestampMs = 1_700_000_000_123;
+		const nonce = "0123456789abcdef012345";
+		const secret = "sidecar-hmac-secret-with-at-least-32-bytes";
+
+		const headers = buildProviderSidecarHmacHeaders({
+			keyId: "v1",
+			method: "POST",
+			path: "/v1/fetch",
+			rawBody,
+			secret,
+			timestampMs,
+			nonce,
+		});
+
+		const bodyHash = crypto.createHash("sha256").update(rawBody).digest("hex");
+		const canonical = ["POST", "/v1/fetch", bodyHash, String(timestampMs), nonce].join("\n");
+		const expectedSignature = crypto
+			.createHmac("sha256", secret)
+			.update(canonical)
+			.digest("base64url");
+
+		expect(headers).toEqual({
+			"x-relay-key-id": "v1",
+			"x-relay-timestamp": String(timestampMs),
+			"x-relay-nonce": nonce,
+			"x-relay-signature": expectedSignature,
+		});
+	});
+
+	it("uses the fixed v1 key id even if an old key-id env var is present", async () => {
+		process.env[PROVIDER_SIDECAR_HMAC_SECRET_ENV] = "sidecar-hmac-secret-with-at-least-32-bytes";
+		process.env.TELCLAUDE_ISRAEL_SIDECAR_HMAC_KEY_ID = "v2";
+
+		const headers = await buildRequiredProviderSidecarRelayAuthHeaders({
+			provider: {
+				id: "israel-services",
+				baseUrl: "https://israel-services.test",
+				services: ["clalit"],
+			},
+			method: "GET",
+			path: "/v1/fetch",
+			rawBody: "",
+		});
+
+		expect(headers["x-relay-key-id"]).toBe("v1");
+	});
+});

--- a/tests/telegram/auto-reply.test.ts
+++ b/tests/telegram/auto-reply.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listJobs } from "../../src/background/index.js";
 import { getMostRecentPendingPlanApproval } from "../../src/security/approvals.js";
-import { resetDatabase } from "../../src/storage/db.js";
+import { getDb, resetDatabase } from "../../src/storage/db.js";
 
 // Hoisted mutable stubs
 const replies: string[] = [];
@@ -26,6 +26,10 @@ const buildTelegramMemoryBundleImpl = vi.hoisted(() =>
 	})),
 );
 const captureTelegramTurnMemoryImpl = vi.hoisted(() => vi.fn());
+const hasTOTPImpl = vi.hoisted(() => vi.fn(async () => ({ hasTOTP: false })));
+const verifyTOTPImpl = vi.hoisted(() => vi.fn(async () => false));
+const disableTOTPImpl = vi.hoisted(() => vi.fn(async () => false));
+const isTOTPDaemonAvailableImpl = vi.hoisted(() => vi.fn(async () => true));
 const loggerImpl = vi.hoisted(() => ({
 	info: vi.fn(),
 	warn: vi.fn(),
@@ -104,6 +108,13 @@ vi.mock("../../src/memory/telegram-capture.js", () => ({
 		captureTelegramTurnMemoryImpl(...args),
 }));
 
+vi.mock("../../src/security/totp.js", () => ({
+	hasTOTP: (...args: unknown[]) => hasTOTPImpl(...args),
+	verifyTOTP: (...args: unknown[]) => verifyTOTPImpl(...args),
+	disableTOTP: (...args: unknown[]) => disableTOTPImpl(...args),
+	isTOTPDaemonAvailable: (...args: unknown[]) => isTOTPDaemonAvailableImpl(...args),
+}));
+
 vi.mock("../../src/telegram/system-context.js", () => ({
 	buildSystemInfoContext: () => null,
 }));
@@ -116,6 +127,7 @@ import { createRelayConversationStore } from "../../src/hermes/relay-conversatio
 import { __test as autoReplyTest } from "../../src/telegram/auto-reply.js";
 import { registerAllCardRenderers } from "../../src/telegram/cards/renderers/index.js";
 import { matchTelegramControlCommand } from "../../src/telegram/control-commands.js";
+import { createWizardPrompter } from "../../src/telegram/wizard/index.js";
 
 const makeMsg = () => ({
 	chatId: 123,
@@ -126,6 +138,14 @@ const makeMsg = () => ({
 		replies.push(text);
 	}),
 });
+
+async function waitFor(condition: () => boolean): Promise<void> {
+	for (let i = 0; i < 50; i++) {
+		if (condition()) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("Timed out waiting for condition");
+}
 
 const baseCtx = () => ({
 	msg: makeMsg(),
@@ -158,9 +178,15 @@ describe("auto-reply executeAndReply", () => {
 		vi.resetModules();
 		buildTelegramMemoryBundleImpl.mockClear();
 		captureTelegramTurnMemoryImpl.mockClear();
+		hasTOTPImpl.mockReset();
+		hasTOTPImpl.mockResolvedValue({ hasTOTP: false });
+		verifyTOTPImpl.mockReset();
+		verifyTOTPImpl.mockResolvedValue(false);
+		disableTOTPImpl.mockReset();
+		disableTOTPImpl.mockResolvedValue(false);
+		isTOTPDaemonAvailableImpl.mockReset();
+		isTOTPDaemonAvailableImpl.mockResolvedValue(true);
 		activeProfileState.profileId = null;
-		// Re-import to get fresh database
-		const { resetDatabase } = await import("../../src/storage/db.js");
 		resetDatabase();
 	});
 
@@ -176,6 +202,10 @@ describe("auto-reply executeAndReply", () => {
 		deleteSessionImpl.mockReset();
 		getChatModelPreferenceImpl.mockReset();
 		getChatModelPreferenceImpl.mockReturnValue(null);
+		hasTOTPImpl.mockReset();
+		verifyTOTPImpl.mockReset();
+		disableTOTPImpl.mockReset();
+		isTOTPDaemonAvailableImpl.mockReset();
 		activeProfileState.profileId = null;
 		loggerImpl.info.mockReset();
 		loggerImpl.warn.mockReset();
@@ -364,7 +394,9 @@ describe("auto-reply executeAndReply", () => {
 			systemPromptAppend?: string;
 		};
 		expect(options.systemPromptAppend).toContain("Granted provider scopes: bank, google");
-		expect(options.systemPromptAppend).toContain("Granted capability scopes: web.fetch, web.search");
+		expect(options.systemPromptAppend).toContain(
+			"Granted capability scopes: web.fetch, web.search",
+		);
 		expect(options.systemPromptAppend).toContain("Do not call provider hostnames");
 		expect(options.systemPromptAppend).toContain("supersedes any legacy external-provider");
 	});
@@ -633,6 +665,42 @@ describe("auto-reply executeAndReply", () => {
 });
 
 describe("auto-reply control commands", () => {
+	let controlTempDir: string;
+
+	beforeEach(() => {
+		controlTempDir = fs.mkdtempSync(path.join(os.tmpdir(), "telclaude-autoreply-control-"));
+		process.env.TELCLAUDE_DATA_DIR = controlTempDir;
+		resetDatabase();
+		hasTOTPImpl.mockReset();
+		hasTOTPImpl.mockResolvedValue({ hasTOTP: false });
+		verifyTOTPImpl.mockReset();
+		verifyTOTPImpl.mockResolvedValue(false);
+		disableTOTPImpl.mockReset();
+		disableTOTPImpl.mockResolvedValue(false);
+		isTOTPDaemonAvailableImpl.mockReset();
+		isTOTPDaemonAvailableImpl.mockResolvedValue(true);
+	});
+
+	afterEach(() => {
+		replies.length = 0;
+		sessionStore.length = 0;
+		executeHermesQueryImpl.mockReset();
+		hasTOTPImpl.mockReset();
+		verifyTOTPImpl.mockReset();
+		disableTOTPImpl.mockReset();
+		isTOTPDaemonAvailableImpl.mockReset();
+		loggerImpl.info.mockReset();
+		loggerImpl.warn.mockReset();
+		loggerImpl.error.mockReset();
+		loggerImpl.debug.mockReset();
+		fs.rmSync(controlTempDir, { recursive: true, force: true });
+		if (ORIGINAL_DATA_DIR === undefined) {
+			delete process.env.TELCLAUDE_DATA_DIR;
+		} else {
+			process.env.TELCLAUDE_DATA_DIR = ORIGINAL_DATA_DIR;
+		}
+	});
+
 	it("rejects /link in group chats", async () => {
 		const msg = {
 			chatId: 999,
@@ -663,6 +731,117 @@ describe("auto-reply control commands", () => {
 
 		expect(autoReplyTest.resolveCommandBody(msg)).toBe("/approve\u200B 123456");
 		expect(autoReplyTest.resolveProcessingBody(msg)).toBe("/approve 123456");
+	});
+
+	it("routes active wizard text before the TOTP auth gate can persist it", async () => {
+		const api = {
+			sendMessage: vi.fn(async () => ({ message_id: 10 })),
+			editMessageText: vi.fn(async () => {}),
+			deleteMessage: vi.fn(async () => {}),
+		};
+		const wizard = createWizardPrompter({
+			api: api as never,
+			actorId: 555,
+			chatId: 123,
+			threadId: 9,
+			timeoutMs: 1_000,
+		});
+		const textPromise = wizard.text({ message: "Enter the one-time provider code:" });
+		await waitFor(() => api.sendMessage.mock.calls.length > 0);
+		await Promise.resolve();
+
+		const consumed = await autoReplyTest.routeWizardTextBeforeAuthGate(
+			{
+				...makeMsg(),
+				id: "42",
+				body: "provider-secret-code",
+				senderId: 555,
+				messageThreadId: 9,
+			},
+			api as never,
+			"provider-secret-code",
+			null,
+		);
+
+		expect(consumed).toBe(true);
+		await expect(textPromise).resolves.toBe("provider-secret-code");
+		expect(api.deleteMessage).toHaveBeenCalledWith(123, 42);
+	});
+
+	it("does not persist non-6-digit provider OTP text when TOTP is expired and a wizard is active", async () => {
+		const otpCode = "AB12-CD34";
+		const chatId = 456;
+		const threadId = 10;
+		const actorId = 777;
+		const db = getDb();
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO identity_links (chat_id, local_user_id, linked_at, linked_by)
+			 VALUES (?, ?, ?, ?)`,
+		).run(999, "admin", now, "test");
+		db.prepare(
+			`INSERT INTO identity_links (chat_id, local_user_id, linked_at, linked_by)
+			 VALUES (?, ?, ?, ?)`,
+		).run(chatId, "operator", now, "test");
+		db.prepare(
+			`INSERT INTO totp_sessions (local_user_id, verified_at, expires_at)
+			 VALUES (?, ?, ?)`,
+		).run("operator", now - 600_000, now - 60_000);
+		hasTOTPImpl.mockResolvedValue({ hasTOTP: true });
+
+		const api = {
+			sendMessage: vi.fn(async () => ({ message_id: 10 })),
+			editMessageText: vi.fn(async () => {}),
+			deleteMessage: vi.fn(async () => {}),
+		};
+		const wizard = createWizardPrompter({
+			api: api as never,
+			actorId,
+			chatId,
+			threadId,
+			timeoutMs: 1_000,
+		});
+		const textPromise = wizard.text({ message: "Enter the one-time provider code:" });
+		await waitFor(() => api.sendMessage.mock.calls.length > 0);
+		await Promise.resolve();
+
+		await autoReplyTest.handleInboundMessage(
+			{
+				...makeMsg(),
+				chatId,
+				id: "77",
+				body: otpCode,
+				senderId: actorId,
+				messageThreadId: threadId,
+			},
+			{ api } as never,
+			{ security: {}, inbound: { reply: { enabled: true } } } as never,
+			{} as never,
+			{} as never,
+			{ log: vi.fn(async () => {}) } as never,
+			new Set<string>(),
+			"simple",
+		);
+
+		await expect(textPromise).resolves.toBe(otpCode);
+		const pendingRows = db
+			.prepare("SELECT body FROM pending_totp_messages WHERE body LIKE ?")
+			.all(`%${otpCode}%`);
+		const logText = [
+			...loggerImpl.info.mock.calls,
+			...loggerImpl.warn.mock.calls,
+			...loggerImpl.error.mock.calls,
+			...loggerImpl.debug.mock.calls,
+		]
+			.map((call) => JSON.stringify(call))
+			.join("\n");
+
+		expect(api.deleteMessage).toHaveBeenCalledWith(chatId, 77);
+		expect(pendingRows).toEqual([]);
+		expect(hasTOTPImpl).not.toHaveBeenCalled();
+		expect(executeHermesQueryImpl).not.toHaveBeenCalled();
+		expect(captureTelegramTurnMemoryImpl).not.toHaveBeenCalled();
+		expect(logText).not.toContain(otpCode);
 	});
 
 	it("dispatches /codex as a background job without entering the Claude session", async () => {

--- a/tests/telegram/cards/provider-list.test.ts
+++ b/tests/telegram/cards/provider-list.test.ts
@@ -1,4 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const canActorManageProvidersMock = vi.hoisted(() => vi.fn(() => true));
+const startProviderSessionEnrollmentCommandMock = vi.hoisted(() => vi.fn(async () => ({})));
+
+vi.mock("../../../src/telegram/control-command-actions.js", () => ({
+	canActorManageProviders: canActorManageProvidersMock,
+	startProviderAddWizard: vi.fn(),
+	startProviderEditWizard: vi.fn(),
+	startProviderRemoveWizard: vi.fn(),
+	startProviderSessionEnrollmentCommand: startProviderSessionEnrollmentCommandMock,
+}));
 
 import { providerListRenderer } from "../../../src/telegram/cards/renderers/provider-list.js";
 import { CardKind } from "../../../src/telegram/cards/types.js";
@@ -22,6 +33,11 @@ function baseCard() {
 }
 
 describe("provider list card", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+		canActorManageProvidersMock.mockReturnValue(true);
+	});
+
 	it("renders list view with health icons", () => {
 		const card = {
 			...baseCard(),
@@ -105,6 +121,76 @@ describe("provider list card", () => {
 		const labels = kbFlat.map((b) => ("text" in b ? b.text : ""));
 		expect(labels.filter((l) => l.includes("Edit")).length).toBe(1);
 		expect(labels.filter((l) => l.includes("Remove")).length).toBe(1);
+	});
+
+	it("renders a one-tap re-auth action for auth-expired session providers", () => {
+		const card = {
+			...baseCard(),
+			state: {
+				kind: CardKind.ProviderList,
+				title: "Providers",
+				providers: [
+					{
+						id: "israel-services",
+						label: "Israel Services",
+						health: "auth_expired" as const,
+						enrollmentService: "clalit",
+					},
+				],
+				selectedProviderId: "israel-services",
+				page: 0,
+				view: "detail" as const,
+				canMutate: true,
+			},
+		} as any;
+
+		const render = providerListRenderer.render(card);
+		const kbFlat = render.keyboard?.inline_keyboard?.flat() ?? [];
+		const labels = kbFlat.map((b) => ("text" in b ? b.text : ""));
+		expect(labels.filter((l) => l.includes("Re-auth")).length).toBe(1);
+	});
+
+	it("starts session enrollment from the auth-expired re-auth action", async () => {
+		const api = {};
+		const card = {
+			...baseCard(),
+			threadId: 19,
+			state: {
+				kind: CardKind.ProviderList,
+				title: "Providers",
+				providers: [
+					{
+						id: "israel-services",
+						label: "Israel Services",
+						health: "auth_expired" as const,
+						enrollmentService: "clalit",
+					},
+				],
+				selectedProviderId: "israel-services",
+				page: 0,
+				view: "detail" as const,
+				canMutate: true,
+			},
+		} as any;
+
+		const result = await providerListRenderer.execute({
+			action: { type: "enroll" },
+			card,
+			ctx: { from: { id: 101 }, api } as any,
+		});
+
+		expect(result.callbackText).toBe("Starting re-auth for clalit");
+		expect(result.callbackAlert).toBeUndefined();
+		expect(result.afterCommit).toBeTypeOf("function");
+
+		await result.afterCommit?.();
+
+		expect(startProviderSessionEnrollmentCommandMock).toHaveBeenCalledWith(api, {
+			actorUserId: "101",
+			chatId: 777,
+			threadId: 19,
+			service: "clalit",
+		});
 	});
 
 	it("renders central remediation commands for provider health failures", () => {
@@ -212,7 +298,8 @@ describe("provider list card", () => {
 	});
 
 	it("rejects provider mutation actions at handler time for non-admin viewers", async () => {
-		for (const action of ["add", "edit", "remove"] as const) {
+		canActorManageProvidersMock.mockReturnValue(false);
+		for (const action of ["add", "edit", "remove", "enroll"] as const) {
 			const card = {
 				...baseCard(),
 				state: {
@@ -223,6 +310,7 @@ describe("provider list card", () => {
 							id: "google",
 							label: "Google Services",
 							health: "ok" as const,
+							enrollmentService: "clalit",
 						},
 					],
 					selectedProviderId: action === "add" ? undefined : "google",
@@ -244,7 +332,9 @@ describe("provider list card", () => {
 					? "Only admin can add providers."
 					: action === "edit"
 						? "Only admin can edit providers."
-						: "Only admin can remove providers.",
+						: action === "remove"
+							? "Only admin can remove providers."
+							: "Only admin can re-auth providers.",
 			);
 		}
 	});

--- a/tests/telegram/control-commands.test.ts
+++ b/tests/telegram/control-commands.test.ts
@@ -59,6 +59,12 @@ describe("telegram control command registry", () => {
 			expect(matchTelegramControlCommand("/codex review the diff")?.command.id).toBe("codex");
 			expect(matchTelegramControlCommand("/help commands")?.command.id).toBe("help:commands");
 			expect(matchTelegramControlCommand("/curator")?.command.id).toBe("curator");
+			expect(matchTelegramControlCommand("/providers enroll clalit")?.command.id).toBe(
+				"providers:enroll",
+			);
+			expect(matchTelegramControlCommand("/provider enroll clalit")?.command.id).toBe(
+				"providers:enroll",
+			);
 		});
 
 		it("passes remaining args correctly for subcommands", () => {
@@ -69,6 +75,10 @@ describe("telegram control command registry", () => {
 			const verifyMatch = matchTelegramControlCommand("/auth verify 123456");
 			expect(verifyMatch?.command.id).toBe("auth:verify");
 			expect(verifyMatch?.args).toEqual(["123456"]);
+
+			const providerEnrollMatch = matchTelegramControlCommand("/provider enroll clalit");
+			expect(providerEnrollMatch?.command.id).toBe("providers:enroll");
+			expect(providerEnrollMatch?.args).toEqual(["clalit"]);
 		});
 
 		it("returns null for unknown subcommands in strict domains", () => {

--- a/tests/telegram/provider-enrollment-command.test.ts
+++ b/tests/telegram/provider-enrollment-command.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const startProviderSessionEnrollmentMock = vi.hoisted(() => vi.fn());
+const pollProviderSessionEnrollmentMock = vi.hoisted(() => vi.fn());
+const isAdminMock = vi.hoisted(() => vi.fn(() => true));
+const getIdentityLinkMock = vi.hoisted(() =>
+	vi.fn(() => ({ chatId: 123, localUserId: "admin", linkedAt: Date.now(), linkedBy: "test" })),
+);
+const getTOTPSessionForChatMock = vi.hoisted(() =>
+	vi.fn(() => ({ localUserId: "admin", verifiedAt: Date.now(), expiresAt: Date.now() + 60_000 })),
+);
+const freshStepUpVerifyMock = vi.hoisted(() => vi.fn(() => ({ ok: true, metadata: {} })));
+
+vi.mock("../../src/relay/provider-enrollment.js", () => ({
+	startProviderSessionEnrollment: startProviderSessionEnrollmentMock,
+	pollProviderSessionEnrollment: pollProviderSessionEnrollmentMock,
+}));
+
+vi.mock("../../src/security/linking.js", () => ({
+	getIdentityLink: getIdentityLinkMock,
+	isAdmin: isAdminMock,
+}));
+
+vi.mock("../../src/security/totp-session.js", () => ({
+	getTOTPSessionForChat: getTOTPSessionForChatMock,
+	stepUpMetadataForTOTPSession: vi.fn((input) => ({
+		method: "totp",
+		actorId: input.actorId,
+		verifiedAtMs: input.session.verifiedAt,
+		expiresAtMs: input.session.expiresAt,
+	})),
+	freshTotpStepUpVerification: {
+		verify: freshStepUpVerifyMock,
+	},
+}));
+
+import { startProviderSessionEnrollmentCommand } from "../../src/telegram/control-command-actions.js";
+
+function makeApi() {
+	return {
+		sendMessage: vi.fn(async () => ({ message_id: 1 })),
+		editMessageReplyMarkup: vi.fn(async () => {}),
+	};
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+	for (let i = 0; i < 50; i++) {
+		if (condition()) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("Timed out waiting for condition");
+}
+
+describe("provider enrollment Telegram command", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		isAdminMock.mockReturnValue(true);
+		getIdentityLinkMock.mockReturnValue({
+			chatId: 123,
+			localUserId: "admin",
+			linkedAt: Date.now(),
+			linkedBy: "test",
+		});
+		getTOTPSessionForChatMock.mockReturnValue({
+			localUserId: "admin",
+			verifiedAt: Date.now(),
+			expiresAt: Date.now() + 60_000,
+		});
+		freshStepUpVerifyMock.mockReturnValue({ ok: true, metadata: {} });
+		startProviderSessionEnrollmentMock.mockResolvedValue({
+			status: "enroll_pending",
+			enrollmentId: "enr_123",
+			interactUrl: "https://novnc.test/?token=single-use",
+			expiresAt: Date.now() + 60_000,
+			pollPath: "/v1/credentials/enroll-session/enr_123",
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("renders the one-time browser URL only in Telegram and starts no durable state", async () => {
+		const api = makeApi();
+
+		await startProviderSessionEnrollmentCommand(api as never, {
+			chatId: 123,
+			threadId: 9,
+			service: "clalit",
+			actorUserId: "453371121",
+			subjectUserId: "admin",
+			poll: false,
+		});
+
+		expect(startProviderSessionEnrollmentMock).toHaveBeenCalledWith({
+			service: "clalit",
+			actorUserId: "453371121",
+			subjectUserId: "admin",
+		});
+		expect(api.sendMessage).toHaveBeenCalledWith(
+			123,
+			expect.stringContaining("Secure enrollment started for clalit."),
+			expect.objectContaining({
+				message_thread_id: 9,
+				reply_markup: {
+					inline_keyboard: [
+						[{ text: "Open secure browser", url: "https://novnc.test/?token=single-use" }],
+					],
+				},
+			}),
+		);
+		expect(pollProviderSessionEnrollmentMock).not.toHaveBeenCalled();
+	});
+
+	it("resolves the enrollment subject from the linked chat when omitted", async () => {
+		const api = makeApi();
+		getIdentityLinkMock.mockReturnValue({
+			chatId: 123,
+			localUserId: "william",
+			linkedAt: Date.now(),
+			linkedBy: "test",
+		});
+
+		await startProviderSessionEnrollmentCommand(api as never, {
+			chatId: 123,
+			service: "clalit",
+			actorUserId: "453371121",
+			poll: false,
+		});
+
+		expect(startProviderSessionEnrollmentMock).toHaveBeenCalledWith({
+			service: "clalit",
+			actorUserId: "453371121",
+			subjectUserId: "william",
+		});
+	});
+
+	it("requires fresh 2FA before opening the enrollment browser", async () => {
+		const api = makeApi();
+		freshStepUpVerifyMock.mockReturnValue({
+			ok: false,
+			code: "fresh_step_up_stale",
+			reason: "too old",
+			retryable: true,
+		});
+
+		await startProviderSessionEnrollmentCommand(api as never, {
+			chatId: 123,
+			threadId: 9,
+			service: "clalit",
+			actorUserId: "453371121",
+			subjectUserId: "admin",
+			poll: false,
+		});
+
+		expect(startProviderSessionEnrollmentMock).not.toHaveBeenCalled();
+		expect(api.sendMessage).toHaveBeenCalledWith(
+			123,
+			expect.stringContaining("Fresh 2FA verification is required"),
+			expect.objectContaining({ message_thread_id: 9 }),
+		);
+	});
+
+	it("does not expose token-bearing provider start errors in Telegram", async () => {
+		const api = makeApi();
+		startProviderSessionEnrollmentMock.mockResolvedValueOnce({
+			status: "error",
+			error: "Open https://novnc.test/vnc.html?token=single-use-secret to continue enrollment",
+		});
+
+		await startProviderSessionEnrollmentCommand(api as never, {
+			chatId: 123,
+			threadId: 9,
+			service: "clalit",
+			actorUserId: "453371121",
+			subjectUserId: "admin",
+			poll: false,
+		});
+
+		const serializedMessages = JSON.stringify(api.sendMessage.mock.calls);
+		expect(serializedMessages).not.toContain("single-use-secret");
+		expect(serializedMessages).not.toContain("novnc.test");
+		expect(api.sendMessage).toHaveBeenLastCalledWith(
+			123,
+			expect.stringContaining("Check provider status and relay logs."),
+			expect.objectContaining({ message_thread_id: 9 }),
+		);
+	});
+
+	it("removes the browser URL button from the enrollment message after terminal status", async () => {
+		const api = makeApi();
+		api.sendMessage.mockResolvedValueOnce({ message_id: 44 });
+		pollProviderSessionEnrollmentMock.mockResolvedValueOnce({
+			status: "ok",
+			summary: {
+				service: "clalit",
+				owner: "admin",
+				authorizedOperators: ["admin", "453371121"],
+				credentialKeys: [],
+				hasSession: true,
+				updatedAt: "2026-06-14T09:00:00.000Z",
+			},
+		});
+
+		await startProviderSessionEnrollmentCommand(api as never, {
+			chatId: 123,
+			threadId: 9,
+			service: "clalit",
+			actorUserId: "453371121",
+			subjectUserId: "admin",
+			poll: true,
+			pollIntervalMs: 0,
+		});
+
+		await waitFor(() => api.editMessageReplyMarkup.mock.calls.length > 0);
+
+		expect(api.editMessageReplyMarkup).toHaveBeenCalledWith(123, 44, {
+			reply_markup: undefined,
+		});
+		expect(api.sendMessage).toHaveBeenLastCalledWith(
+			123,
+			expect.stringContaining("Enrollment complete for clalit."),
+			expect.objectContaining({ message_thread_id: 9 }),
+		);
+	});
+
+	it("does not expose token-bearing provider poll errors in Telegram", async () => {
+		const api = makeApi();
+		api.sendMessage.mockResolvedValueOnce({ message_id: 45 });
+		pollProviderSessionEnrollmentMock.mockResolvedValueOnce({
+			status: "error",
+			error: "poll failed at https://operator.test/browser/session?auth_token=poll-secret",
+		});
+
+		await startProviderSessionEnrollmentCommand(api as never, {
+			chatId: 123,
+			threadId: 9,
+			service: "clalit",
+			actorUserId: "453371121",
+			subjectUserId: "admin",
+			poll: true,
+			pollIntervalMs: 0,
+		});
+
+		await waitFor(() => api.editMessageReplyMarkup.mock.calls.length > 0);
+
+		const serializedMessages = JSON.stringify(api.sendMessage.mock.calls);
+		expect(serializedMessages).not.toContain("poll-secret");
+		expect(serializedMessages).not.toContain("operator.test");
+		expect(api.editMessageReplyMarkup).toHaveBeenCalledWith(123, 45, {
+			reply_markup: undefined,
+		});
+		expect(api.sendMessage).toHaveBeenLastCalledWith(
+			123,
+			expect.stringContaining("Check provider status and relay logs."),
+			expect.objectContaining({ message_thread_id: 9 }),
+		);
+	});
+
+	it("clears the enrollment button and sanitizes Telegram text when polling throws", async () => {
+		const api = makeApi();
+		api.sendMessage.mockResolvedValueOnce({ message_id: 46 });
+		pollProviderSessionEnrollmentMock.mockRejectedValueOnce(
+			new Error("sidecar leaked https://novnc.test/vnc.html?token=throw-secret"),
+		);
+
+		await startProviderSessionEnrollmentCommand(api as never, {
+			chatId: 123,
+			threadId: 9,
+			service: "clalit",
+			actorUserId: "453371121",
+			subjectUserId: "admin",
+			poll: true,
+			pollIntervalMs: 0,
+		});
+
+		await waitFor(() => api.editMessageReplyMarkup.mock.calls.length > 0);
+
+		const serializedMessages = JSON.stringify(api.sendMessage.mock.calls);
+		const terminalMessage = api.sendMessage.mock.calls.at(-1)?.[1];
+		expect(serializedMessages).not.toContain("throw-secret");
+		expect(terminalMessage).not.toContain("novnc.test");
+		expect(api.editMessageReplyMarkup).toHaveBeenCalledWith(123, 46, {
+			reply_markup: undefined,
+		});
+		expect(api.sendMessage).toHaveBeenLastCalledWith(
+			123,
+			expect.stringContaining("Check provider status and relay logs."),
+			expect.objectContaining({ message_thread_id: 9 }),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds the relay side of the secretless provider enrollment flow for Hermes/provider use:

- HMAC-signed relay requests to provider sidecars with fixed protocol key id `v1`
- session-only provider enrollment start/poll plumbing
- Telegram enrollment command/card flow with fresh 2FA gate and one-time browser button cleanup
- provider-proxy redaction for interactive/noVNC/browser URLs and visual payloads
- doctor readiness checks for relay signing before sidecar enforcement
- Docker and CI env wiring for the new sidecar HMAC path

## Why

Private Hermes needs usable provider enrollment and authenticated provider access without putting provider tokens or sidecar secrets inside the contained runtime. The relay signs provider traffic, the sidecar owns provider credentials, and Telegram/operator flows carry the one-time interactive browser link.

## Deployment note

Do not merge/deploy yet. Telclaude deploys relay to william on merge to `main`, and Aviv explicitly chose commit + PRs now while holding production deploy.

Safe rollout order remains:

1. Merge/deploy relay first so it starts signing while sidecar is still observe-mode.
2. Verify signed prod canaries and doctor readiness.
3. Deploy israel-services verify guard in observe mode.
4. Flip `SIDECAR_REQUIRE_RELAY_HMAC=1` only after positive/negative canaries pass.
5. Repeat unsigned rejection and signed provider smoke after enforcement.

## Validation

- `pnpm vitest run tests/telegram/provider-enrollment-command.test.ts`
- `pnpm exec biome check src/telegram/control-command-actions.ts tests/telegram/provider-enrollment-command.test.ts`
- `pnpm typecheck`
- `pnpm test` (227 files / 2240 tests)
- `pnpm lint` (exit 0; known pre-existing optional-chain warnings only)
- `git diff --check`
- `gitleaks stdin` over staged diff
