### PR TITLE
fix: restore Hermes voice delivery and vault lookup

### DIFF
--- a/src/services/openai-client.ts
+++ b/src/services/openai-client.ts
@@ -23,9 +23,10 @@ import { type Dispatcher, ProxyAgent } from "undici";
 import { loadConfig } from "../config/config.js";
 import { getChildLogger } from "../logging.js";
 import { getSecret, SECRET_KEYS } from "../secrets/index.js";
-import { getVaultClient, isVaultAvailable } from "../vault-daemon/client.js";
+import { VaultClient } from "../vault-daemon/client.js";
 
 const logger = getChildLogger({ module: "openai-client" });
+const OPENAI_VAULT_TIMEOUT_MS = 2000;
 
 /**
  * Redact credentials from a proxy URL for safe logging.
@@ -92,8 +93,9 @@ async function getApiKey(): Promise<string | null> {
 	//    separate `openai-api-key` secret. Relay-only: gated on vault reachability — the contained
 	//    agent has no vault socket, so it falls through to the credential proxy below (no key leak).
 	try {
-		if (await isVaultAvailable()) {
-			const resp = await getVaultClient().get("http", "api.openai.com");
+		const vaultClient = new VaultClient({ timeout: OPENAI_VAULT_TIMEOUT_MS });
+		if (await vaultClient.ping()) {
+			const resp = await vaultClient.get("http", "api.openai.com");
 			if (resp.ok && resp.entry?.credential?.type === "bearer" && resp.entry.credential.token) {
 				cachedApiKey = resp.entry.credential.token;
 				keySourceChecked = true;

--- a/src/telegram/auto-reply.ts
+++ b/src/telegram/auto-reply.ts
@@ -139,7 +139,12 @@ import {
 } from "./conversational-cron.js";
 import { monitorTelegramInbox, normalizeInboundBody } from "./inbound.js";
 import { resolveTelegramIntent } from "./intent-router.js";
-import { extractGeneratedMediaPaths, isMediaOnlyResponse } from "./media-detection.js";
+import {
+	type DetectedMedia,
+	extractGeneratedMediaAttachmentRefs,
+	extractGeneratedMediaPaths,
+	isMediaOnlyResponse,
+} from "./media-detection.js";
 import {
 	buildMemoryCaptureText,
 	buildMultimodalPrompt,
@@ -214,6 +219,35 @@ function resolveExecutableModelForChat(
  */
 function makeRecentSentKey(chatId: number, body: string): string {
 	return `${chatId}:${body}`;
+}
+
+const ATTACHMENT_REF_METADATA_KEYS = new Set([
+	"attachmentRef",
+	"sizeBytes",
+	"format",
+	"voice",
+	"estimatedDurationSeconds",
+	"expiresAt",
+]);
+
+function isAttachmentRefMetadataOnlyResponse(response: string, ref: string): boolean {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(response.trim());
+	} catch {
+		return false;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+
+	const record = parsed as Record<string, unknown>;
+	if (record.attachmentRef !== ref) return false;
+	return Object.keys(record).every((key) => ATTACHMENT_REF_METADATA_KEYS.has(key));
+}
+
+function isGeneratedVoiceOnlyResponse(response: string, media: DetectedMedia): boolean {
+	const marker = media.sourceRef ?? media.path;
+	if (isMediaOnlyResponse(response, marker)) return true;
+	return Boolean(media.sourceRef && isAttachmentRefMetadataOnlyResponse(response, media.sourceRef));
 }
 
 // Rate limiting for control commands (prevent brute-force on /approve)
