### PR TITLE
feat(openai): share the vault http:api.openai.com credential for transcription/TTS/image

### DIFF
--- a/src/services/openai-client.ts
+++ b/src/services/openai-client.ts
@@ -6,7 +6,10 @@
  * 1. Keychain (via `telclaude secrets setup-openai`)
  * 2. OPENAI_API_KEY environment variable
  * 3. openai.apiKey in config file
- * 4. Credential proxy (TELCLAUDE_CREDENTIAL_PROXY_URL — no direct key needed)
+ * 4. Vault `http:api.openai.com` bearer credential — reuse the same OpenAI key already
+ *    provisioned for the credential proxy, so it serves transcription/TTS/image too.
+ *    Relay-only (gated on vault reachability); the contained agent has no vault access.
+ * 5. Credential proxy (TELCLAUDE_CREDENTIAL_PROXY_URL — no direct key needed)
  *
  * Proxy support:
  * When HTTP_PROXY or HTTPS_PROXY is set (e.g., inside sandbox), the client
@@ -20,6 +23,7 @@ import { type Dispatcher, ProxyAgent } from "undici";
 import { loadConfig } from "../config/config.js";
 import { getChildLogger } from "../logging.js";
 import { getSecret, SECRET_KEYS } from "../secrets/index.js";
+import { getVaultClient, isVaultAvailable } from "../vault-daemon/client.js";
 
 const logger = getChildLogger({ module: "openai-client" });
 
@@ -83,7 +87,25 @@ async function getApiKey(): Promise<string | null> {
 		return cachedApiKey;
 	}
 
-	// 4. Credential proxy mode (agent → relay proxy, no direct key needed)
+	// 4. Vault HTTP credential for api.openai.com. Reuse the SAME OpenAI key already provisioned
+	//    for the credential proxy / direct HTTP calls, so transcription/TTS/image work without a
+	//    separate `openai-api-key` secret. Relay-only: gated on vault reachability — the contained
+	//    agent has no vault socket, so it falls through to the credential proxy below (no key leak).
+	try {
+		if (await isVaultAvailable()) {
+			const resp = await getVaultClient().get("http", "api.openai.com");
+			if (resp.ok && resp.entry?.credential?.type === "bearer" && resp.entry.credential.token) {
+				cachedApiKey = resp.entry.credential.token;
+				keySourceChecked = true;
+				logger.debug("using OpenAI API key from vault http:api.openai.com credential");
+				return cachedApiKey;
+			}
+		}
+	} catch (err) {
+		logger.debug({ error: String(err) }, "vault http:api.openai.com unavailable for OpenAI key");
+	}
+
+	// 5. Credential proxy mode (agent → relay proxy, no direct key needed)
 	if (process.env.TELCLAUDE_CREDENTIAL_PROXY_URL) {
 		usingCredentialProxy = true;
 		cachedApiKey = "credential-proxy";

--- a/tests/services/openai-client.test.ts
+++ b/tests/services/openai-client.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSecretMock = vi.hoisted(() => vi.fn());
+const isVaultAvailableMock = vi.hoisted(() => vi.fn());
+const vaultGetMock = vi.hoisted(() => vi.fn());
+const loadConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/secrets/index.js", () => ({
+	getSecret: getSecretMock,
+	SECRET_KEYS: { OPENAI_API_KEY: "openai-api-key" },
+}));
+vi.mock("../../src/vault-daemon/client.js", () => ({
+	getVaultClient: () => ({ get: vaultGetMock }),
+	isVaultAvailable: isVaultAvailableMock,
+}));
+vi.mock("../../src/config/config.js", () => ({ loadConfig: loadConfigMock }));
+vi.mock("../../src/logging.js", () => ({
+	getChildLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
+}));
+
+import { clearOpenAICache, getOpenAIKey } from "../../src/services/openai-client.js";
+
+function bearerEntry(token: string) {
+	return {
+		type: "get",
+		ok: true,
+		entry: {
+			protocol: "http",
+			target: "api.openai.com",
+			credential: { type: "bearer", token },
+			createdAt: "2026-01-01T00:00:00.000Z",
+		},
+	};
+}
+
+describe("openai-client getOpenAIKey — shared vault http credential", () => {
+	beforeEach(() => {
+		clearOpenAICache();
+		getSecretMock.mockReset().mockResolvedValue(null);
+		isVaultAvailableMock.mockReset().mockResolvedValue(false);
+		vaultGetMock.mockReset();
+		loadConfigMock.mockReset().mockReturnValue({});
+		delete process.env.OPENAI_API_KEY;
+		delete process.env.TELCLAUDE_CREDENTIAL_PROXY_URL;
+	});
+
+	it("reuses the vault http:api.openai.com bearer when keychain/env/config miss", async () => {
+		isVaultAvailableMock.mockResolvedValue(true);
+		vaultGetMock.mockResolvedValue(bearerEntry("sk-from-vault-http"));
+		expect(await getOpenAIKey()).toBe("sk-from-vault-http");
+		expect(vaultGetMock).toHaveBeenCalledWith("http", "api.openai.com");
+	});
+
+	it("prefers an explicitly provisioned keychain key over the vault http credential", async () => {
+		getSecretMock.mockResolvedValue("sk-from-keychain");
+		isVaultAvailableMock.mockResolvedValue(true);
+		vaultGetMock.mockResolvedValue(bearerEntry("sk-vault"));
+		expect(await getOpenAIKey()).toBe("sk-from-keychain");
+		expect(vaultGetMock).not.toHaveBeenCalled();
+	});
+
+	it("never touches the vault when it is unreachable (contained agent) and uses the credential proxy", async () => {
+		isVaultAvailableMock.mockResolvedValue(false);
+		process.env.TELCLAUDE_CREDENTIAL_PROXY_URL = "http://relay:8792";
+		expect(await getOpenAIKey()).toBe("credential-proxy");
+		expect(vaultGetMock).not.toHaveBeenCalled();
+	});
+
+	it("ignores a non-bearer / missing vault credential and returns null when nothing is configured", async () => {
+		isVaultAvailableMock.mockResolvedValue(true);
+		vaultGetMock.mockResolvedValue({ type: "get", ok: false, error: "not_found" });
+		expect(await getOpenAIKey()).toBeNull();
+	});
+});