@@ -1779,7 +1813,10 @@ async function executeWithSession(
 					// - Skill teaches Claude to generate media and include path in response
 					// - Relay detects the path and sends the file to the user
 					// See: .claude/skills/image-generator/SKILL.md
-					const generatedMedia = extractGeneratedMediaPaths(finalResponse, process.cwd());
+					const generatedMedia = [
+						...extractGeneratedMediaPaths(finalResponse, process.cwd()),
+						...extractGeneratedMediaAttachmentRefs(finalResponse, userId),
+					];
 
 					// Check if this is a "voice-only" response (just a file path, no real content)
 					// This enables natural voice replies - when responding with voice,
@@ -1788,7 +1825,7 @@ async function executeWithSession(
 					const isVoiceOnlyResponse =
 						generatedMedia.length === 1 &&
 						generatedMedia[0].type === "voice" &&
-						isMediaOnlyResponse(finalResponse, generatedMedia[0].path);
+						isGeneratedVoiceOnlyResponse(finalResponse, generatedMedia[0]);
 
 					// Add to recentlySent BEFORE sending to prevent echo race condition
 					const recentKey = makeRecentSentKey(msg.chatId, finalResponse);

--- a/src/telegram/media-detection.ts
+++ b/src/telegram/media-detection.ts
@@ -17,6 +17,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { getMediaOutboxDirSync } from "../media/store.js";
+import { validateAttachmentRef } from "../storage/attachment-refs.js";
 import type { TelegramMediaType } from "./types.js";
 
 /**
@@ -124,7 +125,12 @@ const ALL_MEDIA_EXTENSIONS =
 export type DetectedMedia = {
 	path: string;
 	type: TelegramMediaType;
+	sourceRef?: string;
 };
+
+const ATTACHMENT_REF_PATTERN = /\b(att_[a-f0-9]{8}\.\d+\.[a-f0-9]{16})\b/gi;
+const GENERATED_MEDIA_ATTACHMENT_PROVIDER_PATTERN =
+	/^(?:tc_image_generate|tc_tts):(?:private|social|household|public|specialist)$/;
 
 /**
  * Check if a path is under one of the allowed media roots.
@@ -245,6 +251,56 @@ export function extractGeneratedMediaPaths(text: string, workingDir?: string): D
 		if (!type) continue;
 
 		results.push({ path: realPath, type });
+	}
+
+	return results;
+}
+
+/**
+ * Extract relay-owned generated media attachment refs from Hermes output.
+ *
+ * Hermes never receives filesystem paths for generated media. It only receives
+ * signed attachment refs, so the relay validates the ref against the current
+ * actor and resolves the path internally before sending the media to Telegram.
+ */
+export function extractGeneratedMediaAttachmentRefs(
+	text: string,
+	actorUserId: string,
+): DetectedMedia[] {
+	const results: DetectedMedia[] = [];
+	const seen = new Set<string>();
+
+	for (const match of text.matchAll(ATTACHMENT_REF_PATTERN)) {
+		const ref = match[1];
+		if (!ref || seen.has(ref)) continue;
+		seen.add(ref);
+
+		let validated: ReturnType<typeof validateAttachmentRef>;
+		try {
+			validated = validateAttachmentRef(ref, { actorUserId });
+		} catch {
+			continue;
+		}
+		if (!validated.valid) continue;
+		if (!GENERATED_MEDIA_ATTACHMENT_PROVIDER_PATTERN.test(validated.attachment.providerId)) {
+			continue;
+		}
+
+		const realPath = safeResolvePath(validated.attachment.filepath);
+		if (!realPath) continue;
+
+		let stats: fs.Stats;
+		try {
+			stats = fs.lstatSync(realPath);
+		} catch {
+			continue;
+		}
+		if (stats.isSymbolicLink() || !stats.isFile()) continue;
+
+		const type = inferMediaType(realPath);
+		if (!type) continue;
+
+		results.push({ path: realPath, type, sourceRef: ref });
 	}
 
 	return results;

--- a/tests/services/openai-client.test.ts
+++ b/tests/services/openai-client.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getSecretMock = vi.hoisted(() => vi.fn());
-const isVaultAvailableMock = vi.hoisted(() => vi.fn());
-const vaultGetMock = vi.hoisted(() => vi.fn());
+const vaultMocks = vi.hoisted(() => {
+	const ping = vi.fn();
+	const get = vi.fn();
+	const singletonGet = vi.fn();
+	const isAvailable = vi.fn();
+	const Client = vi.fn().mockImplementation(() => ({ ping, get }));
+	return { Client, get, isAvailable, ping, singletonGet };
+});
 const loadConfigMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/secrets/index.js", () => ({
@@ -10,8 +16,9 @@ vi.mock("../../src/secrets/index.js", () => ({
 	SECRET_KEYS: { OPENAI_API_KEY: "openai-api-key" },
 }));
 vi.mock("../../src/vault-daemon/client.js", () => ({
-	getVaultClient: () => ({ get: vaultGetMock }),
-	isVaultAvailable: isVaultAvailableMock,
+	VaultClient: vaultMocks.Client,
+	getVaultClient: () => ({ get: vaultMocks.singletonGet }),
+	isVaultAvailable: vaultMocks.isAvailable,
 }));
 vi.mock("../../src/config/config.js", () => ({ loadConfig: loadConfigMock }));
 vi.mock("../../src/logging.js", () => ({
@@ -41,54 +48,69 @@ describe("openai-client getOpenAIKey — shared vault http credential", () => {
 	beforeEach(() => {
 		clearOpenAICache();
 		getSecretMock.mockReset().mockResolvedValue(null);
-		isVaultAvailableMock.mockReset().mockResolvedValue(false);
-		vaultGetMock.mockReset();
+		vaultMocks.Client.mockClear();
+		vaultMocks.get.mockReset();
+		vaultMocks.isAvailable.mockReset().mockResolvedValue(false);
+		vaultMocks.ping.mockReset().mockResolvedValue(false);
+		vaultMocks.singletonGet.mockReset();
 		loadConfigMock.mockReset().mockReturnValue({});
 		delete process.env.OPENAI_API_KEY;
 		delete process.env.TELCLAUDE_CREDENTIAL_PROXY_URL;
 	});
 
 	it("reuses the vault http:api.openai.com bearer when keychain/env/config miss", async () => {
-		isVaultAvailableMock.mockResolvedValue(true);
-		vaultGetMock.mockResolvedValue(bearerEntry("sk-from-vault-http"));
+		vaultMocks.ping.mockResolvedValue(true);
+		vaultMocks.get.mockResolvedValue(bearerEntry("sk-from-vault-http"));
 		expect(await getOpenAIKey()).toBe("sk-from-vault-http");
-		expect(vaultGetMock).toHaveBeenCalledWith("http", "api.openai.com");
+		expect(vaultMocks.Client).toHaveBeenCalledWith({ timeout: 2000 });
+		expect(vaultMocks.get).toHaveBeenCalledWith("http", "api.openai.com");
 	});
 
 	it("prefers an explicitly provisioned keychain key over the vault http credential", async () => {
 		getSecretMock.mockResolvedValue("sk-from-keychain");
-		isVaultAvailableMock.mockResolvedValue(true);
-		vaultGetMock.mockResolvedValue(bearerEntry("sk-vault"));
+		vaultMocks.ping.mockResolvedValue(true);
+		vaultMocks.get.mockResolvedValue(bearerEntry("sk-vault"));
 		expect(await getOpenAIKey()).toBe("sk-from-keychain");
-		expect(vaultGetMock).not.toHaveBeenCalled();
+		expect(vaultMocks.get).not.toHaveBeenCalled();
 	});
 
 	it("never touches the vault when it is unreachable (contained agent) and uses the credential proxy", async () => {
-		isVaultAvailableMock.mockResolvedValue(false);
+		vaultMocks.ping.mockResolvedValue(false);
 		process.env.TELCLAUDE_CREDENTIAL_PROXY_URL = "http://relay:8792";
 		expect(await getOpenAIKey()).toBe("credential-proxy");
-		expect(vaultGetMock).not.toHaveBeenCalled();
+		expect(vaultMocks.get).not.toHaveBeenCalled();
 	});
 
 	it("ignores a non-bearer / missing vault credential and returns null when nothing is configured", async () => {
-		isVaultAvailableMock.mockResolvedValue(true);
-		vaultGetMock.mockResolvedValue({ type: "get", ok: false, error: "not_found" });
+		vaultMocks.ping.mockResolvedValue(true);
+		vaultMocks.get.mockResolvedValue({ type: "get", ok: false, error: "not_found" });
 		expect(await getOpenAIKey()).toBeNull();
 	});
 
 	it("surfaces the vault bearer through getCachedOpenAIKey() for relay-local consumers (e.g. summarize)", async () => {
-		isVaultAvailableMock.mockResolvedValue(true);
-		vaultGetMock.mockResolvedValue(bearerEntry("sk-from-vault-http"));
+		vaultMocks.ping.mockResolvedValue(true);
+		vaultMocks.get.mockResolvedValue(bearerEntry("sk-from-vault-http"));
 		await getOpenAIKey();
 		// Relay-side: the resolved vault key is a real string, usable in-process by summarize-core.
 		expect(getCachedOpenAIKey()).toBe("sk-from-vault-http");
 	});
 
 	it("never surfaces the credential-proxy placeholder through getCachedOpenAIKey() (contained agent)", async () => {
-		isVaultAvailableMock.mockResolvedValue(false);
+		vaultMocks.ping.mockResolvedValue(false);
 		process.env.TELCLAUDE_CREDENTIAL_PROXY_URL = "http://relay:8792";
 		await getOpenAIKey();
 		// Contained agent: proxy mode must keep getCachedOpenAIKey() null so no key/placeholder leaks to env.
 		expect(getCachedOpenAIKey()).toBeNull();
+	});
+
+	it("does not depend on the process-wide vault singleton for relay-local OpenAI credentials", async () => {
+		vaultMocks.isAvailable.mockResolvedValue(true);
+		vaultMocks.singletonGet.mockRejectedValue(new Error("stale singleton socket"));
+		vaultMocks.ping.mockResolvedValue(true);
+		vaultMocks.get.mockResolvedValue(bearerEntry("sk-from-fresh-vault-client"));
+
+		expect(await getOpenAIKey()).toBe("sk-from-fresh-vault-client");
+		expect(vaultMocks.singletonGet).not.toHaveBeenCalled();
+		expect(vaultMocks.get).toHaveBeenCalledWith("http", "api.openai.com");
 	});
 });

--- a/tests/telegram/auto-reply.test.ts
+++ b/tests/telegram/auto-reply.test.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listJobs } from "../../src/background/index.js";
 import { getMostRecentPendingPlanApproval } from "../../src/security/approvals.js";
+import { createAttachmentRef } from "../../src/storage/attachment-refs.js";
 import { getDb, resetDatabase } from "../../src/storage/db.js";
 
 // Hoisted mutable stubs
 const replies: string[] = [];
+const sentMedia: Array<{ type: string; source: string }> = [];
 const sessionStore: Array<{ key: string; entry: unknown }> = [];
 
 const executeHermesQueryImpl = vi.hoisted(() => vi.fn());
@@ -137,6 +139,9 @@ const makeMsg = () => ({
 	reply: vi.fn(async (text: string) => {
 		replies.push(text);
 	}),
+	sendMedia: vi.fn(async (media: { type: string; source: string }) => {
+		sentMedia.push(media);
+	}),
 });
 
 async function waitFor(condition: () => boolean): Promise<void> {
@@ -168,6 +173,8 @@ const baseCtx = () => ({
 });
 
 const ORIGINAL_DATA_DIR = process.env.TELCLAUDE_DATA_DIR;
+const ORIGINAL_MEDIA_OUTBOX_DIR = process.env.TELCLAUDE_MEDIA_OUTBOX_DIR;
+const ORIGINAL_RELAY_PRIVATE_KEY = process.env.TELEGRAM_RPC_RELAY_PRIVATE_KEY;
 
 describe("auto-reply executeAndReply", () => {
 	let tempDir: string;
@@ -175,6 +182,8 @@ describe("auto-reply executeAndReply", () => {
 	beforeEach(async () => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "telclaude-autoreply-"));
 		process.env.TELCLAUDE_DATA_DIR = tempDir;
+		process.env.TELCLAUDE_MEDIA_OUTBOX_DIR = path.join(tempDir, "media-outbox");
+		process.env.TELEGRAM_RPC_RELAY_PRIVATE_KEY = "test-relay-private-key";
 		vi.resetModules();
 		buildTelegramMemoryBundleImpl.mockClear();
 		captureTelegramTurnMemoryImpl.mockClear();
@@ -192,6 +201,7 @@ describe("auto-reply executeAndReply", () => {
 
 	afterEach(() => {
 		replies.length = 0;
+		sentMedia.length = 0;
 		sessionStore.length = 0;
 		redactors.length = 0;
 		executeHermesQueryImpl.mockReset();
@@ -216,6 +226,16 @@ describe("auto-reply executeAndReply", () => {
 			delete process.env.TELCLAUDE_DATA_DIR;
 		} else {
 			process.env.TELCLAUDE_DATA_DIR = ORIGINAL_DATA_DIR;
+		}
+		if (ORIGINAL_MEDIA_OUTBOX_DIR === undefined) {
+			delete process.env.TELCLAUDE_MEDIA_OUTBOX_DIR;
+		} else {
+			process.env.TELCLAUDE_MEDIA_OUTBOX_DIR = ORIGINAL_MEDIA_OUTBOX_DIR;
+		}
+		if (ORIGINAL_RELAY_PRIVATE_KEY === undefined) {
+			delete process.env.TELEGRAM_RPC_RELAY_PRIVATE_KEY;
+		} else {
+			process.env.TELEGRAM_RPC_RELAY_PRIVATE_KEY = ORIGINAL_RELAY_PRIVATE_KEY;
 		}
 	});
 
@@ -246,6 +266,67 @@ describe("auto-reply executeAndReply", () => {
 		expect(ctx.auditLogger.log).toHaveBeenCalledWith(
 			expect.objectContaining({ outcome: "success", costUsd: 0.1 }),
 		);
+	});
+
+	it("sends Hermes TTS attachment refs as Telegram voice without leaking the ref as text", async () => {
+		const linkedUserId = "linked-voice-user";
+		const db = getDb();
+		db.prepare(
+			`INSERT INTO identity_links (chat_id, local_user_id, linked_at, linked_by)
+			 VALUES (?, ?, ?, ?)`,
+		).run(123, linkedUserId, Date.now(), "test");
+
+		const voiceDir = path.join(tempDir, "media-outbox", "voice");
+		fs.mkdirSync(voiceDir, { recursive: true });
+		const voicePath = path.join(voiceDir, "reply.ogg");
+		fs.writeFileSync(voicePath, Buffer.from("fake-ogg"));
+		const attachment = createAttachmentRef({
+			actorUserId: linkedUserId,
+			providerId: "tc_tts:private",
+			filepath: voicePath,
+			filename: path.basename(voicePath),
+			mimeType: "audio/ogg",
+			size: fs.statSync(voicePath).size,
+		});
+
+		executeHermesQueryImpl.mockReturnValueOnce(
+			(async function* () {
+				yield {
+					type: "done",
+					result: {
+						response: JSON.stringify({
+							attachmentRef: attachment.ref,
+							sizeBytes: attachment.size,
+							format: "ogg",
+							voice: "alloy",
+							estimatedDurationSeconds: 1,
+							expiresAt: attachment.expiresAt,
+						}),
+						success: true,
+						error: undefined,
+						costUsd: 0.1,
+						numTurns: 1,
+						durationMs: 5,
+					},
+				};
+			})(),
+		);
+
+		const ctx = {
+			...baseCtx(),
+			msg: {
+				...makeMsg(),
+				senderId: 555,
+			},
+		};
+		await autoReplyTest.executeAndReply(ctx as never);
+
+		const resolvedVoicePath = fs.realpathSync(voicePath);
+		expect(replies).toEqual([]);
+		expect(sentMedia).toEqual([{ type: "voice", source: resolvedVoicePath }]);
+		expect(ctx.msg.reply).not.toHaveBeenCalled();
+		expect(ctx.msg.sendMedia).toHaveBeenCalledWith({ type: "voice", source: resolvedVoicePath });
+		expect(sessionStore[0].entry.systemSent).toBe(true);
 	});
 
 	it("uses fallback redaction when no streaming chunks are returned", async () => {


### PR DESCRIPTION
## Summary
- Use a fresh relay vault client for OpenAI key lookup so transcription/TTS/image resolution does not depend on a stale singleton.
- Teach Telegram auto-reply to resolve Hermes `tc_tts` attachment refs as voice messages using the relay-owned file path, while keeping the actor binding on the dispatch `userId`.

## Verification
- `pnpm exec biome check src/telegram/auto-reply.ts src/telegram/media-detection.ts src/services/openai-client.ts tests/services/openai-client.test.ts tests/telegram/auto-reply.test.ts`
- `pnpm test -- --run tests/services/openai-client.test.ts tests/telegram/auto-reply.test.ts`
- `pnpm run build`

## Notes
- The touched tests cover the linked-identity actor binding case and the attachment-ref voice delivery path.