--- a/tests/services/openai-client.test.ts
+++ b/tests/services/openai-client.test.ts
@@ -18,7 +18,11 @@ vi.mock("../../src/logging.js", () => ({
 	getChildLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
 }));
 
-import { clearOpenAICache, getOpenAIKey } from "../../src/services/openai-client.js";
+import {
+	clearOpenAICache,
+	getCachedOpenAIKey,
+	getOpenAIKey,
+} from "../../src/services/openai-client.js";
 
 function bearerEntry(token: string) {
 	return {
@@ -70,5 +74,21 @@ describe("openai-client getOpenAIKey — shared vault http credential", () => {
 		isVaultAvailableMock.mockResolvedValue(true);
 		vaultGetMock.mockResolvedValue({ type: "get", ok: false, error: "not_found" });
 		expect(await getOpenAIKey()).toBeNull();
+	});
+
+	it("surfaces the vault bearer through getCachedOpenAIKey() for relay-local consumers (e.g. summarize)", async () => {
+		isVaultAvailableMock.mockResolvedValue(true);
+		vaultGetMock.mockResolvedValue(bearerEntry("sk-from-vault-http"));
+		await getOpenAIKey();
+		// Relay-side: the resolved vault key is a real string, usable in-process by summarize-core.
+		expect(getCachedOpenAIKey()).toBe("sk-from-vault-http");
+	});
+
+	it("never surfaces the credential-proxy placeholder through getCachedOpenAIKey() (contained agent)", async () => {
+		isVaultAvailableMock.mockResolvedValue(false);
+		process.env.TELCLAUDE_CREDENTIAL_PROXY_URL = "http://relay:8792";
+		await getOpenAIKey();
+		// Contained agent: proxy mode must keep getCachedOpenAIKey() null so no key/placeholder leaks to env.
+		expect(getCachedOpenAIKey()).toBeNull();
 	});
 });


### PR DESCRIPTION
## Problem
Voice transcription failed on william with "OpenAI API key isn't configured" — even though the vault **already holds** an OpenAI key as `http:api.openai.com` (bearer). The audio/image services (`openai-client.ts`) only resolved the key via keychain `openai-api-key` / env / config, so the existing vault credential didn't serve them; it required a **second, duplicate** provisioning under a different name.

## Change
Add a relay-only fallback in `openai-client.ts` `getApiKey()`: when keychain/env/config miss, read the vault `http:api.openai.com` bearer token. **Gated on `isVaultAvailable()`** — the contained Hermes agent has no vault socket, so it still falls through to the credential proxy (no raw key ever reaches the runtime). One stored OpenAI key now serves transcription, TTS, image-gen, and the credential proxy.

Resolution order is now: keychain → env → config → **vault `http:api.openai.com`** → credential proxy.

## Tests
`tests/services/openai-client.test.ts` (4): vault-http fallback resolves; keychain still preferred; vault-unreachable (agent) → credential proxy, never touches the vault; not-found → null. typecheck + lint clean.

## Follow-up
A background investigation found the same shareable-credential gap for **Anthropic** (`http:api.anthropic.com`), X/Twitter bearer, and git credentials, plus several env-only secrets that could be vault-backed (admin secret, TOTP key, telegram-rpc key). Tracked for a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)